### PR TITLE
refactor(knowledge): streamline knowledge retrieval fallback and add docs

### DIFF
--- a/XiansAi.Server.Src/Features/AdminApi/Endpoints/AdminKnowledgeEndpoints.cs
+++ b/XiansAi.Server.Src/Features/AdminApi/Endpoints/AdminKnowledgeEndpoints.cs
@@ -249,11 +249,9 @@ public static class AdminKnowledgeEndpoints
         .Produces(StatusCodes.Status500InternalServerError)
         
         .WithSummary("Get applicable knowledge content")
-        .WithDescription(@"Retrieves the applicable knowledge for the specified tenant, agent, and optional activation. Uses the same fallback logic as the Agent API /latest endpoint:
+        .WithDescription(KnowledgeFallbackDocs.FallbackSummary + @"
 
-1. If activationName is provided: try tenantId + agent + activationName
-2. If not found: try tenantId + agent (any or no activationName)
-3. If not found: try system-scoped knowledge (tenantId=null)
+The tenantId is taken from the URL path. The agent is verified to exist in the tenant and the caller's permissions are checked before resolution. This is the same resolution logic used by the Agent API GET /latest endpoint.
 
 **Query Parameters:**
 - `name` (required): The knowledge item name

--- a/XiansAi.Server.Src/Features/AgentApi/Endpoints/KnowledgeEndpoints.cs
+++ b/XiansAi.Server.Src/Features/AgentApi/Endpoints/KnowledgeEndpoints.cs
@@ -29,13 +29,12 @@ public static class KnowledgeEndpoints
             [FromServices] IKnowledgeService service,
             [FromServices] ITenantContext tenantContext) =>
         {
-            var tenantId = tenantContext.TenantId ?? "(null)";
+            var tenantId = tenantContext.TenantId;
             _logger.LogInformation(
                 "Agent knowledge/latest request: name={Name}, agent={Agent}, activationName={ActivationName}, tenantId={TenantId}",
-                name, agent, activationName ?? "(null)", tenantId);
-            Console.WriteLine($"[Agent API] knowledge/latest: name={name}, agent={agent}, activationName={activationName ?? "(null)"}, tenantId={tenantId}");
+                name, agent, activationName ?? "(null)", tenantId ?? "(null)");
 
-            var result = await service.GetLatestByNameAsync(name, agent, activationName);
+            var result = await service.GetLatestByNameForTenantAsync(name, agent, tenantId, activationName);
             return result.ToHttpResult();
         })
         .Produces<object>(StatusCodes.Status200OK)
@@ -43,7 +42,9 @@ public static class KnowledgeEndpoints
         .ProducesProblem(StatusCodes.Status500InternalServerError)
         
         .WithSummary("Get latest knowledge")
