### PR TITLE
Generic OIDC Implementation

### DIFF
--- a/XiansAi.Server.Src/Features/UserApi/Configuration/UserApiConfiguration.cs
+++ b/XiansAi.Server.Src/Features/UserApi/Configuration/UserApiConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Features.UserApi.Auth;
+using Shared.Auth;
 using Features.UserApi.Services;
 using Features.UserApi.Endpoints;
 

--- a/XiansAi.Server.Src/Features/WebApi/Auth/OidcAuthenticationHandler.cs
+++ b/XiansAi.Server.Src/Features/WebApi/Auth/OidcAuthenticationHandler.cs
@@ -1,0 +1,116 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+using Shared.Auth;
+
+namespace Features.WebApi.Auth;
+
+/// <summary>
+/// Custom authentication handler for Generic OIDC authentication in WebAPI.
+/// Extracts JWT tokens from Authorization header and validates them using DynamicOidcValidator.
+/// </summary>
+public class OidcAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    private readonly IDynamicOidcValidator _oidcValidator;
+    private readonly ILogger<OidcAuthenticationHandler> _logger;
+
+    public OidcAuthenticationHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder,
+        IDynamicOidcValidator oidcValidator)
+        : base(options, logger, encoder)
+    {
+        _oidcValidator = oidcValidator;
+        _logger = logger.CreateLogger<OidcAuthenticationHandler>();
+    }
+
+    protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        try
+        {
+            // Check for Authorization header
+            if (!Request.Headers.ContainsKey("Authorization"))
+            {
+                _logger.LogDebug("Missing Authorization header");
+                return AuthenticateResult.NoResult();
+            }
+
+            var authHeader = Request.Headers["Authorization"].ToString();
+            
+            // Validate Bearer token format
+            if (string.IsNullOrWhiteSpace(authHeader) || !authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogDebug("Invalid Authorization header format");
+                return AuthenticateResult.Fail("Invalid Authorization header format. Expected 'Bearer <token>'");
+            }
+
+            // Extract token
+            var token = authHeader.Substring("Bearer ".Length).Trim();
+            
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                _logger.LogDebug("Empty token in Authorization header");
+                return AuthenticateResult.Fail("Empty token");
+            }
+
+            // Validate token using DynamicOidcValidator (uses "webapi" as pseudo-tenant)
+            _logger.LogDebug("Validating JWT token using Generic OIDC");
+            var (success, canonicalUserId, error) = await _oidcValidator.ValidateAsync("webapi", token);
+
+            if (!success)
+            {
+                _logger.LogWarning("OIDC token validation failed: {Error}", error);
+                return AuthenticateResult.Fail(error ?? "Token validation failed");
+            }
+
+            if (string.IsNullOrWhiteSpace(canonicalUserId))
+            {
+                _logger.LogWarning("Token validation succeeded but no user identifier was extracted");
+                return AuthenticateResult.Fail("No user identifier found in token");
+            }
+
+            // Build claims principal
+            var claims = new List<Claim>
+            {
+                new Claim(ClaimTypes.NameIdentifier, canonicalUserId),
+                new Claim("userId", canonicalUserId),
+                new Claim("authMethod", "oidc")
+            };
+
+            var identity = new ClaimsIdentity(claims, Scheme.Name);
+            var principal = new ClaimsPrincipal(identity);
+            var ticket = new AuthenticationTicket(principal, Scheme.Name);
+
+            _logger.LogInformation("User authenticated successfully via Generic OIDC: UserId={UserId}", canonicalUserId);
+
+            return AuthenticateResult.Success(ticket);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error during OIDC authentication");
+            return AuthenticateResult.Fail("Authentication failed due to internal error");
+        }
+    }
+
+    protected override Task HandleChallengeAsync(AuthenticationProperties properties)
+    {
+        Response.StatusCode = 401;
+        Response.Headers["WWW-Authenticate"] = "Bearer";
+        
+        _logger.LogDebug("Authentication challenge: 401 Unauthorized");
+        
+        return Task.CompletedTask;
+    }
+
+    protected override Task HandleForbiddenAsync(AuthenticationProperties properties)
+    {
+        Response.StatusCode = 403;
+        
+        _logger.LogDebug("Authorization failed: 403 Forbidden");
+        
+        return Task.CompletedTask;
+    }
+}
+

--- a/XiansAi.Server.Src/Features/WebApi/Configuration/WebApiConfiguration.cs
+++ b/XiansAi.Server.Src/Features/WebApi/Configuration/WebApiConfiguration.cs
@@ -1,6 +1,11 @@
 using Features.WebApi.Endpoints;
 using Features.WebApi.Repositories;
 using Features.WebApi.Services;
+using Features.WebApi.Auth;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Shared.Auth;
+using Shared.Services;
 
 namespace Features.WebApi.Configuration;
 
