### PR TITLE
feat(auth): sync SysAdmin from Azure AD group claims on login

### DIFF
--- a/XiansAi.Server.Src/Shared/Providers/Auth/Oidc/OidcConfig.cs
+++ b/XiansAi.Server.Src/Shared/Providers/Auth/Oidc/OidcConfig.cs
@@ -11,6 +11,16 @@ public class OidcConfig
     public string[] AcceptedAlgorithms { get; set; } = new[] { "RS256" };
     public bool RequireHttpsMetadata { get; set; } = true;
     public OidcClaimMappings ClaimMappings { get; set; } = new();
+    /// <summary>
+    /// Optional. Comma-separated list of Azure AD / Entra ID group Object IDs used for automatic SysAdmin promotion.
+    /// When set, every login checks whether the authenticated user's token contains any of these group IDs
+    /// in the "groups" or "roles" claims. If any match is found, the user's IsSysAdmin flag is set to true
+    /// in the database; if none match, it is set to false — keeping SysAdmin status automatically in sync
+    /// with Azure AD group membership on every login.
+    /// Leave empty or unset to disable this feature entirely.
+    /// Environment variable: Oidc__AdminGroupIds=&lt;guid1&gt;,&lt;guid2&gt;
+    /// </summary>
+    public string? AdminGroupIds { get; set; }
 }
 
 public class OidcClaimMappings

--- a/XiansAi.Server.Src/Shared/Repositories/UserRepository.cs
+++ b/XiansAi.Server.Src/Shared/Repositories/UserRepository.cs
@@ -27,6 +27,7 @@ public interface IUserRepository
     Task<bool> UnlockUserAsync(string userId);
     Task<bool> IsLockedOutAsync(string userId);
     Task<bool> IsSysAdmin(string userId);
+    Task<bool> SetSysAdminAsync(string userId, bool isSysAdmin);
     Task<bool> DeleteUser(string userId, string? tenantId = null);
     Task<List<User>> SearchUsersAsync(string query, string? tenantId = null);
 }
@@ -416,6 +417,19 @@ public class UserRepository : IUserRepository
                 .FirstOrDefaultAsync();
             return user?.IsSysAdmin ?? false;
         }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "IsSysAdmin");
+    }
+
+    public async Task<bool> SetSysAdminAsync(string userId, bool isSysAdmin)
+    {
+        return await MongoRetryHelper.ExecuteWithRetryAsync(async () =>
+        {
+            var update = Builders<User>.Update
+                .Set(x => x.IsSysAdmin, isSysAdmin)
+                .Set(x => x.UpdatedAt, DateTime.UtcNow);
+
+            var result = await _users.UpdateOneAsync(x => x.UserId == userId, update);
+            return result.ModifiedCount > 0;
+        }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "SetSysAdmin");
     }
 
     public async Task<bool> DeleteUser(string userId, string? tenantId = null)

--- a/XiansAi.Server.Src/Shared/Services/UserTenantService.cs
+++ b/XiansAi.Server.Src/Shared/Services/UserTenantService.cs
@@ -109,6 +109,10 @@ public class UserTenantService : IUserTenantService
             _logger.LogInformation("User {UserId} created from token", userDto.UserId);
         }
 
+        // Optional: Azure AD group-based SysAdmin promotion
+        // Runs on every login to keep IsSysAdmin in sync with Azure AD group membership
+        await SyncSysAdminFromGroupClaimsAsync(userId, token);
+
         return await GetTenantsForCurrentUser();
     }
 
@@ -592,6 +596,24 @@ public class UserTenantService : IUserTenantService
             _logger.LogError(ex, "Error creating new user in tenant {TenantId}", tenantId);
             return ServiceResult<User>.InternalServerError("An error occurred while creating the new user");
         }
+    }
+
+    private async Task SyncSysAdminFromGroupClaimsAsync(string userId, string token)
+    {
+        var adminGroupIds = _configuration["Oidc:AdminGroupIds"];
+        if (string.IsNullOrEmpty(adminGroupIds)) return;
+
+        var configuredIds = adminGroupIds
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var tokenGroupIds = _jwtClaimsExtractor.ExtractClaims(token, "groups")
+            .Concat(_jwtClaimsExtractor.ExtractClaims(token, "roles"));
+
+        var isSysAdmin = tokenGroupIds.Any(id => configuredIds.Contains(id));
+        await _userRepository.SetSysAdminAsync(userId, isSysAdmin);
+
+        _logger.LogInformation("Azure AD group SysAdmin sync: user={UserId} isSysAdmin={IsSysAdmin}", userId, isSysAdmin);
     }
 
     /// <summary>