-        .WithDescription("Retrieves the most recent knowledge for the specified name and agent. ");
+        .WithDescription(KnowledgeFallbackDocs.FallbackSummary +
+            "\n\nThe tenantId is derived from the request's certificate-authenticated tenant context. " +
+            "This is the same resolution logic used by the Admin API GET /latest endpoint.");
 
         knowledgeGroup.MapGet("/latest/system", async (
             [FromQuery] string name,

--- a/XiansAi.Server.Src/Shared/Repositories/KnowledgeRepository.cs
+++ b/XiansAi.Server.Src/Shared/Repositories/KnowledgeRepository.cs
@@ -9,11 +9,6 @@ namespace Shared.Repositories;
 public interface IKnowledgeRepository
 {
     Task<T?> GetLatestByNameAndTenantAsync<T>(string name, string agent, string tenantId) where T : IKnowledge;
-    /// <summary>
-    /// Gets the latest knowledge for name+agent+tenant, regardless of ActivationName.
-    /// Used as fallback when no matching activation-specific knowledge is found.
-    /// </summary>
-    Task<T?> GetLatestByNameAndTenantAnyActivationAsync<T>(string name, string agent, string tenantId) where T : IKnowledge;
     Task<T?> GetLatestByNameAndActivationAsync<T>(string name, string agent, string tenantId, string activationName) where T : IKnowledge;
     Task<T?> GetLatestSystemByNameAsync<T>(string name, string agent) where T : IKnowledge;
     Task<T?> GetByIdAsync<T>(string id) where T : IKnowledge;
@@ -67,24 +62,6 @@ public class KnowledgeRepository : IKnowledgeRepository
                 .SortByDescending(x => x.CreatedAt)
                 .FirstOrDefaultAsync();
         }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "GetLatestKnowledgeByNameAndTenant");
-    }
-
-    public async Task<T?> GetLatestByNameAndTenantAnyActivationAsync<T>(string name, string agent, string tenantId) where T : IKnowledge
-    {
-        return await MongoRetryHelper.ExecuteWithRetryAsync(async () =>
-        {
-            var collection = GetTypedCollection<T>();
-
-            var nameFilter = Builders<T>.Filter.Eq(x => x.Name, name);
-            var agentFilter = Builders<T>.Filter.Eq(x => x.Agent, agent);
-            var tenantFilter = Builders<T>.Filter.Eq(x => x.TenantId, tenantId);
-
-            var filter = Builders<T>.Filter.And(nameFilter, agentFilter, tenantFilter);
-
-            return await collection.Find(filter)
-                .SortByDescending(x => x.CreatedAt)
-                .FirstOrDefaultAsync();
-        }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "GetLatestKnowledgeByNameAndTenantAnyActivation");
     }
 
     public async Task<T?> GetLatestByNameAndActivationAsync<T>(string name, string agent, string tenantId, string activationName) where T : IKnowledge

--- a/XiansAi.Server.Src/Shared/Services/KnowledgeService.cs
+++ b/XiansAi.Server.Src/Shared/Services/KnowledgeService.cs
@@ -10,6 +10,28 @@ using Shared.Utils.Services;
 
 namespace Shared.Services;
 
+/// <summary>
+/// Single source of truth for the human-readable description of the knowledge
+/// resolution fallback. Shared by the Agent API and Admin API <c>/latest</c> endpoints
+/// so their OpenAPI docs stay in sync with each other and with the actual logic in
+/// <see cref="KnowledgeService.GetLatestByNameForTenantAsync"/>.
+/// Full details: docs/KNOWLEDGE_FALLBACK.md
+/// </summary>
+public static class KnowledgeFallbackDocs
+{
+    /// <summary>
+    /// Describes the 3-step scope fallback used to resolve a single knowledge item by name.
+    /// Keep this in sync with <c>GetLatestByNameForTenantAsync</c> and docs/KNOWLEDGE_FALLBACK.md.
+    /// </summary>
+    public const string FallbackSummary = @"Resolves the most recent applicable knowledge for the given name + agent using a 3-step scope fallback (see docs/KNOWLEDGE_FALLBACK.md for full details):
+
+1. **Activation-specific** — matches tenantId + agent + activationName. Runs only when both tenantId and activationName are provided.
+2. **Tenant-default** — matches tenantId + agent + activation_name = null. Runs whenever tenantId is provided. Returns only the tenant-default; it never falls back to a different activation's knowledge.
+3. **System-scoped** — matches agent (or null-agent) + tenant_id = null + system_scoped = true. Always runs if steps 1 and 2 miss; an agent-specific system document is preferred over a null-agent one.
+
+Returns the first match in this priority order, or 404 if nothing matches.";
+}
+
 public class KnowledgeRequest
 {
     [JsonPropertyName("name")]
@@ -432,16 +454,19 @@ public class KnowledgeService : IKnowledgeService
             }
         }
 