@@ -24,6 +29,91 @@ public static class WebApiConfiguration
         // Register repositories
         builder.Services.AddScoped<ILogRepository, LogRepository>();
         builder.Services.AddScoped<IActivityRepository, ActivityRepository>();      
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures authentication for WebAPI based on the AuthProvider:Provider setting.
+    /// Supports "Oidc" for Generic OpenID Connect authentication, or falls back to provider-specific auth.
+    /// </summary>
+    public static WebApplicationBuilder AddWebApiOidcAuth(this WebApplicationBuilder builder)
+    {
+        var authProvider = builder.Configuration["AuthProvider:Provider"];
+        var logger = builder.Services.BuildServiceProvider().GetRequiredService<ILogger<Program>>();
+
+        if (string.IsNullOrWhiteSpace(authProvider))
+        {
+            logger.LogWarning("AuthProvider:Provider is not configured. WebAPI will run without authentication.");
+            return builder;
+        }
+
+        if (authProvider.Equals("Oidc", StringComparison.OrdinalIgnoreCase))
+        {
+            logger.LogInformation("Configuring WebAPI with Generic OIDC authentication");
+
+            // Register Static OIDC Config Service (reads from appsettings.json)
+            builder.Services.AddSingleton<ITenantOidcConfigService, StaticOidcConfigService>();
+
+            // Register OIDC Validator (shared with User API)
+            builder.Services.AddScoped<IDynamicOidcValidator, DynamicOidcValidator>();
+
+            // Configure authentication scheme
+            builder.Services.AddAuthentication(options =>
+            {
+                options.DefaultAuthenticateScheme = "OidcScheme";
+                options.DefaultChallengeScheme = "OidcScheme";
+            })
+            .AddScheme<AuthenticationSchemeOptions, OidcAuthenticationHandler>("OidcScheme", options => { });
+
+            // Add authorization services with policies
+            builder.Services.AddAuthorization(options =>
+            {
+                // Policy that only validates the token
+                options.AddPolicy("RequireTokenAuth", policy =>
+                {
+                    policy.AuthenticationSchemes.Add("OidcScheme");
+                    policy.Requirements.Add(new AuthRequirement(AuthRequirementOptions.TokenOnly));
+                });
+                
+                // Policy that validates token and tenant ID, but not tenant configuration
+                options.AddPolicy("RequireTenantAuth", policy =>
+                {
+                    policy.AuthenticationSchemes.Add("OidcScheme");
+                    policy.Requirements.Add(new AuthRequirement(AuthRequirementOptions.FullTenantValidation));
+                    policy.RequireRole(SystemRoles.SysAdmin, SystemRoles.TenantAdmin, SystemRoles.TenantUser);
+                });
+                
+                // Optional: Add a policy that validates token and tenant ID but not configuration
+                options.AddPolicy("RequireTenantAuthWithoutConfig", policy =>
+                {
+                    policy.AuthenticationSchemes.Add("OidcScheme");
+                    policy.Requirements.Add(new AuthRequirement(AuthRequirementOptions.TenantWithoutConfig));
+                });
+
+                //role based policies
+                options.AddPolicy("RequireSysAdmin", policy =>
+                {
+                    policy.AuthenticationSchemes.Add("OidcScheme");
+                    policy.Requirements.Add(new AuthRequirement(AuthRequirementOptions.FullTenantValidation, SystemRoles.SysAdmin));
+                });
+
+                options.AddPolicy("RequireTenantAdmin", policy =>
+                {
+                    policy.AuthenticationSchemes.Add("OidcScheme");
+                    policy.Requirements.Add(new AuthRequirement(AuthRequirementOptions.FullTenantValidation, SystemRoles.SysAdmin, SystemRoles.TenantAdmin));
+                });
+            });
+
+            // Register the unified authorization handler
+            builder.Services.AddScoped<IAuthorizationHandler, AuthRequirementHandler>();
+
+            logger.LogInformation("WebAPI Generic OIDC authentication configured successfully");
+        }
+        else
+        {
+            logger.LogInformation("Using provider-specific authentication for '{AuthProvider}'. Consider migrating to Generic OIDC (Provider: 'Oidc') for provider-agnostic authentication.", authProvider);
+        }
 
         return builder;
     }

--- a/XiansAi.Server.Src/Features/WebApi/Endpoints/UserTenantEndpoints.cs
+++ b/XiansAi.Server.Src/Features/WebApi/Endpoints/UserTenantEndpoints.cs
@@ -17,7 +17,23 @@ public static class UserTenantEndpoints
             HttpContext httpContext) =>
         {
             var authHeader = httpContext.Request.Headers["Authorization"].FirstOrDefault();
-            var result = await service.GetCurrentUserTenants(authHeader!.Substring("Bearer ".Length));
+            
+            if (string.IsNullOrEmpty(authHeader))
+            {
+                return Results.Unauthorized();
+            }
+            
+            // Extract token from "Bearer <token>" format
+            var token = authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase)
+                ? authHeader.Substring("Bearer ".Length).Trim()
+                : authHeader.Trim();
+            
+            if (string.IsNullOrEmpty(token))
+            {
+                return Results.Unauthorized();
+            }
+            
+            var result = await service.GetCurrentUserTenants(token);
             return Results.Ok(result);
         })
         .WithName("GetCurrentUserTenants")

--- a/XiansAi.Server.Src/Shared/Auth/DynamicOidcValidator.cs
+++ b/XiansAi.Server.Src/Shared/Auth/DynamicOidcValidator.cs
@@ -9,7 +9,7 @@ using System.Security.Claims;
 using System.Text.Json;
 using Shared.Auth;
 
-namespace Features.UserApi.Auth;
+namespace Shared.Auth;
 
 public interface IDynamicOidcValidator
 {
@@ -163,8 +163,6 @@ public class DynamicOidcValidator : IDynamicOidcValidator
                 foreach (var check in providerRule.AdditionalClaims)
                 {
                     var value = principal.Claims.FirstOrDefault(c => c.Type == check.Claim)?.Value;
-                    //?? principal.Claims.FirstOrDefault(c => c.Type == ClaimConstants.TenantId)?.Value
-                    //?? principal.Claims.FirstOrDefault(c => c.Type == ClaimConstants.Tid)?.Value;
                     if (!EvaluateClaim(value, check))
                     {
                         return (false, null, $"Claim check failed: {check.Claim}");
@@ -330,4 +328,5 @@ public class DynamicOidcValidator : IDynamicOidcValidator
         };
     }
 }
+
 

--- a/XiansAi.Server.Src/Shared/Configuration/SharedConfiguration.cs
+++ b/XiansAi.Server.Src/Shared/Configuration/SharedConfiguration.cs
@@ -1,9 +1,11 @@
 using Shared.Repositories;
 using Shared.Services;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
 using Shared.Providers.Auth.Auth0;
 using Shared.Providers.Auth.AzureB2C;
 using Shared.Providers.Auth.Keycloak;
+using Shared.Providers.Auth.Oidc;
 using Shared.Providers.Auth;
 using Shared.Auth;
 using Shared.Utils;
