### PR TITLE
Tenant Id repetition in the workflow Id fixed

### DIFF
--- a/XiansAi.Server.Src/Shared/Utils/Temporal/NewWorkflowOptions.cs
+++ b/XiansAi.Server.Src/Shared/Utils/Temporal/NewWorkflowOptions.cs
@@ -12,11 +12,17 @@ public class NewWorkflowOptions : WorkflowOptions
             throw new InvalidOperationException("TenantId and LoggedInUser are required to create workflow options");
         }
 
-        if(string.IsNullOrEmpty(proposedId))
+        if (string.IsNullOrEmpty(proposedId))
         {
             proposedId = GenerateNewWorkflowId(agentName, workFlowType, tenantContext);
-        } else {
-            proposedId = tenantContext.TenantId + ":" + proposedId;
+        }
+        else
+        {
+            if (!proposedId.StartsWith(tenantContext.TenantId + ":"))
+            {
+                proposedId = tenantContext.TenantId + ":" + proposedId;
+            }
+
         }
 
         Id = proposedId;
@@ -77,7 +83,7 @@ public class NewWorkflowOptions : WorkflowOptions
 
     public static string GenerateNewWorkflowId(string agentName, string workflowType, ITenantContext tenantContext)
     {
-        var id = $"{agentName}:{workflowType}:{Guid.NewGuid()}" ;
+        var id = $"{agentName}:{workflowType}:{Guid.NewGuid()}";
         var tenantWorkflowId = tenantContext.TenantId + ":" + id.Replace(" ", "");
         return tenantWorkflowId;
     }


### PR DESCRIPTION
Added a conditional statement to ensure that the tenant id is only added for the workflow ids which does not contain a tenant id.