### PR TITLE
Secret Vault Key + Scope Only & Tenant Existence Validation and also Ensuring scope level key uniqueness

### DIFF
--- a/XiansAi.Server.Src/Features/AdminApi/Endpoints/AdminSecretVaultEndpoints.cs
+++ b/XiansAi.Server.Src/Features/AdminApi/Endpoints/AdminSecretVaultEndpoints.cs
@@ -118,34 +118,15 @@ public static class AdminSecretVaultEndpoints
         .WithName("FetchSecretByKey")
         .WithOpenApi(o => { o.Summary = "Fetch secret by key"; o.Description = "Returns decrypted value and optional AdditionalData. Scope by tenantId, agentId, userId, activationName."; return o; });
 
-        group.MapGet("/{id}", async (
-            string id,
-            [FromServices] ISecretVaultService service,
-            [FromServices] ITenantContext tenantContext) =>
-        {
-            var result = await service.GetByIdAsync(id);
-            if (!result.IsSuccess || result.Data == null)
-                return result.ToHttpResult();
-            if (!SecretVaultScopeEnforcement.CanAccessSecretTenant(tenantContext, result.Data.TenantId))
-                return ServiceResult<SecretVaultGetResponse?>.Forbidden("Access denied. Secret is not in your tenant.").ToHttpResult();
-            return result.ToHttpResult();
-        })
-        .WithName("GetSecretById")
-        .WithOpenApi(o => { o.Summary = "Get secret by id"; return o; });
-
-        group.MapPut("/{id}", async (
-            string id,
+        group.MapPut("", async (
             [FromBody] SecretVaultUpdateRequest request,
             [FromServices] ISecretVaultService service,
             [FromServices] ITenantContext tenantContext,
             [FromServices] ITenantCacheService tenantCacheService,
             CancellationToken cancellationToken) =>
         {
-            var getResult = await service.GetByIdAsync(id);
-            if (!getResult.IsSuccess || getResult.Data == null)
-                return getResult.ToHttpResult();
-            if (!SecretVaultScopeEnforcement.CanAccessSecretTenant(tenantContext, getResult.Data.TenantId))
-                return ServiceResult<SecretVaultGetResponse>.Forbidden("Access denied. Secret is not in your tenant.").ToHttpResult();
+            if (string.IsNullOrWhiteSpace(request.Key))
+                return ServiceResult<SecretVaultGetResponse>.BadRequest("Key is required").ToHttpResult();
 
             if (!SecretVaultScopeEnforcement.TryResolveScope(
                 tenantContext,
@@ -180,27 +161,44 @@ public static class AdminSecretVaultEndpoints
                 effectiveUserId,
                 effectiveActivationName,
                 SecretVaultService.NormalizeAdditionalDataFromRequest(request.AdditionalData));
-            var result = await service.UpdateAsync(id, input, actor);
+            var result = await service.UpdateByKeyAsync(request.Key, input, actor);
             return result.ToHttpResult();
         })
-        .WithName("UpdateSecret")
-        .WithOpenApi(o => { o.Summary = "Update secret"; return o; });
+        .WithName("UpdateSecretByKey")
+        .WithOpenApi(o => { o.Summary = "Update secret by key and scope"; return o; });
 
-        group.MapDelete("/{id}", async (
-            string id,
+        group.MapDelete("", async (
+            [FromQuery] string key,
+            [FromQuery] string? tenantId,
+            [FromQuery] string? agentId,
+            [FromQuery] string? userId,
+            [FromQuery] string? activationName,
             [FromServices] ISecretVaultService service,
             [FromServices] ITenantContext tenantContext) =>
         {
-            var getResult = await service.GetByIdAsync(id);
-            if (!getResult.IsSuccess)
-                return getResult.ToHttpResult();
-            if (getResult.Data != null && !SecretVaultScopeEnforcement.CanAccessSecretTenant(tenantContext, getResult.Data.TenantId))
-                return ServiceResult<bool>.Forbidden("Access denied. Secret is not in your tenant.").ToHttpResult();
-            var result = await service.DeleteAsync(id);
+            if (string.IsNullOrWhiteSpace(key))
+                return ServiceResult<bool>.BadRequest("Key is required").ToHttpResult();
+
+            if (!SecretVaultScopeEnforcement.TryResolveScope(
+                tenantContext,
+                tenantId,
+                agentId,
+                userId,
+                activationName,
+                out var effectiveTenantId,
+                out var effectiveAgentId,
+                out var effectiveUserId,
+                out var effectiveActivationName,
+                out var forbiddenResult))
+            {
+                return forbiddenResult!.ToHttpResult();
+            }
+
+            var result = await service.DeleteByKeyAsync(key, effectiveTenantId, effectiveAgentId, effectiveUserId, effectiveActivationName);
             return result.ToHttpResult();
         })
-        .WithName("DeleteSecret")
-        .WithOpenApi(o => { o.Summary = "Delete secret"; return o; });
+        .WithName("DeleteSecretByKey")
+        .WithOpenApi(o => { o.Summary = "Delete secret by key and scope"; return o; });
     }
 }
 

--- a/XiansAi.Server.Src/Features/AdminApi/Endpoints/AdminSecretVaultEndpoints.cs
+++ b/XiansAi.Server.Src/Features/AdminApi/Endpoints/AdminSecretVaultEndpoints.cs
@@ -217,6 +217,7 @@ public class SecretVaultCreateRequest
 
 public class SecretVaultUpdateRequest
 {
+    public string Key { get; set; } = null!;
     public string? Value { get; set; }
     public string? TenantId { get; set; }
     public string? AgentId { get; set; }

--- a/XiansAi.Server.Src/Features/AdminApi/Endpoints/AdminSecretVaultEndpoints.cs
+++ b/XiansAi.Server.Src/Features/AdminApi/Endpoints/AdminSecretVaultEndpoints.cs
@@ -16,7 +16,9 @@ public static class AdminSecretVaultEndpoints
         group.MapPost("", async (
             [FromBody] SecretVaultCreateRequest request,
             [FromServices] ISecretVaultService service,
-            [FromServices] ITenantContext tenantContext) =>
+            [FromServices] ITenantContext tenantContext,
+            [FromServices] ITenantCacheService tenantCacheService,
+            CancellationToken cancellationToken) =>
         {
             if (!SecretVaultScopeEnforcement.TryResolveScope(
                 tenantContext,
@@ -31,6 +33,16 @@ public static class AdminSecretVaultEndpoints
                 out var forbiddenResult))
             {
                 return forbiddenResult!.ToHttpResult();
+            }
+
+            // If a tenant scope is provided/resolved, ensure the tenant exists when tenantId scope is explicitly set.
+            if (!string.IsNullOrWhiteSpace(request.TenantId) && !string.IsNullOrWhiteSpace(effectiveTenantId))
+            {
+                var tenant = await tenantCacheService.GetByTenantIdAsync(effectiveTenantId, cancellationToken);
+                if (tenant == null)
+                {
+                    return ServiceResult<SecretVaultGetResponse>.NotFound("Tenant not found").ToHttpResult();
+                }
             }
 
             var actor = tenantContext.LoggedInUser ?? "system";
@@ -125,7 +137,9 @@ public static class AdminSecretVaultEndpoints
             string id,
             [FromBody] SecretVaultUpdateRequest request,
             [FromServices] ISecretVaultService service,
-            [FromServices] ITenantContext tenantContext) =>
+            [FromServices] ITenantContext tenantContext,
+            [FromServices] ITenantCacheService tenantCacheService,
+            CancellationToken cancellationToken) =>
         {
             var getResult = await service.GetByIdAsync(id);
             if (!getResult.IsSuccess || getResult.Data == null)
@@ -146,6 +160,16 @@ public static class AdminSecretVaultEndpoints
                 out var forbiddenResult))
             {
                 return forbiddenResult!.ToHttpResult();
+            }
+
+            // If a tenant scope is provided/resolved, ensure the tenant exists when tenantId scope is explicitly set.
+            if (!string.IsNullOrWhiteSpace(request.TenantId) && !string.IsNullOrWhiteSpace(effectiveTenantId))
+            {
+                var tenant = await tenantCacheService.GetByTenantIdAsync(effectiveTenantId, cancellationToken);
+                if (tenant == null)
+                {
+                    return ServiceResult<SecretVaultGetResponse>.NotFound("Tenant not found").ToHttpResult();
+                }
             }
 
             var actor = tenantContext.LoggedInUser ?? "system";

--- a/XiansAi.Server.Src/Features/AgentApi/Endpoints/SecretVaultEndpoints.cs
+++ b/XiansAi.Server.Src/Features/AgentApi/Endpoints/SecretVaultEndpoints.cs
@@ -230,6 +230,7 @@ public class AgentSecretVaultCreateRequest
 
 public class AgentSecretVaultUpdateRequest
 {
+    public string Key { get; set; } = null!;
     public string? Value { get; set; }
     public string? TenantId { get; set; }
     public string? AgentId { get; set; }

--- a/XiansAi.Server.Src/Features/AgentApi/Endpoints/SecretVaultEndpoints.cs
+++ b/XiansAi.Server.Src/Features/AgentApi/Endpoints/SecretVaultEndpoints.cs
@@ -131,34 +131,15 @@ public static class SecretVaultEndpoints
         .WithName("Agent_FetchSecretByKey")
         .WithOpenApi(o => { o.Summary = "Fetch secret by key"; o.Description = "Returns decrypted value and optional AdditionalData. Scope by tenantId, agentId, userId, activationName."; return o; });
 
-        group.MapGet("/{id}", async (
-            string id,
-            [FromServices] ISecretVaultService service,
-            [FromServices] ITenantContext tenantContext) =>
-        {
-            var result = await service.GetByIdAsync(id);
-            if (!result.IsSuccess || result.Data == null)
-                return result.ToHttpResult();
-            if (!SecretVaultScopeEnforcement.CanAccessSecretTenant(tenantContext, result.Data.TenantId))
-                return ServiceResult<SecretVaultGetResponse?>.Forbidden("Access denied. Secret is not in your tenant.").ToHttpResult();
-            return result.ToHttpResult();
-        })
-        .WithName("Agent_GetSecretById")
-        .WithOpenApi(o => { o.Summary = "Get secret by id"; return o; });
-
-        group.MapPut("/{id}", async (
-            string id,
+        group.MapPut("", async (
             [FromBody] AgentSecretVaultUpdateRequest request,
             [FromServices] ISecretVaultService service,
             [FromServices] ITenantContext tenantContext,
             [FromServices] ITenantCacheService tenantCacheService,
             CancellationToken cancellationToken) =>
         {
-            var getResult = await service.GetByIdAsync(id);
-            if (!getResult.IsSuccess || getResult.Data == null)
-                return getResult.ToHttpResult();
-            if (!SecretVaultScopeEnforcement.CanAccessSecretTenant(tenantContext, getResult.Data.TenantId))
-                return ServiceResult<SecretVaultGetResponse>.Forbidden("Access denied. Secret is not in your tenant.").ToHttpResult();
+            if (string.IsNullOrWhiteSpace(request.Key))
+                return ServiceResult<SecretVaultGetResponse>.BadRequest("Key is required").ToHttpResult();
 
             if (!SecretVaultScopeEnforcement.TryResolveScope(
                 tenantContext,
@@ -193,27 +174,44 @@ public static class SecretVaultEndpoints
                 effectiveUserId,
                 effectiveActivationName,
                 SecretVaultService.NormalizeAdditionalDataFromRequest(request.AdditionalData));
-            var result = await service.UpdateAsync(id, input, actor);
+            var result = await service.UpdateByKeyAsync(request.Key, input, actor);
             return result.ToHttpResult();
         })
-        .WithName("Agent_UpdateSecret")
-        .WithOpenApi(o => { o.Summary = "Update secret"; return o; });
+        .WithName("Agent_UpdateSecretByKey")
+        .WithOpenApi(o => { o.Summary = "Update secret by key and scope"; return o; });
 
-        group.MapDelete("/{id}", async (
-            string id,
+        group.MapDelete("", async (
+            [FromQuery] string key,
+            [FromQuery] string? tenantId,
+            [FromQuery] string? agentId,
+            [FromQuery] string? userId,
+            [FromQuery] string? activationName,
             [FromServices] ISecretVaultService service,
             [FromServices] ITenantContext tenantContext) =>
         {
-            var getResult = await service.GetByIdAsync(id);
-            if (!getResult.IsSuccess)
-                return getResult.ToHttpResult();
-            if (getResult.Data != null && !SecretVaultScopeEnforcement.CanAccessSecretTenant(tenantContext, getResult.Data.TenantId))
-                return ServiceResult<bool>.Forbidden("Access denied. Secret is not in your tenant.").ToHttpResult();
-            var result = await service.DeleteAsync(id);
+            if (string.IsNullOrWhiteSpace(key))
+                return ServiceResult<bool>.BadRequest("Key is required").ToHttpResult();
+
+            if (!SecretVaultScopeEnforcement.TryResolveScope(
+                tenantContext,
+                tenantId,
+                agentId,
+                userId,
+                activationName,
+                out var effectiveTenantId,
+                out var effectiveAgentId,
+                out var effectiveUserId,
+                out var effectiveActivationName,
+                out var forbiddenResult))
+            {
+                return forbiddenResult!.ToHttpResult();
+            }
+
+            var result = await service.DeleteByKeyAsync(key, effectiveTenantId, effectiveAgentId, effectiveUserId, effectiveActivationName);
             return result.ToHttpResult();
         })
-        .WithName("Agent_DeleteSecret")
-        .WithOpenApi(o => { o.Summary = "Delete secret"; return o; });
+        .WithName("Agent_DeleteSecretByKey")
+        .WithOpenApi(o => { o.Summary = "Delete secret by key and scope"; return o; });
     }
 }
 

--- a/XiansAi.Server.Src/Features/AgentApi/Endpoints/SecretVaultEndpoints.cs
+++ b/XiansAi.Server.Src/Features/AgentApi/Endpoints/SecretVaultEndpoints.cs
@@ -17,7 +17,9 @@ public static class SecretVaultEndpoints
         group.MapPost("", async (
             [FromBody] AgentSecretVaultCreateRequest request,
             [FromServices] ISecretVaultService service,
-            [FromServices] ITenantContext tenantContext) =>
+            [FromServices] ITenantContext tenantContext,
+            [FromServices] ITenantCacheService tenantCacheService,
+            CancellationToken cancellationToken) =>
         {
             if (!SecretVaultScopeEnforcement.TryResolveScope(
                 tenantContext,
@@ -32,6 +34,16 @@ public static class SecretVaultEndpoints
                 out var forbiddenResult))
             {
                 return forbiddenResult!.ToHttpResult();
+            }
+
+            // If a tenant scope is provided/resolved, ensure the tenant exists.
+            if (!string.IsNullOrWhiteSpace(effectiveTenantId))
+            {
+                var tenant = await tenantCacheService.GetByTenantIdAsync(effectiveTenantId, cancellationToken);
+                if (tenant == null)
+                {
+                    return ServiceResult<SecretVaultGetResponse>.NotFound("Tenant not found").ToHttpResult();
+                }
             }
 
             var actor = tenantContext.LoggedInUser ?? "system";
@@ -84,7 +96,9 @@ public static class SecretVaultEndpoints
             [FromQuery] string? userId,
             [FromQuery] string? activationName,
             [FromServices] ISecretVaultService service,
-            [FromServices] ITenantContext tenantContext) =>
+            [FromServices] ITenantContext tenantContext,
+            [FromServices] ITenantCacheService tenantCacheService,
+            CancellationToken cancellationToken) =>
         {
             if (!SecretVaultScopeEnforcement.TryResolveScope(
                 tenantContext,
@@ -99,6 +113,16 @@ public static class SecretVaultEndpoints
                 out var forbiddenResult))
             {
                 return forbiddenResult!.ToHttpResult();
+            }
+
+            // If a tenant scope is provided/resolved, ensure the tenant exists.
+            if (!string.IsNullOrWhiteSpace(effectiveTenantId))
+            {
+                var tenant = await tenantCacheService.GetByTenantIdAsync(effectiveTenantId, cancellationToken);
+                if (tenant == null)
+                {
+                    return ServiceResult<SecretVaultFetchResponse?>.NotFound("Tenant not found").ToHttpResult();
+                }
             }
 
             var result = await service.FetchByKeyAsync(key, effectiveTenantId, effectiveAgentId, effectiveUserId, effectiveActivationName);
@@ -126,7 +150,9 @@ public static class SecretVaultEndpoints
             string id,
             [FromBody] AgentSecretVaultUpdateRequest request,
             [FromServices] ISecretVaultService service,
-            [FromServices] ITenantContext tenantContext) =>
+            [FromServices] ITenantContext tenantContext,
+            [FromServices] ITenantCacheService tenantCacheService,
+            CancellationToken cancellationToken) =>
         {
             var getResult = await service.GetByIdAsync(id);
             if (!getResult.IsSuccess || getResult.Data == null)
@@ -147,6 +173,16 @@ public static class SecretVaultEndpoints
                 out var forbiddenResult))
             {
                 return forbiddenResult!.ToHttpResult();
+            }
+
+            // If a tenant scope is provided/resolved, ensure the tenant exists.
+            if (!string.IsNullOrWhiteSpace(effectiveTenantId))
+            {
+                var tenant = await tenantCacheService.GetByTenantIdAsync(effectiveTenantId, cancellationToken);
+                if (tenant == null)
+                {
+                    return ServiceResult<SecretVaultGetResponse>.NotFound("Tenant not found").ToHttpResult();
+                }
             }
 
             var actor = tenantContext.LoggedInUser ?? "system";

--- a/XiansAi.Server.Src/Shared/Repositories/SecretVaultRepository.cs
+++ b/XiansAi.Server.Src/Shared/Repositories/SecretVaultRepository.cs
@@ -9,6 +9,7 @@ public interface ISecretVaultRepository
     Task<SecretVault?> GetByIdAsync(string id);
     Task<SecretVault?> GetByKeyAsync(string key);
     Task<bool> ExistsByKeyAsync(string key);
+    Task<bool> ExistsByKeyAndScopeAsync(string key, string? tenantId, string? agentId, string? userId, string? activationName, string? excludeId = null);
     Task<SecretVault?> FindForAccessAsync(string key, string? tenantId, string? agentId, string? userId, string? activationName);
     Task<List<SecretVault>> ListAsync(string? tenantId, string? agentId, string? activationName);
     Task CreateAsync(SecretVault entity);
@@ -76,32 +77,7 @@ public class SecretVaultRepository : ISecretVaultRepository
     {
         try
         {
-            var keyFilter = Builders<SecretVault>.Filter.Eq(x => x.Key, key);
-            var filters = new List<MongoDB.Driver.FilterDefinition<SecretVault>> { keyFilter };
-
-            // Request scope must match document scope: if request omits scope, document must have that scope null.
-            if (!string.IsNullOrWhiteSpace(tenantId))
-                filters.Add(Builders<SecretVault>.Filter.Eq(x => x.TenantId, tenantId));
-            else
-                filters.Add(Builders<SecretVault>.Filter.Eq(x => x.TenantId, (string?)null));
-
-            if (!string.IsNullOrWhiteSpace(agentId))
-                filters.Add(Builders<SecretVault>.Filter.Eq(x => x.AgentId, agentId));
-            else
-                filters.Add(Builders<SecretVault>.Filter.Eq(x => x.AgentId, (string?)null));
-
-            if (!string.IsNullOrWhiteSpace(userId))
-                filters.Add(Builders<SecretVault>.Filter.Eq(x => x.UserId, userId));
-            else
-                filters.Add(Builders<SecretVault>.Filter.Eq(x => x.UserId, (string?)null));
-
-            // Request scope must match document scope: if request omits scope, document must have that scope null.
-            if (!string.IsNullOrWhiteSpace(activationName))
-                filters.Add(Builders<SecretVault>.Filter.Eq(x => x.ActivationName, activationName));
-            else
-                filters.Add(Builders<SecretVault>.Filter.Eq(x => x.ActivationName, (string?)null));
-
-            var filter = Builders<SecretVault>.Filter.And(filters);
+            var filter = BuildKeyAndScopeFilter(key, tenantId, agentId, userId, activationName);
             return await _collection.Find(filter).FirstOrDefaultAsync();
         }
         catch (Exception ex)
@@ -109,6 +85,55 @@ public class SecretVaultRepository : ISecretVaultRepository
             _logger.LogError(ex, "Error finding secret for access key {Key}", key);
             return null;
         }
+    }
+
+    public async Task<bool> ExistsByKeyAndScopeAsync(string key, string? tenantId, string? agentId, string? userId, string? activationName, string? excludeId = null)
+    {
+        try
+        {
+            var filter = BuildKeyAndScopeFilter(key, tenantId, agentId, userId, activationName);
+            if (!string.IsNullOrEmpty(excludeId))
+            {
+                var builder = Builders<SecretVault>.Filter;
+                filter = builder.And(filter, builder.Ne(x => x.Id, excludeId));
+            }
+
+            var count = await _collection.CountDocumentsAsync(filter);
+            return count > 0;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error checking existence for key {Key} and scope", key);
+            return false;
+        }
+    }
+
+    private static FilterDefinition<SecretVault> BuildKeyAndScopeFilter(string key, string? tenantId, string? agentId, string? userId, string? activationName)
+    {
+        var builder = Builders<SecretVault>.Filter;
+        var filters = new List<FilterDefinition<SecretVault>>
+        {
+            builder.Eq(x => x.Key, key)
+        };
+
+        // Request scope must match document scope: if request omits scope, document must have that scope null.
+        filters.Add(!string.IsNullOrWhiteSpace(tenantId)
+            ? builder.Eq(x => x.TenantId, tenantId)
+            : builder.Eq(x => x.TenantId, (string?)null));
+
+        filters.Add(!string.IsNullOrWhiteSpace(agentId)
+            ? builder.Eq(x => x.AgentId, agentId)
+            : builder.Eq(x => x.AgentId, (string?)null));
+
+        filters.Add(!string.IsNullOrWhiteSpace(userId)
+            ? builder.Eq(x => x.UserId, userId)
+            : builder.Eq(x => x.UserId, (string?)null));
+
+        filters.Add(!string.IsNullOrWhiteSpace(activationName)
+            ? builder.Eq(x => x.ActivationName, activationName)
+            : builder.Eq(x => x.ActivationName, (string?)null));
+
+        return builder.And(filters);
     }
 
     public async Task<List<SecretVault>> ListAsync(string? tenantId, string? agentId, string? activationName)

--- a/XiansAi.Server.Src/Shared/Services/SecretVaultService.cs
+++ b/XiansAi.Server.Src/Shared/Services/SecretVaultService.cs
@@ -104,9 +104,20 @@ public class SecretVaultService : ISecretVaultService
         if (string.IsNullOrWhiteSpace(input.Value))
             return ServiceResult<SecretVaultGetResponse>.BadRequest("Value is required");
 
-        var exists = await _repository.ExistsByKeyAsync(input.Key);
+        // Normalize scope values so that uniqueness is enforced on the composite (Key + scope) with consistent null handling.
+        var normalizedTenantId = string.IsNullOrWhiteSpace(input.TenantId) ? null : input.TenantId;
+        var normalizedAgentId = string.IsNullOrWhiteSpace(input.AgentId) ? null : input.AgentId;
+        var normalizedUserId = string.IsNullOrWhiteSpace(input.UserId) ? null : input.UserId;
+        var normalizedActivationName = string.IsNullOrWhiteSpace(input.ActivationName) ? null : input.ActivationName;
+
+        var exists = await _repository.ExistsByKeyAndScopeAsync(
+            input.Key,
+            normalizedTenantId,
+            normalizedAgentId,
+            normalizedUserId,
+            normalizedActivationName);
         if (exists)
-            return ServiceResult<SecretVaultGetResponse>.Conflict("A secret with this key already exists");
+            return ServiceResult<SecretVaultGetResponse>.Conflict("A secret with this key already exists for the same scope");
 
         var (sanitizedAdditionalData, additionalDataError) = ValidateAndSanitizeAdditionalData(input.AdditionalData);
         if (additionalDataError != null)
@@ -121,10 +132,10 @@ public class SecretVaultService : ISecretVaultService
                 Id = MongoDB.Bson.ObjectId.GenerateNewId().ToString(),
                 Key = input.Key,
                 EncryptedValue = encrypted,
-                TenantId = string.IsNullOrWhiteSpace(input.TenantId) ? null : input.TenantId,
-                AgentId = string.IsNullOrWhiteSpace(input.AgentId) ? null : input.AgentId,
-                UserId = string.IsNullOrWhiteSpace(input.UserId) ? null : input.UserId,
-                ActivationName = string.IsNullOrWhiteSpace(input.ActivationName) ? null : input.ActivationName,
+                TenantId = normalizedTenantId,
+                AgentId = normalizedAgentId,
+                UserId = normalizedUserId,
+                ActivationName = normalizedActivationName,
                 AdditionalData = sanitizedAdditionalData,
                 CreatedAt = now,
                 CreatedBy = actorUserId
@@ -215,6 +226,17 @@ public class SecretVaultService : ISecretVaultService
                     return ServiceResult<SecretVaultGetResponse>.BadRequest(additionalDataError);
                 entity.AdditionalData = sanitizedAdditionalData;
             }
+
+            // Enforce uniqueness on (Key + scope) combination, excluding the current document.
+            var existsForScope = await _repository.ExistsByKeyAndScopeAsync(
+                entity.Key,
+                entity.TenantId,
+                entity.AgentId,
+                entity.UserId,
+                entity.ActivationName,
+                entity.Id);
+            if (existsForScope)
+                return ServiceResult<SecretVaultGetResponse>.Conflict("A secret with this key already exists for the same scope");
 
             entity.UpdatedAt = DateTime.UtcNow;
             entity.UpdatedBy = actorUserId;

--- a/XiansAi.Server.Src/Shared/Services/SecretVaultService.cs
+++ b/XiansAi.Server.Src/Shared/Services/SecretVaultService.cs
@@ -62,6 +62,8 @@ public interface ISecretVaultService
     Task<ServiceResult<SecretVaultGetResponse>> UpdateAsync(string id, SecretVaultUpdateInput input, string actorUserId);
     Task<ServiceResult<bool>> DeleteAsync(string id);
     Task<ServiceResult<SecretVaultFetchResponse?>> FetchByKeyAsync(string key, string? tenantId, string? agentId, string? userId, string? activationName);
+    Task<ServiceResult<SecretVaultGetResponse>> UpdateByKeyAsync(string key, SecretVaultUpdateInput input, string actorUserId);
+    Task<ServiceResult<bool>> DeleteByKeyAsync(string key, string? tenantId, string? agentId, string? userId, string? activationName);
 }
 
 public class SecretVaultService : ISecretVaultService