@@ -44,12 +46,20 @@ public static class SharedConfiguration
             var httpClient = serviceProvider.GetRequiredService<HttpClient>();
             return new KeycloakTokenService(logger, configuration, httpClient);
         });
+        builder.Services.AddScoped<OidcTokenService>(serviceProvider =>
+        {
+            var logger = serviceProvider.GetRequiredService<ILogger<OidcTokenService>>();
+            var configuration = serviceProvider.GetRequiredService<IConfiguration>();
+            var cache = serviceProvider.GetRequiredService<IMemoryCache>();
+            return new OidcTokenService(logger, configuration, cache);
+        });
         builder.Services.AddScoped<ITokenServiceFactory, TokenServiceFactory>();
 
         // Register auth providers
         builder.Services.AddScoped<Auth0Provider>();
         builder.Services.AddScoped<AzureB2CProvider>();
         builder.Services.AddScoped<KeycloakProvider>();
+        builder.Services.AddScoped<OidcProvider>();
         builder.Services.AddScoped<IAuthProviderFactory, AuthProviderFactory>();
         builder.Services.AddScoped<IAuthMgtConnect, AuthMgtConnect>();
 

--- a/XiansAi.Server.Src/Shared/Providers/Auth/AuthProviderFactory.cs
+++ b/XiansAi.Server.Src/Shared/Providers/Auth/AuthProviderFactory.cs
@@ -1,6 +1,7 @@
 using Shared.Providers.Auth.Auth0;
 using Shared.Providers.Auth.AzureB2C;
 using Shared.Providers.Auth.Keycloak;
+using Shared.Providers.Auth.Oidc;
 
 namespace Shared.Providers.Auth;
 
@@ -30,6 +31,7 @@ public class AuthProviderFactory : IAuthProviderFactory
             AuthProviderType.Auth0 => _serviceProvider.GetRequiredService<Auth0Provider>(),
             AuthProviderType.AzureB2C => _serviceProvider.GetRequiredService<AzureB2CProvider>(),
             AuthProviderType.Keycloak => _serviceProvider.GetRequiredService<KeycloakProvider>(),
+            AuthProviderType.Oidc => _serviceProvider.GetRequiredService<OidcProvider>(),
             _ => throw new ArgumentException($"Unsupported authentication provider: {providerConfig.Provider}")
         };
     }

--- a/XiansAi.Server.Src/Shared/Providers/Auth/IAuthProvider.cs
+++ b/XiansAi.Server.Src/Shared/Providers/Auth/IAuthProvider.cs
@@ -38,7 +38,8 @@ public enum AuthProviderType
 {
     Auth0,
     AzureB2C,
-    Keycloak
+    Keycloak,
+    Oidc
 }
 
 /// <summary>

--- a/XiansAi.Server.Src/Shared/Providers/Auth/Oidc/OidcConfig.cs
+++ b/XiansAi.Server.Src/Shared/Providers/Auth/Oidc/OidcConfig.cs
@@ -1,0 +1,22 @@
+namespace Shared.Providers.Auth.Oidc;
+
+public class OidcConfig
+{
+    public string ProviderName { get; set; } = "Generic OIDC";
+    public string Authority { get; set; } = string.Empty;
+    public string? Issuer { get; set; }
+    public string Audience { get; set; } = string.Empty;
+    public string Scopes { get; set; } = "openid profile email";
+    public bool RequireSignedTokens { get; set; } = true;
+    public string[] AcceptedAlgorithms { get; set; } = new[] { "RS256" };
+    public bool RequireHttpsMetadata { get; set; } = true;
+    public OidcClaimMappings ClaimMappings { get; set; } = new();
+}
+
+public class OidcClaimMappings
+{
+    public string UserIdClaim { get; set; } = "sub";
+    public string EmailClaim { get; set; } = "email";
+    public string NameClaim { get; set; } = "name";
+}
+