-        // Priority 2: Try knowledge with requesting tenant_id (any activation)
+        // Priority 2: Try the tenant-default knowledge (activation_name = null) for this tenant.
+        // Strong activation isolation: we deliberately never fall back to a *different* activation's
+        // knowledge. An activation-scoped request that misses in priority 1 falls back to the
+        // tenant-default here, and a request with no activation only ever matches the tenant-default.
         if (!string.IsNullOrEmpty(tenantId))
         {
-            var knowledge = await _knowledgeRepository.GetLatestByNameAndTenantAnyActivationAsync<Knowledge>(
+            var knowledge = await _knowledgeRepository.GetLatestByNameAndTenantAsync<Knowledge>(
                 name, agent, tenantId);
 
             if (knowledge != null)
             {
-                _logger.LogInformation("Found knowledge (priority 2: tenant match) - tenantId={TenantId}, activationName={ActivationName}",
-                    knowledge.TenantId, knowledge.ActivationName ?? "(null)");
+                _logger.LogInformation("Found knowledge (priority 2: tenant-default match, activation_name=null) - tenantId={TenantId}",
+                    knowledge.TenantId);
                 return ServiceResult<Knowledge>.Success(knowledge);
             }
         }

--- a/XiansAi.Server.Src/docs/KNOWLEDGE_FALLBACK.md
+++ b/XiansAi.Server.Src/docs/KNOWLEDGE_FALLBACK.md
@@ -1,0 +1,210 @@
+# Knowledge Resolution & Fallback Mechanism
+
+This document explains the exact algorithm used when either endpoint resolves a knowledge item by name. Both the Agent API and Admin API share the same underlying logic, implemented in `KnowledgeService.GetLatestByNameForTenantAsync`.
+
+> **Single source of truth.** The fallback is implemented once in `GetLatestByNameForTenantAsync`; both endpoints call it directly. The short OpenAPI/Swagger description shown on both endpoints is also defined once, in `KnowledgeFallbackDocs.FallbackSummary` (`Shared/Services/KnowledgeService.cs`), so the two endpoints can never drift apart. This document is the long-form reference for that summary.
+
+---
+
+## Endpoints That Use This Mechanism
+
+| Endpoint | Route | Caller |
+|---|---|---|
+| Agent API | `GET /api/agent/knowledge/latest` | `KnowledgeService.GetLatestByNameForTenantAsync(name, agent, tenantContext.TenantId, activationName)` |
+| Admin API | `GET /api/v1/admin/tenants/{tenantId}/knowledge/latest` | `KnowledgeService.GetLatestByNameForTenantAsync(name, agentName, tenantId, activationName)` |
+
+Both pass the same four arguments into the same service method. The only difference is that the Agent API derives `tenantId` from the request's certificate-authenticated tenant context, while the Admin API reads it explicitly from the URL path.
+
+---
+
+## Knowledge Document Fields
+
+Every knowledge document in the `knowledge` MongoDB collection has these scope-determining fields:
+
+| Field | MongoDB key | Type | Meaning |
+|---|---|---|---|
+| `Name` | `name` | `string` | Logical identifier for the knowledge item |
+| `Agent` | `agent` | `string?` | The agent this knowledge belongs to |
+| `TenantId` | `tenant_id` | `string?` | `null` for system-scoped; tenant ID string for tenant/activation-scoped |
+| `SystemScoped` | `system_scoped` | `bool` | `true` only for system-scoped knowledge |
+| `ActivationName` | `activation_name` | `string?` | `null` for tenant-default; non-null for activation-specific |
+| `CreatedAt` | `created_at` | `DateTime` | Timestamp used to pick the **latest** version |
+
+Multiple documents can share the same `Name + Agent` — every write creates a new document. The most recent document by `CreatedAt` wins within each step of the fallback.
+
+---
+
+## Scope Levels
+
+```
+System-scoped       → tenant_id = null,       system_scoped = true,  activation_name = null
+Tenant-default      → tenant_id = <tenantId>, system_scoped = false, activation_name = null
+Activation-specific → tenant_id = <tenantId>, system_scoped = false, activation_name = <name>
+```
+
+---
+
+## The 3-Step Fallback Algorithm
+
+```
+GetLatestByNameForTenantAsync(name, agent, tenantId, activationName)
+```
+
+### Step 1 — Activation-specific match  
+**Condition:** `activationName` is provided AND `tenantId` is not empty.
+
+**DB query** (`GetLatestByNameAndActivationAsync`):
+```
+name          = <name>
+agent         = <agent>
+tenant_id     = <tenantId>
+activation_name = <activationName>
+ORDER BY created_at DESC
+LIMIT 1
+```
+
+If a document is found → **return it. Stop.**
+
+---
+
+### Step 2 — Tenant-default match (strict activation isolation)  
+**Condition:** `tenantId` is not empty.  
+Runs regardless of whether `activationName` was supplied.
+
+**DB query** (`GetLatestByNameAndTenantAsync`):
+```
+name            = <name>
+agent           = <agent>
+tenant_id       = <tenantId>
+activation_name = null          ← only tenant-default documents
+ORDER BY created_at DESC
+LIMIT 1
+```
+
+This step matches **only** the tenant-default (`activation_name = null`). It will **never** return a document that belongs to a different activation. See [Activation Isolation](#activation-isolation) below.
+
+If a document is found → **return it. Stop.**
+
+---
+
+### Step 3 — System-scoped fallback  
+**Condition:** Always runs if Steps 1 and 2 both missed.
+
+**DB query** (`GetLatestSystemByNameAsync`):
+```
+name          = <name>
+agent         = <agent> OR agent = null   (agent-specific preferred over null-agent)
+tenant_id     = null
+system_scoped = true
+ORDER BY agent = <agent> DESC, created_at DESC
+LIMIT 1
+```
+
+The in-memory sort means an agent-specific system document beats a `null`-agent system document of the same name. Among documents with equal agent specificity, the most recent wins.
+
+If a document is found → **return it.**  
+If not found → **return 404 Not Found.**
+
+---
+
+## Decision Flow
+
+```
+Request: name, agent, tenantId, activationName
+│
+├─ activationName provided AND tenantId provided?
+│   └─ YES → Query: name + agent + tenantId + activationName
+│              Found? ──► RETURN (activation-specific)
+│
+├─ tenantId provided?
+│   └─ YES → Query: name + agent + tenantId + activation_name=null (tenant-default only)
+│              Found? ──► RETURN (tenant-default; never another activation)
+│
+└─ Query: name + (agent OR null-agent) + tenant_id=null + system_scoped=true
+           Found? ──► RETURN (system-scoped, agent-specific preferred)
+           Not found? ──► 404
+```
+
+---
+
+## Input Combinations and Expected Behaviour
+
+### Case 1 — Only `name` and `agent` provided (no `tenantId`, no `activationName`)
+
+This happens when the request context has no tenant (e.g. a certificate with no tenant claim resolves `tenantId = null`).
+
+- Step 1 is skipped (no `activationName` and no `tenantId`).
+- Step 2 is skipped (no `tenantId`).
+- Step 3 runs: returns system-scoped knowledge for that name+agent or 404.
+
+---
+
+### Case 2 — `name`, `agent`, `tenantId` provided; no `activationName`
+
+- Step 1 is skipped (no `activationName`).
+- Step 2 runs: finds the most recently created **tenant-default** document (`tenant_id = tenantId`, `agent = agent`, `activation_name = null`). Activation-specific documents are ignored.
+- Step 3 runs only if Step 2 found nothing: returns system-scoped knowledge or 404.
+
+---
+
+### Case 3 — All four inputs provided (`name`, `agent`, `tenantId`, `activationName`)
+
+- Step 1 runs: finds `tenant_id = tenantId` + `activation_name = activationName`. If found, returned immediately.
+- Step 2 runs (if Step 1 missed): finds the most recently created **tenant-default** document (`activation_name = null`). It will **not** return any other activation's knowledge.
+- Step 3 runs (if Step 2 missed): returns system-scoped knowledge or 404.
+
+---
+
+### Case 4 — `tenantId` provided but the tenant has no knowledge for this name+agent
+
+- Steps 1 and 2 return nothing.
+- Step 3 finds system-scoped knowledge: `agent = <agent>` beats `agent = null` if both exist with the same name.
+
+---
+
+## Activation Isolation
+
+Activations are **strongly isolated**: the fallback never crosses from one activation to another.
+
+- An **activation-specific request** (`activationName` supplied) resolves in this order only:
+  1. the matching activation (`activation_name = activationName`),
+  2. the tenant-default (`activation_name = null`),
+  3. system-scoped.
+  It will **never** be served another activation's knowledge.
+
+- A **request with no activation** resolves to the tenant-default, then system-scoped. It will **never** be served any activation-specific knowledge.
+
+### Consequence
+
+If a tenant has *only* activation-specific knowledge for a name (e.g. `activation_name = "prod"`) and there is no tenant-default:
+
+| Request | Result |
+|---|---|
+| `activationName = "prod"` | returns the `prod` document (Step 1) |
+| `activationName = "dev"` | skips `prod`, falls through to tenant-default (none) → system-scoped or 404 |
+| no `activationName` | skips `prod`, falls through to tenant-default (none) → system-scoped or 404 |
+
+To provide a shared baseline across activations, create a **tenant-default** document (`activation_name = null`) for that knowledge name. Activation-specific documents then override it only for their own activation.
+
+---
+
+## Version Selection (within each step)
+
+Each step returns only one document: the one with the **highest `created_at`** timestamp among all documents that match the query filters. There is no explicit version pinning — "latest" always means most recently inserted.
+
+For knowledge that was updated via `PATCH`, a new document is always inserted (the old one is never mutated), so the latest `created_at` correctly identifies the current version.
+
+---
+
+## Source References
+
+| Layer | File |
+|---|---|
+| Service (fallback logic) | `Shared/Services/KnowledgeService.cs` → `GetLatestByNameForTenantAsync` |
+| Shared endpoint description | `Shared/Services/KnowledgeService.cs` → `KnowledgeFallbackDocs.FallbackSummary` |
+| Repository Step 1 | `Shared/Repositories/KnowledgeRepository.cs` → `GetLatestByNameAndActivationAsync` |
+| Repository Step 2 | `Shared/Repositories/KnowledgeRepository.cs` → `GetLatestByNameAndTenantAsync` |
+| Repository Step 3 | `Shared/Repositories/KnowledgeRepository.cs` → `GetLatestSystemByNameAsync` |
+| Agent API endpoint | `Features/AgentApi/Endpoints/KnowledgeEndpoints.cs` |
+| Admin API endpoint | `Features/AdminApi/Endpoints/AdminKnowledgeEndpoints.cs` |
+| Data model | `Shared/Data/Models/Knowledge.cs` |


### PR DESCRIPTION
## Summary
- Simplify the knowledge resolution fallback to a clear 3-step scope cascade (activation-specific → tenant-default → system-scoped), with strong activation isolation so a request never falls back to a *different* activation's knowledge.
- Remove the now-redundant `GetLatestByNameAndTenantAnyActivationAsync` repository method, reusing `GetLatestByNameAndTenantAsync` for the tenant-default lookup.
- Route the Agent API `GET /latest` endpoint through `GetLatestByNameForTenantAsync` so it uses the certificate-authenticated tenant context (removed stray `Console.WriteLine` debug logging).
- Introduce `KnowledgeFallbackDocs.FallbackSummary` as a single source of truth for the fallback description, shared by the Agent API and Admin API OpenAPI docs so they stay in sync with the actual logic.
- Add `docs/KNOWLEDGE_FALLBACK.md` documenting the full resolution behavior.

## Test plan
- [ ] `GET /latest` (Agent API) resolves activation-specific knowledge when tenantId + activationName match.
- [ ] Falls back to tenant-default (activation_name = null) when no activation-specific match exists.
- [ ] Falls back to system-scoped knowledge when no tenant match exists; prefers agent-specific over null-agent system docs.
- [ ] Returns 404 when nothing matches.
- [ ] Admin API `GET /latest` produces identical resolution results to the Agent API endpoint.

Made with [Cursor](https://cursor.com)