@@ -299,6 +301,37 @@ public class SecretVaultService : ISecretVaultService
             _logger.LogError(ex, "Error fetching secret vault key {Key}", key);
             return ServiceResult<SecretVaultFetchResponse?>.InternalServerError("Failed to fetch secret");
         }
+    }
+
+    public async Task<ServiceResult<SecretVaultGetResponse>> UpdateByKeyAsync(string key, SecretVaultUpdateInput input, string actorUserId)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+            return ServiceResult<SecretVaultGetResponse>.BadRequest("Key is required");
+
+        // Normalize scope for lookup to match repository semantics
+        var lookupTenantId = input.TenantId == null ? null : (string.IsNullOrWhiteSpace(input.TenantId) ? null : input.TenantId);
+        var lookupAgentId = input.AgentId == null ? null : (string.IsNullOrWhiteSpace(input.AgentId) ? null : input.AgentId);
+        var lookupUserId = input.UserId == null ? null : (string.IsNullOrWhiteSpace(input.UserId) ? null : input.UserId);
+        var lookupActivationName = input.ActivationName == null ? null : (string.IsNullOrWhiteSpace(input.ActivationName) ? null : input.ActivationName);
+
+        var entity = await _repository.FindForAccessAsync(key, lookupTenantId, lookupAgentId, lookupUserId, lookupActivationName);
+        if (entity == null)
+            return ServiceResult<SecretVaultGetResponse>.NotFound("Secret not found");
+
+        // Reuse existing update logic by delegating to UpdateAsync
+        return await UpdateAsync(entity.Id, input, actorUserId);
+    }
+
+    public async Task<ServiceResult<bool>> DeleteByKeyAsync(string key, string? tenantId, string? agentId, string? userId, string? activationName)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+            return ServiceResult<bool>.BadRequest("Key is required");
+
+        var entity = await _repository.FindForAccessAsync(key, tenantId, agentId, userId, activationName);
+        if (entity == null)
+            return ServiceResult<bool>.NotFound("Secret not found");
+
+        return await DeleteAsync(entity.Id);
     }
 
     private static SecretVaultGetResponse ToGetResponse(SecretVault entity, string decryptedValue)