--- a/XiansAi.Server.Src/Shared/Providers/Auth/Oidc/OidcProvider.cs
+++ b/XiansAi.Server.Src/Shared/Providers/Auth/Oidc/OidcProvider.cs
@@ -1,0 +1,216 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Shared.Providers.Auth.Auth0;
+using Shared.Services;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+
+namespace Shared.Providers.Auth.Oidc;
+
+public class OidcProvider : IAuthProvider
+{
+    private readonly ILogger<OidcProvider> _logger;
+    private readonly OidcConfig _config;
+    private readonly OidcTokenService _tokenService;
+
+    public OidcProvider(
+        ILogger<OidcProvider> logger,
+        OidcTokenService tokenService,
+        IConfiguration configuration)
+    {
+        _logger = logger;
+        _tokenService = tokenService;
+
+        // Load OIDC configuration
+        _config = configuration.GetSection("Oidc").Get<OidcConfig>() ??
+            throw new ArgumentException("OIDC configuration is missing");
+
+        if (string.IsNullOrEmpty(_config.Authority))
+            throw new ArgumentException("OIDC Authority is missing");
+
+        if (string.IsNullOrEmpty(_config.Audience))
+            throw new ArgumentException("OIDC Audience is missing");
+
+        _logger.LogInformation("Initialized OIDC Provider: {ProviderName}, Authority: {Authority}",
+            _config.ProviderName, _config.Authority);
+    }
+
+    public void ConfigureJwtBearer(JwtBearerOptions options, IConfiguration configuration)
+    {
+        options.Authority = _config.Authority;
+        options.RequireHttpsMetadata = _config.RequireHttpsMetadata;
+
+        options.TokenValidationParameters.ValidateIssuer = true;
+        options.TokenValidationParameters.ValidIssuer = _config.Issuer ?? _config.Authority;
+        
+        options.TokenValidationParameters.ValidateAudience = true;
+        options.TokenValidationParameters.ValidAudience = _config.Audience;
+        
+        options.TokenValidationParameters.ValidateLifetime = true;
+        options.TokenValidationParameters.ClockSkew = TimeSpan.FromMinutes(5);
+        
+        options.TokenValidationParameters.RequireSignedTokens = _config.RequireSignedTokens;
+        options.TokenValidationParameters.ValidAlgorithms = _config.AcceptedAlgorithms;
+
+        // Map claims properly
+        options.MapInboundClaims = false;
+        
+        // Clear default claim type mappings to use original claim names
+        JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.Clear();
+
+        options.Events = new JwtBearerEvents
+        {
+            OnAuthenticationFailed = context =>
+            {
+                _logger.LogError("JWT Bearer authentication failed: {Exception}", context.Exception?.Message);
+                _logger.LogError("Exception details: {FullException}", context.Exception?.ToString());
+                return Task.CompletedTask;
+            },
+
+            OnChallenge = context =>
+            {
+                _logger.LogWarning("JWT Bearer challenge triggered: {Error}, {ErrorDescription}",
+                    context.Error, context.ErrorDescription);
+                return Task.CompletedTask;
+            },
+
+            OnTokenValidated = async context =>
+            {
+                if (context.Principal?.Identity is ClaimsIdentity identity)
+                {
+                    _logger.LogInformation("Original identity authenticated: {IsAuthenticated}, Type: {AuthenticationType}",
+                        identity.IsAuthenticated, identity.AuthenticationType);
+
+                    // Ensure the identity is properly authenticated
+                    if (!identity.IsAuthenticated)
+                    {
+                        _logger.LogInformation("Creating new authenticated identity with JWT authentication type");
+                        var authenticatedIdentity = new ClaimsIdentity(
+                            identity.Claims,
+                            "JWT",
+                            identity.NameClaimType,
+                            identity.RoleClaimType);
+                        context.Principal = new ClaimsPrincipal(authenticatedIdentity);
+                        identity = authenticatedIdentity;
+
+                        _logger.LogInformation("New identity authenticated: {IsAuthenticated}, Type: {AuthenticationType}",
+                            authenticatedIdentity.IsAuthenticated, authenticatedIdentity.AuthenticationType);
+                    }
+
+                    // Extract user ID using configured claim mapping
+                    var userId = identity.FindFirst(_config.ClaimMappings.UserIdClaim)?.Value;
+
+                    // Fallback to standard claims if custom mapping not found
+                    if (string.IsNullOrEmpty(userId))
+                    {
+                        userId = identity.FindFirst(ClaimTypes.NameIdentifier)?.Value 
+                            ?? identity.FindFirst("sub")?.Value;
+                    }
+
+                    if (!string.IsNullOrEmpty(userId))
+                    {
+                        // Add NameIdentifier claim if not present
+                        if (identity.FindFirst(ClaimTypes.NameIdentifier) == null)
+                        {
+                            identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, userId));
+                        }
+
+                        _logger.LogInformation("Extracted user ID: {UserId}", userId);
+
+                        // Handle tenant-based roles
+                        var tenantId = context.HttpContext.Request.Headers["X-Tenant-Id"].FirstOrDefault();
+
+                        if (!string.IsNullOrEmpty(tenantId))
+                        {
+                            using var scope = context.HttpContext.RequestServices.CreateScope();
+                            var roleCacheService = scope.ServiceProvider
+                                .GetRequiredService<IRoleCacheService>();
+
+                            var roles = await roleCacheService.GetUserRolesAsync(userId, tenantId);
+
+                            // Remove existing role claims to prevent accumulation
+                            var existingRoleClaims = identity.Claims
+                                .Where(c => c.Type == ClaimTypes.Role)
+                                .ToList();
+                            foreach (var existingClaim in existingRoleClaims)
+                            {
+                                identity.RemoveClaim(existingClaim);
+                            }
+
+                            // Add fresh role claims
+                            var uniqueRoles = roles.Distinct().ToList();
+                            foreach (var role in uniqueRoles)
+                            {
+                                identity.AddClaim(new Claim(ClaimTypes.Role, role));
+                            }
+
+                            _logger.LogInformation("Added {RoleCount} roles to user {UserId}: {Roles}",
+                                roles.Count(), userId, string.Join(", ", roles));
+                        }
+                        else
+                        {
+                            // No tenant ID header - assign default TenantUser role
+                            _logger.LogInformation("No X-Tenant-Id header found, assigning default TenantUser role to user {UserId}", userId);
+                            
+                            // Remove existing role claims
+                            var existingRoleClaims = identity.Claims
+                                .Where(c => c.Type == ClaimTypes.Role)
+                                .ToList();
+                            foreach (var existingClaim in existingRoleClaims)
+                            {
+                                identity.RemoveClaim(existingClaim);
+                            }
+                            
+                            // Add default role
+                            identity.AddClaim(new Claim(ClaimTypes.Role, SystemRoles.TenantUser));
+                        }
+                    }
+
+                    // Set the User property of HttpContext
+                    context.HttpContext.User = context.Principal;
+
+                    _logger.LogInformation("OIDC user authenticated: {UserId}, IsAuthenticated: {IsAuthenticated}",
+                        userId, context.HttpContext.User.Identity?.IsAuthenticated);
+                }
+                else
+                {
+                    _logger.LogWarning("No principal or identity found in OnTokenValidated");
+                }
+            }
+        };
+    }
+
+    public async Task<(bool success, string? userId)> ValidateToken(string token)
+    {
+        return await _tokenService.ProcessToken(token);
+    }
+
+    public Task<UserInfo> GetUserInfo(string userId)
+    {
+        // For generic OIDC, we don't have a management API to fetch user info
+        // Return basic info from token claims
+        _logger.LogInformation("GetUserInfo called for generic OIDC provider - returning minimal user info");
+        
+        return Task.FromResult(new UserInfo
+        {
+            UserId = userId,
+            Nickname = userId,
+            AppMetadata = new AppMetadata { Tenants = Array.Empty<string>() },
+            CreatedAt = DateTime.UtcNow,
+            LastLogin = DateTime.UtcNow
+        });
+    }
+
+    public Task<List<string>> GetUserTenants(string userId)
+    {
+        // Generic OIDC doesn't have tenant management built-in
+        return Task.FromResult(new List<string>());
+    }
+
+    public Task<string> SetNewTenant(string userId, string tenantId)
+    {
+        // Generic OIDC doesn't support setting tenants via management API
+        _logger.LogWarning("SetNewTenant called for generic OIDC provider - not supported");
+        return Task.FromResult("Generic OIDC provider does not support tenant management");
+    }
+}
+