--- a/XiansAi.Server.Src/Shared/Utils/JwtClaimsExtractor.cs
+++ b/XiansAi.Server.Src/Shared/Utils/JwtClaimsExtractor.cs
@@ -47,6 +47,14 @@ public interface IJwtClaimsExtractor
     string? ExtractName(string token);
 
     /// <summary>
+    /// Extracts all values for a claim type from a token (for multi-value claims like "groups")
+    /// </summary>
+    /// <param name="token">The JWT token</param>
+    /// <param name="claimType">The claim type to extract all values for</param>
+    /// <returns>List of all values for the given claim type</returns>
+    IEnumerable<string> ExtractClaims(string token, string claimType);
+
+    /// <summary>
     /// Safely extracts Bearer token from Authorization header
     /// </summary>
     /// <param name="authorizationHeader">The Authorization header value</param>
@@ -139,6 +147,27 @@ public class JwtClaimsExtractor : IJwtClaimsExtractor
         {
             _logger.LogError(ex, "Error validating JWT token and extracting claims");
             return JwtValidationResult.Failure("Token processing failed");
+        }
+    }
+
+    /// <summary>
+    /// Extracts all values for a claim type (handles multi-value claims like "groups")
+    /// </summary>
+    public IEnumerable<string> ExtractClaims(string token, string claimType)
+    {
+        try
+        {
+            var handler = new JwtSecurityTokenHandler();
+            if (handler.ReadToken(token) is not JwtSecurityToken jsonToken) return [];
+
+            return jsonToken.Claims
+                .Where(c => c.Type == claimType)
+                .Select(c => c.Value);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error extracting claims '{ClaimType}' from token", claimType);
+            return [];
         }
     }
 