--- a/XiansAi.Server.Src/docs/SECRET_VAULT.md
+++ b/XiansAi.Server.Src/docs/SECRET_VAULT.md
@@ -32,10 +32,10 @@ Fetch by key:
   → Service decrypts value
   → Response { value, additionalData } (additionalData as JSON object)
 
-Get by id / List:
+List:
   → Repository load
-  → Service decrypts value (for get), parses additionalData to object for response
-  → Response with decrypted value and additionalData as JSON object
+  → Service parses additionalData to object for response
+  → Response with metadata and additionalData as JSON object (no value)
 ```
 
 ### Scope Semantics
@@ -130,9 +130,8 @@ Authentication: **API key** (Bearer token). Policy: `AdminEndpointAuthPolicy` (e
 | POST | `/` | Create secret. Key must be unique. Body: key, value, tenantId?, agentId?, userId?, activationName?, additionalData? |
 | GET | `/` | List secrets. Query: tenantId?, agentId?, activationName? (optional filters) |
 | GET | `/fetch?key=&tenantId=&agentId=&userId=&activationName=` | Fetch secret by key with strict scope; returns `{ value, additionalData }` only |
-| GET | `/{id}` | Get secret by id (full record including decrypted value) |
-| PUT | `/{id}` | Update secret (value, scope, additionalData) |
-| DELETE | `/{id}` | Delete secret |
+| PUT | `/` | Update secret (value, scope, additionalData) by key+scope |
+| DELETE | `/` | Delete secret by key+scope (query: key, tenantId?, agentId?, userId?, activationName?) |
 
 **CreatedBy / UpdatedBy** are set from `ITenantContext.LoggedInUser` (fallback `"system"`).
 
@@ -140,7 +139,7 @@ Authentication: **API key** (Bearer token). Policy: `AdminEndpointAuthPolicy` (e
 
 Authentication: **Client certificate** (Bearer token = Base64-encoded client certificate). Policy: `RequiresCertificate`.
 
-Same operations as Admin API, under base path `/api/agent/secrets`. Actor for CreatedBy/UpdatedBy is `"agent-api"` (no user context in certificate flow).
+Same operations as Admin API (create by body, list, fetch by key, update by key+scope, delete by key+scope) under base path `/api/agent/secrets`. Actor for CreatedBy/UpdatedBy is `"agent-api"` (no user context in certificate flow).
 
 ### Request / Response Shapes
 
@@ -169,9 +168,9 @@ Same operations as Admin API, under base path `/api/agent/secrets`. Actor for Cr
 }
 ```
 