--- a/XiansAi.Server.Src/Shared/Providers/Auth/Oidc/OidcTokenService.cs
+++ b/XiansAi.Server.Src/Shared/Providers/Auth/Oidc/OidcTokenService.cs
@@ -1,0 +1,193 @@
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+
+namespace Shared.Providers.Auth.Oidc;
+
+public class OidcTokenService : ITokenService
+{
+    private readonly ILogger<OidcTokenService> _logger;
+    private readonly OidcConfig _config;
+    private readonly ConfigurationManager<OpenIdConnectConfiguration>? _configurationManager;
+    private readonly IMemoryCache _cache;
+
+    public OidcTokenService(
+        ILogger<OidcTokenService> logger,
+        IConfiguration configuration,
+        IMemoryCache cache)
+    {
+        _logger = logger;
+        _cache = cache;
+
+        // Load OIDC configuration
+        _config = configuration.GetSection("Oidc").Get<OidcConfig>() ??
+            throw new ArgumentException("OIDC configuration is missing");
+
+        if (string.IsNullOrEmpty(_config.Authority))
+            throw new ArgumentException("OIDC Authority is missing");
+
+        if (string.IsNullOrEmpty(_config.Audience))
+            throw new ArgumentException("OIDC Audience is missing");
+
+        // Initialize configuration manager for fetching OIDC metadata
+        _configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+            $"{_config.Authority.TrimEnd('/')}/.well-known/openid-configuration",
+            new OpenIdConnectConfigurationRetriever(),
+            new HttpDocumentRetriever());
+    }
+
+    public async Task<(bool success, string? userId)> ProcessToken(string token)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                _logger.LogWarning("Token is null or empty");
+                return (false, null);
+            }
+            
+            // Log token format for debugging (first/last few chars only for security)
+            _logger.LogDebug("Processing token: {TokenStart}...{TokenEnd} (length: {Length})", 
+                token.Substring(0, Math.Min(10, token.Length)), 
+                token.Length > 10 ? token.Substring(token.Length - 10) : "", 
+                token.Length);
+            
+            // Check cache first
+            var cacheKey = GetCacheKey(token);
+            if (_cache.TryGetValue<(bool success, string? userId)>(cacheKey, out var cachedResult))
+            {
+                _logger.LogDebug("Token validation cache hit");
+                return cachedResult;
+            }
+
+            var handler = new JwtSecurityTokenHandler();
+            
+            // Validate JWT format before processing (must have 3 segments: header.payload.signature)
+            var segments = token.Split('.');
+            if (segments.Length != 3)
+            {
+                _logger.LogError("Invalid JWT format: token has {SegmentCount} segments, expected 3. Token: {TokenPreview}...", 
+                    segments.Length, 
+                    token.Length > 50 ? token.Substring(0, 50) : token);
+                return (false, null);
+            }
+            
+            // Get OIDC configuration from discovery endpoint
+            var oidcConfig = await _configurationManager!.GetConfigurationAsync(CancellationToken.None);
+
+            var validationParameters = new TokenValidationParameters
+            {
+                ValidateIssuer = true,
+                ValidIssuer = _config.Issuer ?? _config.Authority,
+                ValidateAudience = true,
+                ValidAudience = _config.Audience,
+                ValidateIssuerSigningKey = _config.RequireSignedTokens,
+                IssuerSigningKeys = oidcConfig.SigningKeys,
+                ValidateLifetime = true,
+                ClockSkew = TimeSpan.FromMinutes(5),
+                RequireSignedTokens = _config.RequireSignedTokens,
+                ValidAlgorithms = _config.AcceptedAlgorithms
+            };
+
+            _logger.LogDebug("Validating JWT token with {KeyCount} signing keys", oidcConfig.SigningKeys.Count);
+            var principal = handler.ValidateToken(token, validationParameters, out var validatedToken);
+            
+            // Extract user ID using configured claim mapping
+            var userId = principal.FindFirst(_config.ClaimMappings.UserIdClaim)?.Value;
+            
+            if (string.IsNullOrEmpty(userId))
+            {
+                _logger.LogWarning("User ID claim '{UserIdClaim}' not found in token", _config.ClaimMappings.UserIdClaim);
+                var result = (false, (string?)null);
+                // Don't cache failed validations
+                return result;
+            }
+
+            _logger.LogInformation("Successfully validated OIDC token for user: {UserId}", userId);
+            var successResult = (true, (string?)userId);
+            
+            // Cache successful validation for 5 minutes
+            var cacheOptions = new MemoryCacheEntryOptions()
+                .SetAbsoluteExpiration(TimeSpan.FromMinutes(5))
+                .SetPriority(CacheItemPriority.High);
+            _cache.Set(cacheKey, successResult, cacheOptions);
+            
+            return successResult;
+        }
+        catch (SecurityTokenExpiredException ex)
+        {
+            _logger.LogWarning("Token expired: {Message}", ex.Message);
+            return (false, null);
+        }
+        catch (SecurityTokenException ex)
+        {
+            _logger.LogError("Token validation failed: {Message}", ex.Message);
+            return (false, null);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error during token validation");
+            return (false, null);
+        }
+    }
+
+    public string? ExtractUserId(JwtSecurityToken token)
+    {
+        // Try the configured user ID claim first
+        var userId = token.Claims.FirstOrDefault(c => c.Type == _config.ClaimMappings.UserIdClaim)?.Value;
+        if (!string.IsNullOrEmpty(userId))
+        {
+            _logger.LogDebug("Found user ID in '{ClaimType}' claim: {UserId}", _config.ClaimMappings.UserIdClaim, userId);
+            return userId;
+        }
+
+        // Fallback to standard 'sub' claim if configured claim is not found
+        userId = token.Claims.FirstOrDefault(c => c.Type == "sub")?.Value;
+        if (!string.IsNullOrEmpty(userId))
+        {
+            _logger.LogDebug("Found user ID in 'sub' claim: {UserId}", userId);
+            return userId;
+        }
+
+        // Try other common alternative claim names
+        var alternativeClaimTypes = new[] { "user_id", "uid", "id", "email", "preferred_username" };
+        foreach (var claimType in alternativeClaimTypes)
+        {
+            userId = token.Claims.FirstOrDefault(c => c.Type == claimType)?.Value;
+            if (!string.IsNullOrEmpty(userId))
+            {
+                _logger.LogInformation("Found user ID in '{ClaimType}' claim: {UserId}", claimType, userId);
+                return userId;
+            }
+        }
+
+        _logger.LogWarning("No user identifier found in any known claim types");
+        return null;
+    }
+
+    public IEnumerable<string> ExtractTenantIds(JwtSecurityToken token)
+    {
+        // Generic OIDC providers don't have a standard tenant claim
+        // This can be customized based on the specific provider's token structure
+        _logger.LogDebug("Generic OIDC provider does not have standard tenant claims");
+        return new List<string>();
+    }
+
+    private string GetCacheKey(string token)
+    {
+        // Use SHA256 hash to avoid collisions and not log the full token
+        using var sha = System.Security.Cryptography.SHA256.Create();
+        var hashBytes = sha.ComputeHash(System.Text.Encoding.UTF8.GetBytes(token));
+        var hash = Convert.ToBase64String(hashBytes);
+        return $"oidc_token_validation:{hash}";
+    }
+
+    public Task<string> GetManagementApiToken()
+    {
+        throw new NotImplementedException("Management API not supported for generic OIDC provider");
+    }
+}
+

