### PR TITLE
Add missing index for updated_at property in flow_definitions

### DIFF
--- a/XiansAi.Server.Src/Features/WebApi/Scripts/CreateIndexes.cs
+++ b/XiansAi.Server.Src/Features/WebApi/Scripts/CreateIndexes.cs
@@ -18,6 +18,13 @@ public class CreateIndexes
             )
         );
 
+        // Create index for sorting by update date
+        await collection.Indexes.CreateOneAsync(
+            new CreateIndexModel<FlowDefinition>(
+                Builders<FlowDefinition>.IndexKeys.Descending(x => x.UpdatedAt)
+            )
+        );
+
         // Create index for agent field (used for querying by agent)
         await collection.Indexes.CreateOneAsync(
             new CreateIndexModel<FlowDefinition>(


### PR DESCRIPTION
This index is essential for the Cosmos DB store, specifically when using the MongoDB API. Although Cosmos DB's core engine automatically indexes all properties, the MongoDB API operates with a more explicit indexing model, where certain index paths (like those needed for sorting) must be defined.