-**Get by id / Create response** (full secret record)
+**Create response** (full secret record)
 
-- Same as above, plus: `id`, `key`, `tenantId`, `agentId`, `userId`, `activationName`, `createdAt`, `createdBy`, `updatedAt`, `updatedBy`. The `value` is decrypted; `additionalData` is returned as a JSON object.
+- Same as above, plus: `id`, `key`, `tenantId`, `agentId`, `userId`, `activationName`, `createdAt`, `createdBy`, `updatedAt`, `updatedBy`. The `value` is decrypted; `additionalData` is returned as a JSON object. Subsequent fetch/update/delete operations address the secret by **key + scope**, not by id.
 
 ## AdditionalData: Structure and Security
 

--- a/XiansAi.Server.Src/docs/SECRET_VAULT.md
+++ b/XiansAi.Server.Src/docs/SECRET_VAULT.md
@@ -1,8 +1,8 @@
-# Secret Vault
+## Secret Vault
 
 ## Overview
 
-The Secret Vault is a simple, secure store for key-value secrets with optional scoping by tenant, agent, and user. The secret **value** is encrypted at rest using AES-256-GCM (via `ISecureEncryptionService`). The vault supports CRUD and a dedicated **fetch-by-key** operation with strict scope matching. Optional **additionalData** allows flat key-value metadata (string keys and string values only), validated and sanitized on create/update.
+The Secret Vault is a simple, secure store for key-value secrets with optional scoping by tenant, agent, user, and activation. The secret **value** is encrypted at rest using AES-256-GCM (via `ISecureEncryptionService`). The vault supports CRUD and a dedicated **fetch-by-key** operation with strict scope matching. Optional **additionalData** allows flat key-value metadata (string, number, or boolean values only), validated and sanitized on create/update.
 
 ## Architecture
 