--- a/XiansAi.Server.Src/Shared/Providers/Auth/TokenServiceFactory.cs
+++ b/XiansAi.Server.Src/Shared/Providers/Auth/TokenServiceFactory.cs
@@ -1,6 +1,7 @@
 using Shared.Providers.Auth.Auth0;
 using Shared.Providers.Auth.AzureB2C;
 using Shared.Providers.Auth.Keycloak;
+using Shared.Providers.Auth.Oidc;
 
 namespace Shared.Providers.Auth;
 
@@ -30,6 +31,7 @@ public class TokenServiceFactory : ITokenServiceFactory
             AuthProviderType.Auth0 => _serviceProvider.GetRequiredService<Auth0TokenService>(),
             AuthProviderType.AzureB2C => _serviceProvider.GetRequiredService<AzureB2CTokenService>(),
             AuthProviderType.Keycloak => _serviceProvider.GetRequiredService<KeycloakTokenService>(),
+            AuthProviderType.Oidc => _serviceProvider.GetRequiredService<OidcTokenService>(),
             _ => throw new ArgumentException($"Unsupported authentication provider: {providerConfig.Provider}")
         };
     }

--- a/XiansAi.Server.Src/Shared/Services/StaticOidcConfigService.cs
+++ b/XiansAi.Server.Src/Shared/Services/StaticOidcConfigService.cs
@@ -1,0 +1,181 @@
+using System.Text.Json;
+using Shared.Utils.Services;
+
+namespace Shared.Services;
+
+/// <summary>
+/// Static OIDC configuration service that reads from appsettings.json.
+/// Used by WebAPI for single-provider authentication (unlike User API which supports multi-tenant/per-tenant configs).
+/// </summary>
+public class StaticOidcConfigService : ITenantOidcConfigService
+{
+    private readonly TenantOidcRules? _staticRules;
+    private readonly ILogger<StaticOidcConfigService> _logger;
+
+    public StaticOidcConfigService(IConfiguration configuration, ILogger<StaticOidcConfigService> logger)
+    {
+        _logger = logger;
+        
+        // Read Oidc section from appsettings.json
+        var oidcSection = configuration.GetSection("Oidc");
+        
+        if (!oidcSection.Exists())
+        {
+            _logger.LogWarning("Oidc configuration section is missing in appsettings.json. WebAPI OIDC authentication will not work.");
+            _staticRules = null;
+            return;
+        }
+
+        try
+        {
+            // Extract configuration values
+            var providerName = oidcSection["ProviderName"] ?? "default";
+            var authority = oidcSection["Authority"];
+            var issuer = oidcSection["Issuer"];
+            var audience = oidcSection["Audience"];
+            var scopes = oidcSection["Scopes"];
+            
+            // Parse optional boolean values
+            var requireSignedTokens = oidcSection["RequireSignedTokens"];
+            var requireHttpsMetadata = oidcSection["RequireHttpsMetadata"];
+            
+            // Parse accepted algorithms (comma-separated or array)
+            List<string>? acceptedAlgorithms = null;
+            var algorithmsValue = oidcSection["AcceptedAlgorithms"];
+            if (!string.IsNullOrWhiteSpace(algorithmsValue))
+            {
+                acceptedAlgorithms = algorithmsValue.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
+            }
+            else
+            {
+                // Try to read as array from configuration
+                var algsArray = oidcSection.GetSection("AcceptedAlgorithms").Get<List<string>>();
+                if (algsArray != null && algsArray.Any())
+                {
+                    acceptedAlgorithms = algsArray;
+                }
+            }
+
+            // Parse expected audience (can be single value or array)
+            List<string>? expectedAudience = null;
+            if (!string.IsNullOrWhiteSpace(audience))
+            {
+                expectedAudience = new List<string> { audience };
+            }
+            else
+            {
+                // Try to read as array
+                var audienceArray = oidcSection.GetSection("Audience").Get<List<string>>();
+                if (audienceArray != null && audienceArray.Any())
+                {
+                    expectedAudience = audienceArray;
+                }
+            }
+
+            // Parse claim mappings
+            Dictionary<string, object>? providerSpecificSettings = null;
+            var claimMappingsSection = oidcSection.GetSection("ClaimMappings");
+            if (claimMappingsSection.Exists())
+            {
+                providerSpecificSettings = new Dictionary<string, object>();
+                
+                var userIdClaim = claimMappingsSection["UserIdClaim"];
+                if (!string.IsNullOrWhiteSpace(userIdClaim))
+                {
+                    providerSpecificSettings["userIdClaim"] = userIdClaim;
+                }
+            }
+
+            // Validate required fields
+            if (string.IsNullOrWhiteSpace(authority))
+            {
+                throw new InvalidOperationException("Oidc:Authority is required in appsettings.json");
+            }
+
+            if (expectedAudience == null || !expectedAudience.Any())
+            {
+                throw new InvalidOperationException("Oidc:Audience is required in appsettings.json");
+            }
+
+            // Build the provider rule
+            var providerRule = new OidcProviderRule
+            {
+                Authority = authority,
+                Issuer = issuer ?? authority, // Default issuer to authority if not specified
+                ExpectedAudience = expectedAudience,
+                Scope = scopes,
+                RequireSignedTokens = string.IsNullOrWhiteSpace(requireSignedTokens) ? true : bool.Parse(requireSignedTokens),
+                AcceptedAlgorithms = acceptedAlgorithms,
+                RequireHttpsMetadata = string.IsNullOrWhiteSpace(requireHttpsMetadata) ? true : bool.Parse(requireHttpsMetadata),
+                ProviderSpecificSettings = providerSpecificSettings
+            };
+
+            // Build the tenant rules (for "webapi" pseudo-tenant)
+            _staticRules = new TenantOidcRules
+            {
+                TenantId = "webapi",
+                Providers = new Dictionary<string, OidcProviderRule>
+                {
+                    [providerName] = providerRule
+                },
+                Notes = "Static configuration from appsettings.json for WebAPI"
+            };
+
+            _logger.LogInformation("Loaded static OIDC configuration: Provider={ProviderName}, Authority={Authority}, Audience={Audience}", 
+                providerName, authority, string.Join(", ", expectedAudience));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to parse Oidc configuration from appsettings.json");
+            throw new InvalidOperationException("Invalid Oidc configuration in appsettings.json", ex);
+        }
+    }
+
+    /// <summary>
+    /// Always returns the static configuration from appsettings.json (tenantId is ignored).
+    /// </summary>
+    public Task<ServiceResult<TenantOidcRules?>> GetForTenantAsync(string tenantId)
+    {
+        if (_staticRules == null)
+        {
+            return Task.FromResult(ServiceResult<TenantOidcRules?>.InternalServerError(
+                "OIDC configuration is not available. Check appsettings.json for Oidc section."));
+        }
+
+        return Task.FromResult(ServiceResult<TenantOidcRules?>.Success(_staticRules));
+    }
+
+    /// <summary>
+    /// Not supported for static configuration.
+    /// </summary>
+    public Task<ServiceResult<bool>> UpsertAsync(string tenantId, string jsonConfig, string actorUserId)
+    {
+        return Task.FromResult(ServiceResult<bool>.BadRequest(
+            "Upsert is not supported for static OIDC configuration. Update appsettings.json instead."));
+    }
+
+    /// <summary>
+    /// Not supported for static configuration.
+    /// </summary>
+    public Task<ServiceResult<bool>> DeleteAsync(string tenantId)
+    {
+        return Task.FromResult(ServiceResult<bool>.BadRequest(
+            "Delete is not supported for static OIDC configuration. Update appsettings.json instead."));
+    }
+
+    /// <summary>
+    /// Returns all configurations (just the single static one).
+    /// </summary>
+    public Task<ServiceResult<List<(string tenantId, TenantOidcRules? rules)>>> GetAllAsync()
+    {
+        var list = new List<(string tenantId, TenantOidcRules? rules)>();
+        
+        if (_staticRules != null)
+        {
+            list.Add(("webapi", _staticRules));
+        }
+
+        return Task.FromResult(ServiceResult<List<(string tenantId, TenantOidcRules? rules)>>.Success(list));
+    }
+}
+

