### PR TITLE
Forward inbound webhook HTTP headers to agents via Metadata

### DIFF
--- a/XiansAi.Server.Src/Features/UserApi/Endpoints/WebhookEndpoints.cs
+++ b/XiansAi.Server.Src/Features/UserApi/Endpoints/WebhookEndpoints.cs
@@ -104,13 +104,15 @@ public static class WebhookEndpoints
                 // Build workflowId from workflowName (format: tenant:workflowName)
                 // Using webhookName as the scope/method identifier
                 var workflowId = $"{tenantId}:{agentName}:{workflowName}{(activationName != null ? $":{activationName}" : string.Empty)}";
-                
+
                 // Use participantId from query or default to "webhook" for identification
                 // Normalize to lowercase for consistency (especially important for emails)
                 var resolvedParticipantId = (participantId ?? "webhook").ToLowerInvariant();
 
                 // Generate unique request ID for correlation
                 var requestId = MessageRequestProcessor.GenerateRequestId(workflowId, resolvedParticipantId);
+
+                var inboundMetadata = WebhookHeaderCapture.Capture(httpContext.Request.Headers);
 
                 // Create the chat request for the message service
                 var chatRequest = new ChatOrDataRequest
@@ -122,7 +124,8 @@ public static class WebhookEndpoints
                     Data = body,
                     Scope = scope,
                     Authorization = authorization ?? tenantContext.Authorization,
-                    Origin = $"webhook:builtin:{webhookName}"
+                    Origin = $"webhook:builtin:{webhookName}",
+                    Metadata = inboundMetadata
                 };
 
                 // Use the sync message handler to process and wait for response
@@ -157,7 +160,7 @@ public static class WebhookEndpoints
                 if (dataProperty != null)
                 {
                     var dataValue = dataProperty.GetValue(result);
-                    
+
                     // If Data is already a WebhookResponse
                     if (dataValue is WebhookResponse wr)
                     {
@@ -209,17 +212,17 @@ public static class WebhookEndpoints
                         }
                     }
                 }
-            
+
 
                 // Apply the WebhookResponse to the HTTP context
                 if (webhookResponse != null)
                 {
                     logger.LogInformation(
-                        "Applying WebhookResponse: StatusCode={StatusCode}, ContentType={ContentType}, HeaderCount={HeaderCount}", 
-                        webhookResponse.StatusCode, 
-                        webhookResponse.ContentType, 
+                        "Applying WebhookResponse: StatusCode={StatusCode}, ContentType={ContentType}, HeaderCount={HeaderCount}",
+                        webhookResponse.StatusCode,
+                        webhookResponse.ContentType,
                         webhookResponse.Headers?.Count ?? 0);
-                    
+
                     await webhookResponse.ApplyToHttpContextAsync(httpContext);
                     return Results.Empty;
                 }
@@ -251,7 +254,7 @@ public static class WebhookEndpoints
         .WithTags("User API - Webhooks")
         .RequireAuthorization("EndpointAuthPolicy")
         .WithAgentUserApiRateLimit()