@@ -51,6 +51,41 @@ Get by id / List:
 - If the **request** sends a scope (e.g. `tenantId=99xio`), the **document** must have that exact value. A document with `tenant_id: null` will not match a request that sends `tenantId=99xio`.
 
 So: to fetch a secret scoped to a tenant, the request must include that tenantId (and similarly for agentId, userId, activationName when the secret is scoped).
+
+### Tenant Existence Validation
+
+- **Agent API**:
+  - For **create**, **update**, and **fetch** operations, when a tenant scope is resolved (non-empty `tenantId`), the endpoint first verifies that the tenant exists using `ITenantCacheService.GetByTenantIdAsync`.
+  - If the tenant does not exist, the request fails with **404** `"Tenant not found"` and the secret operation is not performed.
+
+- **Admin API**:
+  - When creating or updating a secret **and** a `tenantId` scope is explicitly provided in the request, the resolved tenant ID is validated via `ITenantCacheService.GetByTenantIdAsync`.
+  - If the tenant does not exist, the request fails with **404** `"Tenant not found"` and the secret is not created/updated.
+
+This ensures that all tenant-scoped secrets always reference a real tenant in the Xians tenant collection, for both Agent and Admin flows.
+
+### Key and Scope Uniqueness
+
+Secret uniqueness is enforced on the **combination** of key and full scope tuple:
+
+- `Key`
+- `TenantId`
+- `AgentId`
+- `UserId`
+- `ActivationName`
+
+This means:
+
+- You **can** create multiple secrets with the same key as long as their **scope combination is different** (e.g. different tenant, agent, user, or activation).
+- You **cannot** create or update a secret such that there are two documents with the **same key and identical scope tuple** (`tenantId`, `agentId`, `userId`, `activationName`).
+
+Implementation details:
+
+- `SecretVaultRepository.ExistsByKeyAndScopeAsync` checks whether a document already exists for a given key and scope (with an optional `excludeId` for updates).
+- `SecretVaultService.CreateAsync` normalizes scope values (whitespace → `null`) and uses `ExistsByKeyAndScopeAsync` to prevent duplicates at create time.
+- `SecretVaultService.UpdateAsync` re-checks `ExistsByKeyAndScopeAsync` after applying scope changes, excluding the current document via `excludeId`, to avoid collisions when changing scope.
+
+This guarantees that **within a single scope combination, the key is unique**, while still allowing reuse of the same key across different scopes.
 
 ## Configuration
 