--- a/XiansAi.Server.Tests/UnitTests/Shared/Services/UserTenantServiceSyncSysAdminTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Shared/Services/UserTenantServiceSyncSysAdminTests.cs
@@ -1,0 +1,183 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.IdentityModel.Tokens;
+using Moq;
+using Shared.Auth;
+using Shared.Data.Models;
+using Shared.Repositories;
+using Shared.Services;
+using Shared.Utils;
+
+namespace Tests.UnitTests.Shared.Services;
+
+public class UserTenantServiceSyncSysAdminTests
+{
+    private readonly Mock<IUserRepository> _userRepo = new();
+    private readonly Mock<ITenantContext> _tenantContext = new();
+    private readonly Mock<IAuthMgtConnect> _authMgtConnect = new();
+    private readonly Mock<IUserManagementService> _userManagementService = new();
+    private readonly Mock<ITenantRepository> _tenantRepo = new();
+    private readonly Mock<IJwtClaimsExtractor> _jwtExtractor = new();
+
+    private const string UserId = "user-oid-abc123";
+    private const string AdminGroupId1 = "aaaaaaaa-0000-0000-0000-000000000001";
+    private const string AdminGroupId2 = "bbbbbbbb-0000-0000-0000-000000000002";
+
+    private UserTenantService BuildService(string? adminGroupIds)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Oidc:AdminGroupIds"] = adminGroupIds
+            })
+            .Build();
+
+        _tenantContext.Setup(x => x.LoggedInUser).Returns(UserId);
+        _userRepo.Setup(x => x.GetByUserIdAsync(UserId))
+            .ReturnsAsync(new User { UserId = UserId });
+        _userRepo.Setup(x => x.SetSysAdminAsync(It.IsAny<string>(), It.IsAny<bool>()))
+            .ReturnsAsync(true);
+        _userRepo.Setup(x => x.IsSysAdmin(UserId))
+            .ReturnsAsync(false);
+        _userRepo.Setup(x => x.GetUserTenantsAsync(UserId))
+            .ReturnsAsync(new List<TenantInfoDto>());
+
+        return new UserTenantService(
+            _userRepo.Object,
+            NullLogger<UserTenantService>.Instance,
+            _tenantContext.Object,
+            _authMgtConnect.Object,
+            config,
+            _userManagementService.Object,
+            _tenantRepo.Object,
+            _jwtExtractor.Object);
+    }
+
+    [Fact]
+    public async Task GetCurrentUserTenants_SkipsSysAdminSync_WhenAdminGroupIdsNotConfigured()
+    {
+        var service = BuildService(adminGroupIds: null);
+
+        await service.GetCurrentUserTenants(BuildToken());
+
+        _userRepo.Verify(x => x.SetSysAdminAsync(It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetCurrentUserTenants_SkipsSysAdminSync_WhenAdminGroupIdsIsEmpty()
+    {
+        var service = BuildService(adminGroupIds: string.Empty);
+
+        await service.GetCurrentUserTenants(BuildToken());
+
+        _userRepo.Verify(x => x.SetSysAdminAsync(It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetCurrentUserTenants_SetsSysAdminTrue_WhenGroupsClaimMatchesSingleConfiguredId()
+    {
+        _jwtExtractor.Setup(x => x.ExtractClaims(It.IsAny<string>(), "groups"))
+            .Returns([AdminGroupId1, "unrelated-group-id"]);
+        _jwtExtractor.Setup(x => x.ExtractClaims(It.IsAny<string>(), "roles"))
+            .Returns([]);
+
+        var service = BuildService(adminGroupIds: AdminGroupId1);
+        await service.GetCurrentUserTenants(BuildToken());
+
+        _userRepo.Verify(x => x.SetSysAdminAsync(UserId, true), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetCurrentUserTenants_SetsSysAdminFalse_WhenNoGroupsMatchConfiguredId()
+    {
+        _jwtExtractor.Setup(x => x.ExtractClaims(It.IsAny<string>(), "groups"))
+            .Returns(["unrelated-group-id"]);
+        _jwtExtractor.Setup(x => x.ExtractClaims(It.IsAny<string>(), "roles"))
+            .Returns([]);
+
+        var service = BuildService(adminGroupIds: AdminGroupId1);
+        await service.GetCurrentUserTenants(BuildToken());
+
+        _userRepo.Verify(x => x.SetSysAdminAsync(UserId, false), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetCurrentUserTenants_SetsSysAdminTrue_WhenAnyOfMultipleConfiguredGroupIdsMatch()
+    {
+        _jwtExtractor.Setup(x => x.ExtractClaims(It.IsAny<string>(), "groups"))
+            .Returns([AdminGroupId2]);
+        _jwtExtractor.Setup(x => x.ExtractClaims(It.IsAny<string>(), "roles"))
+            .Returns([]);
+
+        var service = BuildService(adminGroupIds: $"{AdminGroupId1},{AdminGroupId2}");
+        await service.GetCurrentUserTenants(BuildToken());
+
+        _userRepo.Verify(x => x.SetSysAdminAsync(UserId, true), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetCurrentUserTenants_SetsSysAdminTrue_WhenRolesClaimMatchesConfiguredId()
+    {
+        _jwtExtractor.Setup(x => x.ExtractClaims(It.IsAny<string>(), "groups"))
+            .Returns([]);
+        _jwtExtractor.Setup(x => x.ExtractClaims(It.IsAny<string>(), "roles"))
+            .Returns([AdminGroupId1]);
+
+        var service = BuildService(adminGroupIds: AdminGroupId1);
+        await service.GetCurrentUserTenants(BuildToken());
+
+        _userRepo.Verify(x => x.SetSysAdminAsync(UserId, true), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetCurrentUserTenants_SetsSysAdminTrue_WhenConfigHasWhitespaceAroundGroupIds()
+    {
+        _jwtExtractor.Setup(x => x.ExtractClaims(It.IsAny<string>(), "groups"))
+            .Returns([AdminGroupId1]);
+        _jwtExtractor.Setup(x => x.ExtractClaims(It.IsAny<string>(), "roles"))
+            .Returns([]);
+
+        var service = BuildService(adminGroupIds: $"  {AdminGroupId1}  ,  {AdminGroupId2}  ");
+        await service.GetCurrentUserTenants(BuildToken());
+
+        _userRepo.Verify(x => x.SetSysAdminAsync(UserId, true), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetCurrentUserTenants_SetsSysAdminTrue_WhenGroupIdMatchIsCaseInsensitive()
+    {
+        _jwtExtractor.Setup(x => x.ExtractClaims(It.IsAny<string>(), "groups"))
+            .Returns([AdminGroupId1.ToUpper()]);
+        _jwtExtractor.Setup(x => x.ExtractClaims(It.IsAny<string>(), "roles"))
+            .Returns([]);
+
+        var service = BuildService(adminGroupIds: AdminGroupId1.ToLower());
+        await service.GetCurrentUserTenants(BuildToken());
+
+        _userRepo.Verify(x => x.SetSysAdminAsync(UserId, true), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetCurrentUserTenants_CallsSetSysAdminOnce_PerLogin()
+    {
+        _jwtExtractor.Setup(x => x.ExtractClaims(It.IsAny<string>(), "groups"))
+            .Returns([AdminGroupId1]);
+        _jwtExtractor.Setup(x => x.ExtractClaims(It.IsAny<string>(), "roles"))
+            .Returns([]);
+
+        var service = BuildService(adminGroupIds: AdminGroupId1);
+        await service.GetCurrentUserTenants(BuildToken());
+
+        _userRepo.Verify(x => x.SetSysAdminAsync(UserId, It.IsAny<bool>()), Times.Once);
+    }
+
+    private static string BuildToken()
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes("test-signing-key-32-chars-minimum!"));
+        var token = new JwtSecurityToken(
+            signingCredentials: new SigningCredentials(key, SecurityAlgorithms.HmacSha256));
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}

--- a/XiansAi.Server.Tests/UnitTests/Shared/Utils/JwtClaimsExtractorExtractClaimsTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Shared/Utils/JwtClaimsExtractorExtractClaimsTests.cs
@@ -1,0 +1,99 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.IdentityModel.Tokens;
+using Moq;
+using Shared.Providers.Auth;
+using Shared.Utils;
+
+namespace Tests.UnitTests.Shared.Utils;
+
+public class JwtClaimsExtractorExtractClaimsTests
+{
+    private readonly JwtClaimsExtractor _extractor;
+
+    public JwtClaimsExtractorExtractClaimsTests()
+    {
+        var factory = new Mock<IAuthProviderFactory>();
+        _extractor = new JwtClaimsExtractor(factory.Object, NullLogger<JwtClaimsExtractor>.Instance);
+    }
+
+    [Fact]
+    public void ExtractClaims_ReturnsAllValues_ForMultiValueClaim()
+    {
+        var token = BuildToken(
+            new Claim("groups", "group-id-1"),
+            new Claim("groups", "group-id-2"),
+            new Claim("groups", "group-id-3"));
+
+        var result = _extractor.ExtractClaims(token, "groups").ToList();
+
+        Assert.Equal(3, result.Count);
+        Assert.Contains("group-id-1", result);
+        Assert.Contains("group-id-2", result);
+        Assert.Contains("group-id-3", result);
+    }
+
+    [Fact]
+    public void ExtractClaims_ReturnsEmpty_WhenClaimTypeNotPresent()
+    {
+        var token = BuildToken(new Claim("sub", "user-123"));
+
+        var result = _extractor.ExtractClaims(token, "groups").ToList();
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ExtractClaims_ReturnsEmpty_ForInvalidToken()
+    {
+        var result = _extractor.ExtractClaims("not.a.valid.jwt.token", "groups").ToList();
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ExtractClaims_ReturnsSingleValue_WhenOnlyOneClaim()
+    {
+        var token = BuildToken(new Claim("groups", "only-group-id"));
+
+        var result = _extractor.ExtractClaims(token, "groups").ToList();
+
+        Assert.Single(result);
+        Assert.Equal("only-group-id", result[0]);
+    }
+
+    [Fact]
+    public void ExtractClaims_DoesNotReturnOtherClaimTypes()
+    {
+        var token = BuildToken(
+            new Claim("groups", "group-id-1"),
+            new Claim("roles", "role-id-1"));
+
+        var groups = _extractor.ExtractClaims(token, "groups").ToList();
+        var roles = _extractor.ExtractClaims(token, "roles").ToList();
+
+        Assert.Single(groups);
+        Assert.Equal("group-id-1", groups[0]);
+        Assert.Single(roles);
+        Assert.Equal("role-id-1", roles[0]);
+    }
+
+    [Fact]
+    public void ExtractClaims_ReturnsEmpty_WhenTokenIsEmpty()
+    {
+        var result = _extractor.ExtractClaims(string.Empty, "groups").ToList();
+
+        Assert.Empty(result);
+    }
+
+    private static string BuildToken(params Claim[] claims)
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes("test-signing-key-32-chars-minimum!"));
+        var token = new JwtSecurityToken(
+            claims: claims,
+            signingCredentials: new SigningCredentials(key, SecurityAlgorithms.HmacSha256));
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}


### PR DESCRIPTION
  Add optional OIDC group-based SysAdmin promotion. When
  Oidc__AdminGroupIds is configured with a comma-separated list of
  Azure AD group Object IDs, each login checks the token's "groups"
  and "roles" claims and sets IsSysAdmin accordingly — automatically
  revoking when the user is removed from the group.

  - Add AdminGroupIds (comma-separated) to OidcConfig
  - Add SetSysAdminAsync to IUserRepository and UserRepository
  - Add ExtractClaims (multi-value) to IJwtClaimsExtractor
  - Add SyncSysAdminFromGroupClaimsAsync in UserTenantService,
    called after user creation to avoid first-login timing issue
  - Add unit tests for ExtractClaims and SyncSysAdminFromGroupClaimsAsync