### PR TITLE
Add Thread Deletion Capability

### DIFF
--- a/XiansAi.Server.Src/Features/UserApi/Endpoints/RestEndpoints.cs
+++ b/XiansAi.Server.Src/Features/UserApi/Endpoints/RestEndpoints.cs
@@ -84,7 +84,7 @@ public static class RestEndpoints
             {
                 return Results.BadRequest(errorMessage);
             }
-            
+
             var resolvedParticipantId = string.IsNullOrEmpty(participantId) ? tenantContext.LoggedInUser : participantId;
 
             // Generate unique request ID for correlation
@@ -137,7 +137,30 @@ public static class RestEndpoints
         .WithSummary("Get conversation history with caching")
         .WithDescription("Retrieves conversation history with optimized database queries and caching");
 
+        // Delete thread endpoint
+        restGroup.MapDelete("/thread", async (
+            [FromQuery] string workflow,
+            [FromQuery] string participantId,
+            [FromServices] IMessageService messageService,
+            [FromServices] ITenantContext tenantContext) =>
+        {
+            // Validate request parameters
+            if (string.IsNullOrEmpty(workflow))
+            {
+                return Results.BadRequest("Workflow is required parameter");
+            }
+
+            var resolvedParticipantId = string.IsNullOrEmpty(participantId) ? tenantContext.LoggedInUser : participantId;
+            var workflowId = new WorkflowIdentifier(workflow, tenantContext).WorkflowId;
+
+            var result = await messageService.DeleteThreadAsync(workflowId, resolvedParticipantId);
+            return result.ToHttpResult();
+        })
+        .WithName("DeleteThread")
+        .WithSummary("Delete conversation thread")
+        .WithDescription("Deletes a conversation thread and all its associated messages for the specified workflow and participant");
+
+        
 
     }
 }
-

--- a/XiansAi.Server.Src/Shared/Repositories/ConversationThreadRepository.cs
+++ b/XiansAi.Server.Src/Shared/Repositories/ConversationThreadRepository.cs
@@ -56,6 +56,7 @@ public interface IConversationThreadRepository
     Task<List<ConversationThread>> GetByTenantAndAgentAsync(string tenantId, string agent, int? page = null, int? pageSize = null);
     Task<string> CreateOrGetAsync(ConversationThread thread);
     Task<bool> DeleteAsync(string id);
+    Task<string> GetThreadIdAsync(string tenantId, string workflowId, string participantId);
 }
 
 public class ConversationThreadRepository : IConversationThreadRepository
@@ -131,6 +132,16 @@ public class ConversationThreadRepository : IConversationThreadRepository
             // For other errors, rethrow
             throw;
         }
+    }
+
+    public async Task<string> GetThreadIdAsync(string tenantId, string workflowId, string participantId)
+    {
+        var thread = await GetByCompositeKeyAsync(tenantId, workflowId, participantId);
+        if (thread == null)
+        {
+            throw new KeyNotFoundException($"No conversation thread found for tenant '{tenantId}', workflow '{workflowId}', and participant '{participantId}'.");
+        }
+        return thread.Id;
     }
 
     public async Task<bool> DeleteAsync(string id)


### PR DESCRIPTION
Implements thread deletion functionality for the SignalR WebSocket API, allowing users to delete conversation threads and their associated messages.

- SignalR method for real-time thread deletion
- Service layer orchestration for thread deletion
- Repository method to delete all thread messages
- Helper for thread ID resolution