@@ -173,7 +208,7 @@ Stored value is the **sanitized** JSON string (types preserved for number and bo
 
 - **Collection:** `secret_vault`
 - **Document fields:** `_id`, `key`, `encrypted_value`, `tenant_id`, `agent_id`, `user_id`, `activation_name`, `additional_data`, `created_at`, `created_by`, `updated_at`, `updated_by`
-- **Uniqueness:** The secret **key** is unique in the collection (one document per key).
+- **Uniqueness:** The combination of **key + scope tuple** (`tenantId`, `agentId`, `userId`, `activationName`) is unique. The same key can exist in multiple rows as long as their scope differs.
 
 ## Security Considerations
 
@@ -193,6 +228,6 @@ Stored value is the **sanitized** JSON string (types preserved for number and bo
 |--------|--------|
 | **Storage** | MongoDB collection `secret_vault`; value encrypted, additionalData as sanitized JSON string |
 | **APIs** | Admin API (API key) and Agent API (client cert); same service, different auth |
-| **Scope** | tenantId, agentId, userId, activationName; null = “any”; fetch uses strict scope match for all |
+| **Scope** | tenantId, agentId, userId, activationName; null = “any”; fetch uses strict scope match for all; uniqueness is enforced on key + full scope tuple |
 | **AdditionalData** | Flat key-value; values: string, number, or boolean only; validated and sanitized on create/update; returned as JSON object |
 | **Encryption** | `EncryptionKeys:UniqueSecrets:SecretVaultKey` (fallback: BaseSecret) via `ISecureEncryptionService` |

--- a/XiansAi.Server.Src/docs/SECRET_VAULT_VALIDATION.md
+++ b/XiansAi.Server.Src/docs/SECRET_VAULT_VALIDATION.md
@@ -41,9 +41,9 @@ Returns:
 - `true` and the effective scope (effectiveTenantId, effectiveAgentId, effectiveUserId, effectiveActivationName) when the request is allowed.
 - `false` and a `ServiceResult<object>.Forbidden` when the request must be rejected with 403.
 
-#### 2. `CanAccessSecretTenant` (get by id, update, delete)
+#### 2. `CanAccessSecretTenant` (internal id-based checks)
 
-Used for operations that identify a secret by **id** (get by id, update, delete). The server loads the secret first, then checks whether the caller may access that secret’s tenant.
+Used internally for operations that identify a secret by **id** (e.g. service-level operations). For external APIs, callers address secrets by **key + scope**, not by id. The server loads the secret first, then checks whether the caller may access that secret’s tenant.
 
 | Input | Description |
 |-------|-------------|
@@ -67,16 +67,15 @@ Returns `true` if the caller may access the secret, `false` otherwise. The endpo
 | **POST** (create) | `TryResolveScope` with body scope → use effective scope; if forbidden, return 403. |
 | **GET** (list) | `TryResolveScope` with query tenantId, agentId, activationName → list with effective scope. |
 | **GET** /fetch | `TryResolveScope` with query scope → fetch with effective scope. |
-| **GET** /{id} | Load secret; `CanAccessSecretTenant(tenantContext, secret.TenantId)` → if false, return 403. |
-| **PUT** /{id} | Load secret; `CanAccessSecretTenant` → if false, return 403. Then `TryResolveScope` on update body → update with effective scope. |
-| **DELETE** /{id} | Load secret; `CanAccessSecretTenant` → if false, return 403; then delete. |
+| **PUT** `/` (update by key+scope) | `TryResolveScope` on update body → update with effective scope. |
+| **DELETE** `/` (delete by key+scope) | `TryResolveScope` with query scope → delete with effective scope. |
 
 ### Admin API (`Features/AdminApi/Endpoints/AdminSecretVaultEndpoints.cs`)
 
 Same rules as Agent API:
 
 - Create, list, fetch: `TryResolveScope` and use effective scope; return 403 when forbidden.
-- Get by id, update, delete: load secret, then `CanAccessSecretTenant`; if false, return 403. For update, also resolve scope from the body with `TryResolveScope`.
+- Update/delete: accept key + scope, resolve scope with `TryResolveScope`, and apply changes only within the effective tenant.
 
 ## Roles and context
 

--- a/XiansAi.Server.Tests/http/AdminApi/admin-secret-vault-endpoints.http
+++ b/XiansAi.Server.Tests/http/AdminApi/admin-secret-vault-endpoints.http
@@ -5,9 +5,6 @@
 # API Key Authentication (SysAdmin)
 @apiKey = sk-Xnai-SEoFvTEYIuBRjdIJWYPWykvJoFUj1OeAOfP8FZk5vGE
 
-# Replace with id from Create response when testing Get/Update/Delete
-@secretId = 699fd9525d56097919802e3a
-
 ### ============================================
 ### Admin API - Secret Vault
 ### ============================================
@@ -83,20 +80,14 @@ Accept: application/json
 
 ###
 
-### 7. Get Secret by Id (full record including decrypted value)
-GET {{baseUrl}}/api/{{apiVersion}}/admin/secrets/{{secretId}}
-Authorization: Bearer {{apiKey}}
-Accept: application/json
-
-###
-
-### 8. Update Secret
-PUT {{baseUrl}}/api/{{apiVersion}}/admin/secrets/{{secretId}}
+### 7. Update Secret by Key and Scope
+PUT {{baseUrl}}/api/{{apiVersion}}/admin/secrets
 Authorization: Bearer {{apiKey}}
 Content-Type: application/json
 Accept: application/json
 
 {
+  "key": "my-api-key-01",
   "value": "my-api-key-01",
   "tenantId": "99xio",
   "agentId": "agent-01",
@@ -107,8 +98,8 @@ Accept: application/json
 
 ###
 
-### 9. Delete Secret
-DELETE {{baseUrl}}/api/{{apiVersion}}/admin/secrets/{{secretId}}
+### 8. Delete Secret by Key and Scope
+DELETE {{baseUrl}}/api/{{apiVersion}}/admin/secrets?key=my-api-key-01&tenantId=99xio&agentId=agent-01&userId=user-123&activationName=my-activation
 Authorization: Bearer {{apiKey}}
 Accept: application/json
 

--- a/XiansAi.Server.Tests/http/AgentApi/agent-secret-vault-endpoints.http
+++ b/XiansAi.Server.Tests/http/AgentApi/agent-secret-vault-endpoints.http
@@ -30,7 +30,7 @@ Accept: application/json
 {
   "key": "agent-api-secret-014",
   "value": "agent-secret-value",
-  "tenantId": "hello",
+  "tenantId": "",
   "agentId": null,
   "userId": null,
   "activationName": null,

--- a/XiansAi.Server.Tests/http/AgentApi/agent-secret-vault-endpoints.http
+++ b/XiansAi.Server.Tests/http/AgentApi/agent-secret-vault-endpoints.http
@@ -12,9 +12,6 @@
 # Optional: tenant context (must match cert tenant unless SysAdmin). Use for tenant-scoped secrets.
 @tenantId = 99xio
 
-# Replace with id from Create response when testing Get/Update/Delete
-@secretId = 699fd9525d56097919802e3a
-
 ### ============================================
 ### Agent API - Secret Vault (Certificate auth)
 ### ============================================
@@ -70,20 +67,14 @@ Accept: application/json
 
 ###
 
-### 6. Get Secret by Id
-GET {{agentBaseUrl}}/api/agent/secrets/{{secretId}}
-Authorization: Bearer {{clientCertBase64}}
-Accept: application/json
-
-###
-
-### 7. Update Secret
-PUT {{agentBaseUrl}}/api/agent/secrets/{{secretId}}
+### 6. Update Secret by Key and Scope
+PUT {{agentBaseUrl}}/api/agent/secrets
 Authorization: Bearer {{clientCertBase64}}
 Content-Type: application/json
 Accept: application/json
 
 {
+  "key": "agent-api-secret-014",
   "value": "updated-agent-secreti",
   "tenantId": null,
   "agentId": null,
@@ -94,8 +85,8 @@ Accept: application/json
 
 ###
 
-### 8. Delete Secret
-DELETE {{agentBaseUrl}}/api/agent/secrets/{{secretId}}
+### 7. Delete Secret by Key and Scope
+DELETE {{agentBaseUrl}}/api/agent/secrets?key=agent-api-secret-014
 Authorization: Bearer {{clientCertBase64}}
 Accept: application/json
 


### PR DESCRIPTION
## Summary

Secret Vault APIs now identify secrets by **key + scope** only for fetch, update, and delete. The “get by id” endpoint has been removed. When a tenant scope is used, the server validates that the tenant exists in the Xians tenant collection.

## Changes

### Service (`SecretVaultService`)

- **Added** `UpdateByKeyAsync(string key, SecretVaultUpdateInput input, string actorUserId)` – finds secret via `FindForAccessAsync(key, scope)` then delegates to `UpdateAsync(entity.Id, ...)`.
- **Added** `DeleteByKeyAsync(string key, string? tenantId, string? agentId, string? userId, string? activationName)` – finds via `FindForAccessAsync` then calls `DeleteAsync(entity.Id)`.
- Existing `GetByIdAsync`, `UpdateAsync`, `DeleteAsync` remain for internal use.

### Agent API (`SecretVaultEndpoints`)

- **Removed** `GET /api/agent/secrets/{id}` (Get by id).
- **Update**: `PUT /api/agent/secrets` – body must include `key`; scope from body, resolved with `TryResolveScope`; tenant existence checked when effective tenant is set; calls `UpdateByKeyAsync(request.Key, ...)`.
- **Delete**: `DELETE /api/agent/secrets?key=...&tenantId=...&agentId=...&userId=...&activationName=...` – scope from query, resolved with `TryResolveScope`; calls `DeleteByKeyAsync(key, effectiveTenantId, ...)`.

### Admin API (`AdminSecretVaultEndpoints`)

- **Removed** `GET /api/v1/admin/secrets/{id}` (Get by id).
- **Update**: `PUT /api/v1/admin/secrets` – body must include `key`; scope and tenant validation (when `request.TenantId` set) then `UpdateByKeyAsync(request.Key, ...)`.
- **Delete**: `DELETE /api/v1/admin/secrets?key=...&tenantId=...&agentId=...&userId=...&activationName=...` – scope from query, `TryResolveScope`, then `DeleteByKeyAsync`.

### Tenant existence validation

- **Agent API**: On create, update, and fetch, when effective `tenantId` is non-empty, endpoint calls `ITenantCacheService.GetByTenantIdAsync`; if tenant is missing, returns **404** “Tenant not found”.
- **Admin API**: On create and update, when `request.TenantId` and effective tenant are set, same check; 404 if tenant does not exist.

### Documentation

- **SECRET_VAULT.md**: Data flow (no “Get by id”), API reference table (PUT/DELETE by key+scope, no GET by id), create response note that subsequent operations use key+scope.
- **SECRET_VAULT_VALIDATION.md**: `CanAccessSecretTenant` described as internal; Agent/Admin tables updated for update/delete by key+scope.

### HTTP test files

- **agent-secret-vault-endpoints.http**: Removed `@secretId` and id-based GET/PUT/DELETE; added PUT body with `key`, DELETE with `?key=...`.
- **admin-secret-vault-endpoints.http**: Same; PUT with `key` in body, DELETE with key and scope query params.

## Breaking changes

- Clients must not rely on `GET /api/v1/admin/secrets/{id}` or `GET /api/agent/secrets/{id}`; use list + fetch by key (or list only) instead.
- Update and delete must be called with key and correct scope (query or body as above).

## Checklist

- [ ] DB and uniqueness unchanged (key + scope tuple).
- [ ] Tenant validation only when tenant scope is present; cross-tenant (null) unchanged.
