### PR TITLE
fix: filter totalMessages to Chat type only in messaging stats

### DIFF
--- a/XiansAi.Server.Src/Shared/Repositories/ConversationRepository.cs
+++ b/XiansAi.Server.Src/Shared/Repositories/ConversationRepository.cs
@@ -1050,10 +1050,11 @@ string tenantId, string threadId, int? page = null, int? pageSize = null, string
                 "Getting messaging stats for tenantId {TenantId}, dateRange {StartDate} to {EndDate}, participantId {ParticipantId}",
                 tenantId, startDate, endDate, participantId ?? "null");
 
-            // Build filter for messages in date range
+            // Build filter for messages in date range, only counting Chat type messages
             var filterBuilder = Builders<ConversationMessage>.Filter;
             var filter = filterBuilder.And(
                 filterBuilder.Eq(m => m.TenantId, tenantId),
+                filterBuilder.Eq(m => m.MessageType, MessageType.Chat),
                 filterBuilder.Gte(m => m.CreatedAt, startDate),
                 filterBuilder.Lte(m => m.CreatedAt, endDate)
             );


### PR DESCRIPTION
## Summary

- Updated `GetMessagingStatsAsync` in `ConversationRepository` to only count messages where `message_type` is `Chat`
- Previously, all message types were included in the `totalMessages` count, which inflated the stat with non-chat messages (e.g. system messages, events, etc.)
- The `Chat` filter is also applied to the distinct active users count, keeping both metrics consistent

## Changes

- `XiansAi.Server.Src/Shared/Repositories/ConversationRepository.cs` — added `MessageType.Chat` filter in `GetMessagingStatsAsync`


Made with [Cursor](https://cursor.com)