### PR TITLE
Auto/controlled upload of instructions, agent source code to server - Add hash check endpoint

### DIFF
--- a/XiansAi.Server.Src/Features/AgentApi/Endpoints/DefinitionsEndpoints.cs
+++ b/XiansAi.Server.Src/Features/AgentApi/Endpoints/DefinitionsEndpoints.cs
@@ -31,5 +31,19 @@ public static class DefinitionsEndpoints
             operation.Description = "Creates a new flow definition in the system";
             return operation;
         });
+
+        definitionsGroup.MapGet("/check", async (
+            [FromQuery] string workflowType,
+            [FromQuery] string hash,
+            [FromServices] IDefinitionsService endpoint) =>
+        {
+            return await endpoint.CheckHash(workflowType, hash);
+        })
+        .WithOpenApi(operation =>
+        {
+            operation.Summary = "Check if flow definition hash already exists";
+            operation.Description = "Checks if a flow definition with the same workflow type and hash already exists to prevent unnecessary uploads.";
+            return operation;
+        });
     }
 } 


### PR DESCRIPTION
New endpoint `api/agent/definitions/check` added.

This endpoint is used to verify whether a given flow definition source code already exists on the server by comparing hash values. It helps avoid unnecessary uploads by checking if the client's version is already stored.

Query Parameters:


Name | Type | Required | Description
-- | -- | -- | --
workflowType | string | ✅ | The unique name/type of the workflow.
hash | string | ✅ | SHA-256 hash of the flow definition source.

Example

> GET /api/agent/definitions/check?workflowType=LeadQualificationFlow&hash=3b2f6d2a9bd...