--- a/XiansAi.Server.Src/docs/webapi/GENERIC_OIDC.md
+++ b/XiansAi.Server.Src/docs/webapi/GENERIC_OIDC.md
@@ -1,0 +1,108 @@
+## Generic OIDC in XiansAi.Server (Web API)
+
+This guide explains how the server validates JWT access tokens issued by any OpenID Connect (OIDC) provider. It’s written for beginners and focuses on what you need to configure and how the request flow works.
+
+### What Generic OIDC Means Here
+- The server does not perform an interactive sign‑in. Your frontend/app signs the user in with the provider and obtains a JWT access token.
+- The server only validates that JWT on every request. Therefore, client ID/secret and redirect URIs are handled on the client side, not by this server.
+
+### Where to Configure
+Set the provider type and the generic OIDC settings in `appsettings.json`:
+
+```12:44:C:\99xProjectDir\xians.ai\New folder\XiansAi.Server\XiansAi.Server.Src\appsettings.json
+// Supported Provider values: "Auth0", "AzureB2C", "Keycloak", "Oidc"
+"AuthProvider": {
+  "Provider": "Oidc"
+},
+
+"Oidc": {
+  "ProviderName": "AzureB2C",            // free-form, for logs only
+  "Authority": "https://<your-auth-domain>/", // base URL; used for discovery
+  "Issuer": "https://<your-issuer>/",     // optional; defaults to Authority
+  "Audience": "api://your-api-id",        // must match the token's audience
+  "Scopes": "openid,profile,email",       // informational here
+  "RequireSignedTokens": true,
+  "AcceptedAlgorithms": ["RS256"],
+  "RequireHttpsMetadata": true,
+  "ClaimMappings": {
+    "UserIdClaim": "sub"                  // or "oid", etc. based on your IdP
+  }
+}
+```
+
+Key fields the server uses:
+- **Authority/Issuer**: used to fetch discovery metadata (`.well-known/openid-configuration`) and to validate the issuer.
+- **Audience**: must match the `aud` in the access token presented to the API.
+- **AcceptedAlgorithms** and **RequireSignedTokens**: restrict acceptable signing algorithms.
+- **ClaimMappings.UserIdClaim**: which claim to treat as the unique user id (e.g. `sub`, `oid`).
+
+### Request Authentication Flow
+1. Frontend acquires an access token from your IdP (using client credentials on the frontend or SPA flow).
+2. Frontend calls this API with `Authorization: Bearer <access-token>`.
+3. Server’s JWT bearer handler validates the token using your `Oidc` config:
+   - Loads discovery metadata from `Authority/.well-known/openid-configuration`.
+   - Verifies signature, issuer, audience, lifetime, and allowed algorithms.
+4. After validation, the server extracts the user id using `ClaimMappings.UserIdClaim`, with fallbacks to common claims (e.g., `sub`).
+5. If you pass `X-Tenant-Id` header, the server loads role claims for that user+tenant (via `IRoleCacheService`). If not, it assigns a default `TenantUser` role.
+
+Code references:
+
+```8:21:C:\99xProjectDir\xians.ai\New folder\XiansAi.Server\XiansAi.Server.Src\Features\WebApi\Auth\AuthConfigurationExtensions.cs
+public static WebApplicationBuilder AddWebApiAuth(this WebApplicationBuilder builder)
+{
+    builder.Services.AddAuthentication()
+    .AddJwtBearer("JWT", options =>
+    {
+        var serviceProvider = builder.Services.BuildServiceProvider();
+        var authProviderFactory = serviceProvider.GetRequiredService<IAuthProviderFactory>();
+        var authProvider = authProviderFactory.GetProvider();
+        authProvider.ConfigureJwtBearer(options, builder.Configuration);
+    });
+```
+
+```37:53:C:\99xProjectDir\xians.ai\New folder\XiansAi.Server\XiansAi.Server.Src\Shared\Providers\Auth\Oidc\OidcProvider.cs
+public void ConfigureJwtBearer(JwtBearerOptions options, IConfiguration configuration)
+{
+    options.Authority = _config.Authority;
+    options.RequireHttpsMetadata = _config.RequireHttpsMetadata;
+    options.TokenValidationParameters.ValidIssuer = _config.Issuer ?? _config.Authority;
+    options.TokenValidationParameters.ValidAudience = _config.Audience;
+    options.TokenValidationParameters.RequireSignedTokens = _config.RequireSignedTokens;
+    options.TokenValidationParameters.ValidAlgorithms = _config.AcceptedAlgorithms;
+    options.MapInboundClaims = false;
+    // OnTokenValidated → set user id and role claims
+}
+```
+
+### User Profile Handling
+- Generic OIDC does not call a provider management API. The server returns minimal info based on token claims and your own app data.
+- Roles come from your own store (`IRoleCacheService`), keyed by user id and `X-Tenant-Id`.
+
+```187:201:C:\99xProjectDir\xians.ai\New folder\XiansAi.Server\XiansAi.Server.Src\Shared\Providers\Auth\Oidc\OidcProvider.cs
+public Task<UserInfo> GetUserInfo(string userId)
+{
+    // No provider mgmt API — return minimal info
+    return Task.FromResult(new UserInfo { UserId = userId, ... });
+}
+```
+
+### Differences vs Provider-Specific Modes
+- **Auth0**: Same JWT validation, plus optional user profile and app metadata (e.g., tenants) via Auth0 Management API.
+  - See `Shared/Providers/Auth/Auth0/Auth0Provider.cs`.
+- **Azure Entra ID/B2C**: Same JWT validation, can fetch user info via Microsoft Graph if configured.
+  - See `Shared/Providers/Auth/AzureB2C/AzureB2CProvider.cs`.
+- **Generic OIDC**: No provider management API usage. Pure JWT validation + claim mapping + your app’s role loading.
+
+### Quick Checklist
+- Set `AuthProvider:Provider` to `Oidc`.
+- Configure `Oidc.Authority`, `Issuer` (optional), `Audience`, `AcceptedAlgorithms`.
+- Map `ClaimMappings.UserIdClaim` to your IdP’s unique id claim.
+- Ensure frontend requests include `Authorization: Bearer <token>`.
+- Optionally include `X-Tenant-Id` to load tenant‑specific roles.
+
+### Troubleshooting Tips
+- 401 with "Invalid issuer/audience": check `Issuer`/`Authority` and `Audience` values against the token.
+- 401 with "Signing algorithm not allowed": ensure `AcceptedAlgorithms` includes the IdP’s signing alg (e.g., `RS256`).
+- No roles assigned: pass `X-Tenant-Id` and verify your role store configuration.
+
+


### PR DESCRIPTION
- Implement provider-agnostic OIDC via OidcProvider and OidcTokenService
- Configure JwtBearer through AuthConfigurationExtensions using IAuthProviderFactory
- Add StaticOidcConfigService (appsettings-based) and integrate DynamicOidcValidator
- Add optional OidcAuthenticationHandler and WebApiConfiguration.AddWebApiOidcAuth
- Expose tenant-scoped OIDC config endpoints (OidcConfigEndpoints)
- Register providers/services in SharedConfiguration (DI updates)
- Read OIDC settings from appsettings.json (Oidc section: Authority, Issuer, Audience, ClaimMappings)
- No interactive login; API validates Bearer tokens; user ID via ClaimMappings.UserIdClaim; roles via IRoleCacheService and X-Tenant-Id