-        
+
         .WithSummary("Process a builtin webhook using message passing infrastructure")
         .WithDescription(@"Receives webhook calls and delivers them as messages to the specified workflow,
 waiting synchronously for a response using the message passing infrastructure.
@@ -320,7 +323,7 @@ This allows the workflow to control the HTTP response returned to the webhook ca
                 // Get tenantId from authenticated context (set by EndpointAuthenticationHandler)
                 // This prevents IDOR vulnerabilities by ensuring the tenantId matches the authenticated API key
                 var tenantId = tenantContext.TenantId;
-                
+
                 if (string.IsNullOrEmpty(tenantId))
                 {
                     return Results.Problem(
@@ -352,10 +355,10 @@ This allows the workflow to control the HTTP response returned to the webhook ca
                 {
                     // Return the WebhookResponse directly
                     var webhookResponse = result.Data ?? throw new Exception("WebhookResponse is null");
-                    
+
                     // Apply the webhook response to the HTTP context
                     await webhookResponse.ApplyToHttpContextAsync(httpContext);
-                    
+
                     return Results.Empty;
                 }
 
@@ -372,7 +375,7 @@ This allows the workflow to control the HTTP response returned to the webhook ca
         .WithTags("User API - Webhooks")
         .RequireAuthorization("EndpointAuthPolicy")
         .WithAgentUserApiRateLimit() // Apply rate limiting to prevent enumeration attacks
-        
+
         .WithSummary("Process a webhook for a temporal workflow")
         .WithDescription(@"Receives webhook calls and delivers them as Temporal Updates to the specified workflow.
             

--- a/XiansAi.Server.Src/Shared/Services/MessageService.cs
+++ b/XiansAi.Server.Src/Shared/Services/MessageService.cs
@@ -76,6 +76,11 @@ public class ChatOrDataRequest
     //public string? ThreadId { get; set; }
     public string? Authorization { get; set; }
     public string? Origin { get; set; }
+
+    /// <summary>
+    /// Optional key-value metadata (e.g. inbound HTTP headers for webhooks).
+    /// </summary>
+    public Dictionary<string, string>? Metadata { get; set; }
 }
 
 public class HandoffRequest
@@ -408,7 +413,8 @@ public class MessageService : IMessageService
                  request.TaskId,
                  request.Data,
                  Type = messageType.ToString(),
-                 request.Authorization
+                 request.Authorization,
+                 request.Metadata
             }
         };
         await _workflowSignalService.SignalWithStartWorkflow(signalRequest);

--- a/XiansAi.Server.Src/Shared/Utils/WebhookHeaderCapture.cs
+++ b/XiansAi.Server.Src/Shared/Utils/WebhookHeaderCapture.cs
@@ -1,0 +1,40 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+
+namespace Shared.Utils;
+
+/// <summary>
+/// Captures inbound HTTP headers for webhook metadata forwarding.
+/// </summary>
+public static class WebhookHeaderCapture
+{
+    /// <summary>
+    /// Returns captured headers, or null if none captured.
+    /// </summary>
+    public static Dictionary<string, string>? Capture(IHeaderDictionary requestHeaders)
+    {
+        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        foreach (var header in requestHeaders)
+        {
+            var value = GetFirstNonEmpty(header.Value);
+            if (value is null)
+                continue;
+
+            result[header.Key] = value;
+        }
+
+        return result.Count > 0 ? result : null;
+    }
+
+    private static string? GetFirstNonEmpty(StringValues values)
+    {
+        foreach (var v in values)
+        {
+            if (!string.IsNullOrEmpty(v))
+                return v;
+        }
+
+        return null;
+    }
+}

--- a/XiansAi.Server.Src/docs/WEBHOOKS.md
+++ b/XiansAi.Server.Src/docs/WEBHOOKS.md
@@ -4,7 +4,7 @@ Webhooks are used to notify the agents when a certain event occurs.
 
 ## Webhook URL Format
 
-```
+```http
 POST <server-url>/api/user/webhooks/{workflow}/{methodName}
 Authorization: Bearer <apikey>
 ```
@@ -18,7 +18,7 @@ Authorization: Bearer <apikey>
 
 For backward compatibility, the API key may also be passed as a query parameter:
 
-```
+```http
 POST <server-url>/api/user/webhooks/{workflow}/{methodName}?apikey={apikey}
 ```
 
@@ -44,11 +44,38 @@ public async Task<string> WebhookUpdateMethod(IDictionary<string, string> queryP
 
 The return value should be a string which will be sent to the webhook URL caller in response body.
 
+## Builtin webhooks
+
+```http
+POST <server-url>/api/user/webhooks/builtin?workflowName=...&webhookName=...&agentName=...
+Authorization: Bearer <apikey>
+```
+
+The agent worker handles the event via `OnWebhook(WebhookContext)` and returns an HTTP response
+when the handler calls `context.Respond(...)`.
+
+### Inbound HTTP headers forwarded to agents
+
+Only the builtin endpoint forwards inbound headers to the agent as
+`WebhookContext.Metadata` (`Dictionary<string, string>`).
+
+**Behavior:**
+
+- All inbound headers are forwarded with no size limit (including auth/sensitive headers).
+- Multiple values for one header: the **first** non-empty value is used.
+- Header names are forwarded using the key casing provided by ASP.NET request headers.
+- Captured metadata is sent on the Temporal signal only; it is **not** stored in MongoDB
+  conversation messages in the current version.
+
+The legacy `POST /api/user/webhooks/{workflow}/{methodName}` (Temporal Update) path does not
+forward inbound headers.
+
 ## Implementation
 
 - Endpoint: Features/UserApi/Endpoints/WebhookEndpoints.cs
   - authenticate with APIkey
   - use WorkflowIdentifier to get the WorkflowId and WorkflowType
+  - builtin path: `Shared/Utils/WebhookHeaderCapture.cs` for inbound header forwarding
 - Service: Features/UserApi/Services/WebhookService.cs
 - Util Class: Shared/Utils/Temporal/UpdateService.cs
   - use NewWorkflowOptions to send the Update with Start


### PR DESCRIPTION
Forward inbound HTTP headers from builtin webhook requests to agent workers via Temporal signal Metadata, so headers from providers like GitHub and Azure DevOps are available in WebhookContext.Metadata.

- `WebhookHeaderCapture.cs` — Captures all inbound request headers into Dictionary<string, string> (first non-empty value per header).
- `WebhookEndpoints.cs` — Builtin webhook path calls capture and sets ChatOrDataRequest.Metadata before sync processing.
- `MessageService.cs `— Adds optional Metadata on ChatOrDataRequest and includes it in the HandleInboundChatOrData signal payload (not persisted on conversation messages).
- `WEBHOOKS.md` — Documents header forwarding on the builtin endpoint.
