### PR TITLE
fix(security): sanitize user input in logs and pin patched dependencies

### DIFF
--- a/.github/workflows/azure-deploy-staging.yml
+++ b/.github/workflows/azure-deploy-staging.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches: [ staging ]
 
+permissions:
+  contents: read
+
 env:
   RESOURCE_GROUP: rg-xians-ai-staging-api
   APP_NAME: xiansai-server-staging

--- a/.github/workflows/azure-deploy-uat.yml
+++ b/.github/workflows/azure-deploy-uat.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches: [ uat ]
 
+permissions:
+  contents: read
+
 env:
   RESOURCE_GROUP: rg-xiansai-uat
   APP_NAME: xiansai-server-uat

--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches: [ production ]
 
+permissions:
+  contents: read
+
 env:
   RESOURCE_GROUP: rg-api
   APP_NAME: xiansai-server

--- a/.github/workflows/dockerhub-deploy.yml
+++ b/.github/workflows/dockerhub-deploy.yml
@@ -6,6 +6,9 @@ on:
       - 'v*'  # This will trigger on version tags like v1.0.0, v2.1.0, etc.
   workflow_dispatch:  # Allow manual triggering
 
+permissions:
+  contents: read
+
 env:
   IMAGE_NAME: xiansai-server
   DOCKERHUB_USERNAME: hasithy99x  # DockerHub login username

--- a/XiansAi.Server.Src/Features/AdminApi/Auth/AdminEndpointAuthenticationHandler.cs
+++ b/XiansAi.Server.Src/Features/AdminApi/Auth/AdminEndpointAuthenticationHandler.cs
@@ -6,6 +6,7 @@ using Shared.Services;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using Shared.Data.Models;
+using Shared.Utils;
 
 namespace Features.AdminApi.Auth
 {
@@ -39,12 +40,12 @@ namespace Features.AdminApi.Auth
             var adminApiPattern = "/api/";
             var adminSuffix = "/admin";
             
-            _logger.LogDebug("AdminEndpointAuthenticationHandler: Evaluating path '{Path}'", Request.Path);
+            _logger.LogDebug("AdminEndpointAuthenticationHandler: Evaluating path '{Path}'", LogSanitizer.Sanitize(Request.Path));
             
             // Check if path matches AdminApi pattern: /api/{version}/admin
             if (!path.StartsWith(adminApiPattern) || !path.Contains(adminSuffix))
             {
-                _logger.LogDebug("Skipping admin endpoint authentication for non-AdminApi path: {Path}", Request.Path);
+                _logger.LogDebug("Skipping admin endpoint authentication for non-AdminApi path: {Path}", LogSanitizer.Sanitize(Request.Path));
                 return AuthenticateResult.NoResult(); // Let other handlers process this request
             }
             
@@ -52,11 +53,11 @@ namespace Features.AdminApi.Auth
             var pathParts = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
             if (pathParts.Length < 3 || pathParts[0] != "api" || pathParts[2] != "admin")
             {
-                _logger.LogDebug("Skipping admin endpoint authentication for non-AdminApi path: {Path}", Request.Path);
+                _logger.LogDebug("Skipping admin endpoint authentication for non-AdminApi path: {Path}", LogSanitizer.Sanitize(Request.Path));
                 return AuthenticateResult.NoResult(); // Let other handlers process this request
             }
 
-            _logger.LogDebug("Processing AdminApi endpoint request: {Path}", Request.Path);
+            _logger.LogDebug("Processing AdminApi endpoint request: {Path}", LogSanitizer.Sanitize(Request.Path));
 
             // Extract API key from Authorization header only.
             // Query parameter (?apikey=) is not supported: it can leak into reverse-proxy logs, CDN logs, and browser history.
@@ -92,7 +93,7 @@ namespace Features.AdminApi.Auth
             // Note: tenantId is now optional. If not provided, it will be derived from the API key.
             // This prevents IDOR vulnerabilities by ensuring the tenant matches the authenticated credential.
 
-            _logger.LogDebug("Processing AdminApi Endpoint request: {Path}", Request.Path);
+            _logger.LogDebug("Processing AdminApi Endpoint request: {Path}", LogSanitizer.Sanitize(Request.Path));
             if (_tenantContext != null)
             {
 
@@ -150,7 +151,7 @@ namespace Features.AdminApi.Auth
                         var principal = new ClaimsPrincipal(identity);
                         var ticket = new AuthenticationTicket(principal, Scheme.Name);
                         _logger.LogInformation("Successfully authenticated AdminApi connection: User={UserId}, Tenant={TenantId}, Roles={Roles}", 
-                            apiKey.CreatedBy, finalTenantId, string.Join(", ", userRoles));
+                            LogSanitizer.Sanitize(apiKey.CreatedBy), LogSanitizer.Sanitize(finalTenantId), LogSanitizer.Sanitize(string.Join(", ", userRoles)));
 
                         return AuthenticateResult.Success(ticket);
                     }

--- a/XiansAi.Server.Src/Features/AdminApi/Auth/AdminRoleTenantResolver.cs
+++ b/XiansAi.Server.Src/Features/AdminApi/Auth/AdminRoleTenantResolver.cs
@@ -3,6 +3,7 @@ using Shared.Data.Models;
 using Shared.Exceptions;
 using Shared.Repositories;
 using Shared.Services;
+using Shared.Utils;
 
 namespace Features.AdminApi.Auth;
 
@@ -78,7 +79,7 @@ public sealed class AdminRoleTenantResolver : IAdminRoleTenantResolver
 
             _logger.LogWarning(
                 "User {UserId} does not have SysAdmin or TenantAdmin role and no domain match. Roles: {Roles}",
-                userId, string.Join(", ", userRoles));
+                LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(string.Join(", ", userRoles)));
             return new AdminRoleTenantResolutionResult(
                 Success: false,
                 null, null,
@@ -95,20 +96,20 @@ public sealed class AdminRoleTenantResolver : IAdminRoleTenantResolver
                 {
                     _logger.LogWarning(
                         "SysAdmin user {UserId} requested non-existent tenant: {TenantId}",
-                        userId, tenantIdFromRequest);
+                        LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(tenantIdFromRequest));
                     throw new TenantNotFoundException(tenantIdFromRequest);
                 }
                 finalTenantId = tenantIdFromRequest;
                 _logger.LogDebug(
                     "SysAdmin user {UserId} using provided tenantId: {TenantId}",
-                    userId, finalTenantId);
+                    LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(finalTenantId));
             }
             else
             {
                 finalTenantId = apiKey.TenantId;
                 _logger.LogDebug(
                     "SysAdmin user {UserId} using API key tenantId: {TenantId}",
-                    userId, finalTenantId);
+                    LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(finalTenantId));
             }
         }
         else
@@ -119,7 +120,7 @@ public sealed class AdminRoleTenantResolver : IAdminRoleTenantResolver
                 {
                     _logger.LogWarning(
                         "TenantAdmin user {UserId} provided tenantId {ProvidedTenantId} that does not match API key tenantId {ApiKeyTenantId}",
-                        userId, tenantIdFromRequest, apiKey.TenantId);
+                        LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(tenantIdFromRequest), LogSanitizer.Sanitize(apiKey.TenantId));
                     return new AdminRoleTenantResolutionResult(
                         Success: false,
                         null, null,
@@ -128,14 +129,14 @@ public sealed class AdminRoleTenantResolver : IAdminRoleTenantResolver
                 finalTenantId = tenantIdFromRequest;
                 _logger.LogDebug(
                     "TenantAdmin user {UserId} validated tenantId: {TenantId}",
-                    userId, finalTenantId);
+                    LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(finalTenantId));
             }
             else
             {
                 finalTenantId = apiKey.TenantId;
                 _logger.LogDebug(
                     "TenantAdmin user {UserId} using API key tenantId: {TenantId}",
-                    userId, finalTenantId);
+                    LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(finalTenantId));
             }
         }
 
@@ -176,7 +177,7 @@ public sealed class AdminRoleTenantResolver : IAdminRoleTenantResolver
 
         _logger.LogInformation(
             "User {UserId} matched tenant {TenantId} via email domain {Domain}, granting TenantParticipant role",
-            userId, targetTenantId, tenant.Domain);
+            LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(targetTenantId), LogSanitizer.Sanitize(tenant.Domain));
 
         return new AdminRoleTenantResolutionResult(
             Success: true,

--- a/XiansAi.Server.Src/Features/AdminApi/Auth/ValidAdminEndpointAccessHandler.cs
+++ b/XiansAi.Server.Src/Features/AdminApi/Auth/ValidAdminEndpointAccessHandler.cs
@@ -3,6 +3,7 @@ using Shared.Auth;
 using Shared.Exceptions;
 using Shared.Services;
 using System.Security.Claims;
+using Shared.Utils;
 
 namespace Features.AdminApi.Auth
 {
@@ -130,7 +131,7 @@ namespace Features.AdminApi.Auth
 
                 if (!resolutionResult.Success)
                 {
-                    _logger.LogWarning("Admin role resolution failed: {Error}", resolutionResult.ErrorMessage);
+                    _logger.LogWarning("Admin role resolution failed: {Error}", LogSanitizer.Sanitize(resolutionResult.ErrorMessage));
                     context.Fail();
                     return;
                 }
@@ -148,7 +149,7 @@ namespace Features.AdminApi.Auth
                 _tenantContext.Authorization = accessToken;
 
                 _logger.LogInformation("Successfully authorized AdminApi Endpoint Connection: User={UserId}, Tenant={TenantId}, Roles={Roles}", 
-                    loggedInUser, finalTenantId, string.Join(", ", userRoles));
+                    LogSanitizer.Sanitize(loggedInUser), LogSanitizer.Sanitize(finalTenantId), LogSanitizer.Sanitize(string.Join(", ", userRoles)));
                 context.Succeed(requirement);
             }
             catch (TenantNotFoundException)

--- a/XiansAi.Server.Src/Features/AdminApi/Endpoints/AdminParticipantsEndpoints.cs
+++ b/XiansAi.Server.Src/Features/AdminApi/Endpoints/AdminParticipantsEndpoints.cs
@@ -4,6 +4,7 @@ using Shared.Data.Models;
 using Shared.Data.Models.Validation;
 using Microsoft.AspNetCore.Mvc;
 using System.Text.Json.Serialization;
+using Shared.Utils;
 
 namespace Features.AdminApi.Endpoints;
 
@@ -75,16 +76,6 @@ public class ParticipantTenantsResponse
 public static class AdminParticipantsEndpoints
 {
     /// <summary>
-    /// Redacts email for logging to reduce PII retention. Returns "***@domain" format.
-    /// </summary>
-    private static string RedactEmailForLogging(string? email)
-    {
-        if (string.IsNullOrEmpty(email)) return "[empty]";
-        var atIndex = email.IndexOf('@');
-        if (atIndex < 0) return "***@[no-domain]";
-        return "***@" + email[(atIndex + 1)..];
-    }
-    /// <summary>
     /// Maps all AdminApi participant endpoints.
     /// </summary>
     public static void MapAdminParticipantsEndpoints(this RouteGroupBuilder adminApiGroup)
@@ -116,7 +107,7 @@ public static class AdminParticipantsEndpoints
                 var validatedEmail = ValidationHelpers.SanitizeAndValidateEmail(email);
                 if (validatedEmail == null)
                 {
-                    logger.LogWarning("Invalid email format or length for participant lookup: {EmailRedacted}", RedactEmailForLogging(email));
+                    logger.LogWarning("Invalid email format or length for participant lookup: {EmailRedacted}", LogSanitizer.RedactEmail(email));
                     return Results.Problem(
                         detail: "Invalid email address. Email must be well-formed and not exceed 254 characters.",
                         statusCode: StatusCodes.Status400BadRequest);
@@ -133,7 +124,7 @@ public static class AdminParticipantsEndpoints
                 // Reject locked-out users
                 if (user?.IsLockedOut == true)
                 {
-                    logger.LogWarning("Participant lookup denied: user {EmailRedacted} is locked out", RedactEmailForLogging(email));
+                    logger.LogWarning("Participant lookup denied: user {EmailRedacted} is locked out", LogSanitizer.RedactEmail(email));
                     return Results.Problem(
                         detail: "Access denied: the user account is locked out",
                         statusCode: StatusCodes.Status403Forbidden);
@@ -156,11 +147,11 @@ public static class AdminParticipantsEndpoints
                     }
 
                     logger.LogInformation("User {EmailRedacted} has participant roles in {Count} tenants: {TenantIds}", 
-                        RedactEmailForLogging(email), participantTenantIds.Count, string.Join(", ", participantTenantIds));
+                        LogSanitizer.RedactEmail(email), participantTenantIds.Count, string.Join(", ", participantTenantIds));
                 }
                 else
                 {
-                    logger.LogInformation("User {EmailRedacted} not found, will check domain matching only", RedactEmailForLogging(email));
+                    logger.LogInformation("User {EmailRedacted} not found, will check domain matching only", LogSanitizer.RedactEmail(email));
                 }
 
                 // Query tenants by domain matching (if email has domain)
@@ -220,7 +211,7 @@ public static class AdminParticipantsEndpoints
                 {
                     logger.LogWarning("User {EmailRedacted} has matching tenants but no enabled tenants found. " +
                         "Matching tenant IDs: {TenantIds}, Matched tenants: {MatchedCount}", 
-                        RedactEmailForLogging(email), string.Join(", ", matchingTenants.Select(t => t.TenantId)), matchingTenants.Count);
+                        LogSanitizer.RedactEmail(email), string.Join(", ", matchingTenants.Select(t => t.TenantId)), matchingTenants.Count);
                     return Results.NotFound(new { message = $"User with email '{email}' has no enabled tenants" });
                 }
 
@@ -234,7 +225,7 @@ public static class AdminParticipantsEndpoints
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "Error retrieving participant tenants for {EmailRedacted}", RedactEmailForLogging(email));
+                logger.LogError(ex, "Error retrieving participant tenants for {EmailRedacted}", LogSanitizer.RedactEmail(email));
                 return Results.Problem(
                     detail: "An error occurred while retrieving participant tenants",
                     statusCode: StatusCodes.Status500InternalServerError);

--- a/XiansAi.Server.Src/Features/AdminApi/Endpoints/AdminUserEndpoints.cs
+++ b/XiansAi.Server.Src/Features/AdminApi/Endpoints/AdminUserEndpoints.cs
@@ -7,6 +7,7 @@ using Shared.Data.Models.Validation;
 using Shared.Providers.Auth;
 using Shared.Repositories;
 using Shared.Services;
+using Shared.Utils;
 
 namespace Features.AdminApi.Endpoints;
 

--- a/XiansAi.Server.Src/Features/AdminApi/Utils/AdminApiDebugLoggingMiddleware.cs
+++ b/XiansAi.Server.Src/Features/AdminApi/Utils/AdminApiDebugLoggingMiddleware.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
+using Shared.Utils;
 
 namespace Features.AdminApi.Utils;
 
@@ -36,7 +37,7 @@ public class AdminApiDebugLoggingMiddleware
             _logger.LogWarning(
                 "AdminApi:EnableDebugLogging is enabled but forced OFF in {Environment} environment. " +
                 "Full request/response body logging exposes PII and must not run in production or staging.",
-                hostEnvironment.EnvironmentName);
+                LogSanitizer.Sanitize(hostEnvironment.EnvironmentName));
             _isEnabled = false;
         }
         else
@@ -62,7 +63,7 @@ public class AdminApiDebugLoggingMiddleware
         {
             var requestId = Guid.NewGuid().ToString("N");
             await LogRequest(context, requestId);
-            _logger.LogDebug("[AdminAPI Debug] [RequestId: {RequestId}] Streaming endpoint - skipping response capture", requestId);
+            _logger.LogDebug("[AdminAPI Debug] [RequestId: {RequestId}] Streaming endpoint - skipping response capture", LogSanitizer.Sanitize(requestId));
             await _next(context);
             return;
         }
@@ -95,7 +96,7 @@ public class AdminApiDebugLoggingMiddleware
             stopwatch.Stop();
             _logger.LogError(ex, 
                 "[AdminAPI Debug] [RequestId: {RequestId}] Exception occurred after {ElapsedMs}ms", 
-                normalRequestId, 
+                LogSanitizer.Sanitize(normalRequestId), 
                 stopwatch.ElapsedMilliseconds);
             throw;
         }

--- a/XiansAi.Server.Src/Features/AgentApi/Auth/CertificateAuthenticationHandler.cs
+++ b/XiansAi.Server.Src/Features/AgentApi/Auth/CertificateAuthenticationHandler.cs
@@ -50,11 +50,11 @@ public class CertificateAuthenticationHandler : AuthenticationHandler<Certificat
             var path = Request.Path.Value?.ToLowerInvariant() ?? "";
             if (!path.StartsWith("/api/agent/"))
             {
-                _logger.LogDebug("Skipping certificate authentication for non-AgentApi path: {Path}", Request.Path);
+                _logger.LogDebug("Skipping certificate authentication for non-AgentApi path: {Path}", LogSanitizer.Sanitize(Request.Path));
                 return AuthenticateResult.NoResult(); // Let other handlers process this request
             }
 
-            _logger.LogDebug("Handling certificate authentication for {Path}", Request.Path);
+            _logger.LogDebug("Handling certificate authentication for {Path}", LogSanitizer.Sanitize(Request.Path));
 
             var certHeader = await ExtractCertificateFromHeader();
             if (certHeader == null)
@@ -76,7 +76,7 @@ public class CertificateAuthenticationHandler : AuthenticationHandler<Certificat
             var validationResult = await ValidateCertificateAsync(cert);
             if (!validationResult.IsValid)
             {
-                _logger.LogWarning("Certificate validation failed for tenant ID {TenantId}", cert.Subject);
+                _logger.LogWarning("Certificate validation failed for tenant ID {TenantId}", LogSanitizer.Sanitize(cert.Subject));
                 // Note: Invalid results are not cached to prevent cache pollution
                 return AuthenticateResult.Fail(string.Join(", ", validationResult.Errors));
             }
@@ -133,7 +133,7 @@ public class CertificateAuthenticationHandler : AuthenticationHandler<Certificat
             // Check if certificate is revoked
             if (await _certificateRepository.IsRevokedAsync(cert.Thumbprint))
             {
-                _logger.LogWarning("Certificate has been revoked for tenant ID {TenantId}", cert.Subject);
+                _logger.LogWarning("Certificate has been revoked for tenant ID {TenantId}", LogSanitizer.Sanitize(cert.Subject));
                 result.AddError("Certificate has been revoked");
                 return result;
             }
@@ -151,7 +151,7 @@ public class CertificateAuthenticationHandler : AuthenticationHandler<Certificat
             
             if (!isValid)
             {
-                _logger.LogWarning("Certificate validation chain failed for tenant ID {TenantId}", cert.Subject);
+                _logger.LogWarning("Certificate validation chain failed for tenant ID {TenantId}", LogSanitizer.Sanitize(cert.Subject));
                 var errors = chain.ChainStatus
                     .Select(s => $"Chain validation error: {s.StatusInformation}")
                     .ToList();
@@ -163,7 +163,7 @@ public class CertificateAuthenticationHandler : AuthenticationHandler<Certificat
             var chainRoot = chain.ChainElements[chain.ChainElements.Count - 1].Certificate;
             if (!chainRoot.Thumbprint.Equals(rootCert.Thumbprint, StringComparison.OrdinalIgnoreCase))
             {
-                _logger.LogWarning("Certificate is not signed by the expected root CA for tenant ID {TenantId}", cert.Subject);
+                _logger.LogWarning("Certificate is not signed by the expected root CA for tenant ID {TenantId}", LogSanitizer.Sanitize(cert.Subject));
                 result.AddError("Certificate is not signed by the expected root CA");
                 return result;
             }
@@ -175,7 +175,7 @@ public class CertificateAuthenticationHandler : AuthenticationHandler<Certificat
                 
             if (enhancedKeyUsage == null || !HasClientAuthenticationPurpose(enhancedKeyUsage))
             {
-                _logger.LogWarning("Certificate does not have client authentication purpose for tenant ID {TenantId}", cert.Subject);
+                _logger.LogWarning("Certificate does not have client authentication purpose for tenant ID {TenantId}", LogSanitizer.Sanitize(cert.Subject));
                 result.AddError("Certificate does not have client authentication purpose");
                 return result;
             }
@@ -184,16 +184,16 @@ public class CertificateAuthenticationHandler : AuthenticationHandler<Certificat
             var tenantId = GetSubjectValue(cert.Subject, "O");
             if (string.IsNullOrEmpty(tenantId))
             {
-                _logger.LogWarning("Invalid tenant: No tenant ID found in certificate for tenant ID {TenantId}", cert.Subject);
+                _logger.LogWarning("Invalid tenant: No tenant ID found in certificate for tenant ID {TenantId}", LogSanitizer.Sanitize(cert.Subject));
                 result.AddError("Invalid tenant: No tenant ID found in certificate");
                 return result;
             }
-            _logger.LogInformation("Getting tenant by tenant ID {TenantId}", tenantId);
+            _logger.LogInformation("Getting tenant by tenant ID {TenantId}", LogSanitizer.Sanitize(tenantId));
             var tenant = await _tenantRepository.GetByTenantIdAsync(tenantId);
             _logger.LogInformation("Tenant result: {TenantResult}", tenant);
             if (tenant == null)
             {
-                _logger.LogWarning("Invalid tenant: {TenantId} not found", tenantId);
+                _logger.LogWarning("Invalid tenant: {TenantId} not found", LogSanitizer.Sanitize(tenantId));
                 result.AddError($"Invalid tenant: {tenantId}.");
                 return result;
             }
@@ -269,7 +269,7 @@ public class CertificateAuthenticationHandler : AuthenticationHandler<Certificat
             {
                 // Sys admin can impersonate any tenant
                 _logger.LogInformation("Sys admin {UserId} impersonating tenant {ImpersonatedTenantId} (original tenant: {OriginalTenantId})", 
-                    userId, requestedTenantIdStr, tenantId);
+                    LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(requestedTenantIdStr), LogSanitizer.Sanitize(tenantId));
                 tenantId = requestedTenantIdStr;
             }
             else
@@ -278,10 +278,10 @@ public class CertificateAuthenticationHandler : AuthenticationHandler<Certificat
                 if (!tenantId.Equals(requestedTenantIdStr, StringComparison.OrdinalIgnoreCase))
                 {
                     _logger.LogWarning("Non admin User `{UserId}` attempted to access tenant `{RequestedTenantId}` but certificate is for tenant `{CertTenantId}`", 
-                        userId, requestedTenantIdStr, tenantId);
+                        LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(requestedTenantIdStr), LogSanitizer.Sanitize(tenantId));
                     return Task.FromResult(AuthenticateResult.Fail("X-Tenant-Id header does not match certificate tenant ID"));
                 }
-                _logger.LogDebug("User {UserId} X-Tenant-Id header matches certificate tenant {TenantId}", userId, tenantId);
+                _logger.LogDebug("User {UserId} X-Tenant-Id header matches certificate tenant {TenantId}", LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(tenantId));
             }
         }
 

--- a/XiansAi.Server.Src/Features/AgentApi/Endpoints/ActivationEndpoint.cs
+++ b/XiansAi.Server.Src/Features/AgentApi/Endpoints/ActivationEndpoint.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Features.AgentApi.Auth;
 using Shared.Auth;
 using Shared.Repositories;
+using Shared.Utils;
 
 namespace Features.AgentApi.Endpoints;
 
@@ -37,7 +38,7 @@ public static class ActivationEndpoints
 
             _logger.LogInformation(
                 "Retrieving workflow inputs: activationName={ActivationName}, agentName={AgentName}, workflowType={WorkflowType}, workflowId={WorkflowId}, tenantId={TenantId}",
-                activationName, agentName, workflowType, workflowId, tenantId);
+                LogSanitizer.Sanitize(activationName), LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(workflowType), LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(tenantId));
 
             var activation = await activationRepository.GetByNameAndAgentAsync(tenantId, agentName, activationName);
 
@@ -45,7 +46,7 @@ public static class ActivationEndpoints
             {
                 _logger.LogWarning(
                     "Activation not found: activationName={ActivationName}, agentName={AgentName}, tenantId={TenantId}",
-                    activationName, agentName, tenantId);
+                    LogSanitizer.Sanitize(activationName), LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(tenantId));
                 return Results.Problem(
                     $"Activation '{activationName}' not found for agent '{agentName}'",
                     statusCode: StatusCodes.Status404NotFound);
@@ -55,7 +56,7 @@ public static class ActivationEndpoints
             {
                 _logger.LogWarning(
                     "Activation '{ActivationName}' for agent '{AgentName}' in tenant '{TenantId}' is not active",
-                    activationName, agentName, tenantId);
+                    LogSanitizer.Sanitize(activationName), LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(tenantId));
                 return Results.Problem(
                     $"Activation '{activationName}' is not active",
                     statusCode: StatusCodes.Status400BadRequest);
@@ -65,7 +66,7 @@ public static class ActivationEndpoints
             {
                 _logger.LogWarning(
                     "WorkflowId '{WorkflowId}' is not registered in activation '{ActivationName}'",
-                    workflowId, activationName);
+                    LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(activationName));
                 return Results.Problem(
                     $"WorkflowId '{workflowId}' is not registered in activation '{activationName}'",
                     statusCode: StatusCodes.Status400BadRequest);
@@ -78,7 +79,7 @@ public static class ActivationEndpoints
             {
                 _logger.LogWarning(
                     "WorkflowType '{WorkflowType}' not found in activation '{ActivationName}'",
-                    workflowType, activationName);
+                    LogSanitizer.Sanitize(workflowType), LogSanitizer.Sanitize(activationName));
                 return Results.Ok(Array.Empty<object>());
             }
 
@@ -88,7 +89,7 @@ public static class ActivationEndpoints
 
             _logger.LogInformation(
                 "Returning {Count} workflow input(s) for workflowType={WorkflowType}, workflowId={WorkflowId}, activationName={ActivationName}",
-                inputValues.Length, workflowType, workflowId, activationName);
+                inputValues.Length, LogSanitizer.Sanitize(workflowType), LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(activationName));
 
             return Results.Ok(inputValues);
         })

--- a/XiansAi.Server.Src/Features/AgentApi/Endpoints/DocumentEndpoints.cs
+++ b/XiansAi.Server.Src/Features/AgentApi/Endpoints/DocumentEndpoints.cs
@@ -4,6 +4,7 @@ using Features.AgentApi.Services;
 using Features.AgentApi.Models;
 using System.Text.Json;
 using Shared.Utils.Services;
+using Shared.Utils;
 
 namespace Features.AgentApi.Endpoints;
 
@@ -50,7 +51,7 @@ public static class DocumentEndpoints
             [FromBody] DocumentIdRequest request,
             [FromServices] IDocumentService service) =>
         {
-            _logger.LogInformation("Getting document with ID: {Id}", request.Id);
+            _logger.LogInformation("Getting document with ID: {Id}", LogSanitizer.Sanitize(request.Id));
             var result = await service.GetAsync(request.Id);
             return result.ToHttpResult();
         })
@@ -65,7 +66,7 @@ public static class DocumentEndpoints
             [FromBody] DocumentKeyRequest request,
             [FromServices] IDocumentService service) =>
         {
-            _logger.LogInformation("Getting document with Type: {Type} and Key: {Key}", request.Type, request.Key);
+            _logger.LogInformation("Getting document with Type: {Type} and Key: {Key}", LogSanitizer.Sanitize(request.Type), LogSanitizer.Sanitize(request.Key));
             var result = await service.GetByKeyAsync(request.Type, request.Key);
             return result.ToHttpResult();
         })
@@ -111,7 +112,7 @@ public static class DocumentEndpoints
             [FromBody] DocumentIdRequest request,
             [FromServices] IDocumentService service) =>
         {
-            _logger.LogInformation("Deleting document with ID: {Id}", request.Id);
+            _logger.LogInformation("Deleting document with ID: {Id}", LogSanitizer.Sanitize(request.Id));
             var result = await service.DeleteAsync(request.Id);
             return result.ToHttpResult();
         })
@@ -141,7 +142,7 @@ public static class DocumentEndpoints
             [FromBody] DocumentIdRequest request,
             [FromServices] IDocumentService service) =>
         {
-            _logger.LogInformation("Checking existence of document with ID: {Id}", request.Id);
+            _logger.LogInformation("Checking existence of document with ID: {Id}", LogSanitizer.Sanitize(request.Id));
             var result = await service.ExistsAsync(request.Id);
             return result.ToHttpResult();
         })

--- a/XiansAi.Server.Src/Features/AgentApi/Endpoints/KnowledgeEndpoints.cs
+++ b/XiansAi.Server.Src/Features/AgentApi/Endpoints/KnowledgeEndpoints.cs
@@ -3,6 +3,7 @@ using Features.AgentApi.Auth;
 using Shared.Auth;
 using Shared.Services;
 using Shared.Utils.Services;
+using Shared.Utils;
 
 namespace Features.AgentApi.Endpoints;
 
@@ -32,7 +33,7 @@ public static class KnowledgeEndpoints
             var tenantId = tenantContext.TenantId;
             _logger.LogInformation(
                 "Agent knowledge/latest request: name={Name}, agent={Agent}, activationName={ActivationName}, tenantId={TenantId}",
-                name, agent, activationName ?? "(null)", tenantId ?? "(null)");
+                LogSanitizer.Sanitize(name), LogSanitizer.Sanitize(agent), LogSanitizer.Sanitize(activationName ?? "(null)"), LogSanitizer.Sanitize(tenantId ?? "(null)"));
 
             var result = await service.GetLatestByNameForTenantAsync(name, agent, tenantId, activationName);
             return result.ToHttpResult();
@@ -51,7 +52,7 @@ public static class KnowledgeEndpoints
             [FromQuery] string agent,
             [FromServices] IKnowledgeService service) =>
         {
-            _logger.LogInformation("Getting latest system knowledge for name: {name}, agent: {agent}", name, agent);
+            _logger.LogInformation("Getting latest system knowledge for name: {name}, agent: {agent}", LogSanitizer.Sanitize(name), LogSanitizer.Sanitize(agent));
             var result = await service.GetLatestSystemByNameAsync(name, agent);
             return result.ToHttpResult();
         })
@@ -67,7 +68,7 @@ public static class KnowledgeEndpoints
             [FromServices] IKnowledgeService endpoint) =>
         {
             _logger.LogInformation("Creating new knowledge with name: {Name}, agent: {Agent}, activationName: {ActivationName}", 
-                request.Name, request.Agent, request.ActivationName);
+                LogSanitizer.Sanitize(request.Name), LogSanitizer.Sanitize(request.Agent), LogSanitizer.Sanitize(request.ActivationName));
             var knowledgeRequest = new KnowledgeRequest 
             {
                 Name = request.Name,
@@ -94,7 +95,7 @@ public static class KnowledgeEndpoints
             [FromQuery] string agent,
             [FromServices] IKnowledgeService service) =>
         {
-            _logger.LogInformation("Deleting knowledge with name: {Name}, agent: {Agent}", name, agent);
+            _logger.LogInformation("Deleting knowledge with name: {Name}, agent: {Agent}", LogSanitizer.Sanitize(name), LogSanitizer.Sanitize(agent));
             var deleteRequest = new DeleteAllVersionsRequest 
             {
                 Name = name,
@@ -114,7 +115,7 @@ public static class KnowledgeEndpoints
             [FromQuery] string agent,
             [FromServices] IKnowledgeService service) =>
         {
-            _logger.LogInformation("Listing knowledge for agent: {Agent}", agent);
+            _logger.LogInformation("Listing knowledge for agent: {Agent}", LogSanitizer.Sanitize(agent));
             var result = await service.GetLatestByAgent(agent);
             return result;
         })

--- a/XiansAi.Server.Src/Features/AgentApi/Repositories/DocumentRepository.cs
+++ b/XiansAi.Server.Src/Features/AgentApi/Repositories/DocumentRepository.cs
@@ -90,7 +90,7 @@ public class DocumentRepository : IDocumentRepository
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error retrieving document with ID: {Id}", id);
+            _logger.LogError(ex, "Error retrieving document with ID: {Id}", LogSanitizer.Sanitize(id));
             throw;
         }
     }
@@ -114,7 +114,7 @@ public class DocumentRepository : IDocumentRepository
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error retrieving document with Type: {Type} and Key: {Key}", type, key);
+            _logger.LogError(ex, "Error retrieving document with Type: {Type} and Key: {Key}", LogSanitizer.Sanitize(type), LogSanitizer.Sanitize(key));
             throw;
         }
     }
@@ -296,7 +296,7 @@ public class DocumentRepository : IDocumentRepository
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error getting distinct document types for tenant {TenantId}, agent {AgentId}", 
-                tenantId, agentId);
+                LogSanitizer.Sanitize(tenantId), LogSanitizer.Sanitize(agentId));
             throw;
         }
     }
@@ -336,7 +336,7 @@ public class DocumentRepository : IDocumentRepository
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error getting distinct activation names for tenant {TenantId}, agent {AgentId}", 
-                tenantId, agentId);
+                LogSanitizer.Sanitize(tenantId), LogSanitizer.Sanitize(agentId));
             throw;
         }
     }
@@ -363,7 +363,7 @@ public class DocumentRepository : IDocumentRepository
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error updating document with ID: {Id}", document.Id);
+            _logger.LogError(ex, "Error updating document with ID: {Id}", LogSanitizer.Sanitize(document.Id));
             throw;
         }
     }
@@ -388,7 +388,7 @@ public class DocumentRepository : IDocumentRepository
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error deleting document with ID: {Id}", id);
+            _logger.LogError(ex, "Error deleting document with ID: {Id}", LogSanitizer.Sanitize(id));
             throw;
         }
     }
@@ -472,14 +472,14 @@ public class DocumentRepository : IDocumentRepository
                 _logger);
 
             _logger.LogInformation("Deleted {DeletedCount} documents matching filter - AgentId: {AgentId}, Type: {Type}, ActivationName: {ActivationName}", 
-                result.DeletedCount, filter.AgentId, filter.Type, filter.ActivationName);
+                result.DeletedCount, LogSanitizer.Sanitize(filter.AgentId), LogSanitizer.Sanitize(filter.Type), LogSanitizer.Sanitize(filter.ActivationName));
 
             return (int)result.DeletedCount;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error deleting documents by filter - AgentId: {AgentId}, Type: {Type}", 
-                filter.AgentId, filter.Type);
+                LogSanitizer.Sanitize(filter.AgentId), LogSanitizer.Sanitize(filter.Type));
             throw;
         }
     }
@@ -504,7 +504,7 @@ public class DocumentRepository : IDocumentRepository
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error checking document existence with ID: {Id}", id);
+            _logger.LogError(ex, "Error checking document existence with ID: {Id}", LogSanitizer.Sanitize(id));
             throw;
         }
     }
@@ -530,7 +530,7 @@ public class DocumentRepository : IDocumentRepository
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error checking document existence with Type: {Type} and Key: {Key}", type, key);
+            _logger.LogError(ex, "Error checking document existence with Type: {Type} and Key: {Key}", LogSanitizer.Sanitize(type), LogSanitizer.Sanitize(key));
             throw;
         }
     }

--- a/XiansAi.Server.Src/Features/AgentApi/Services/ActivityHistoryService.cs
+++ b/XiansAi.Server.Src/Features/AgentApi/Services/ActivityHistoryService.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 using Features.AgentApi.Repositories;
 using Shared.Data.Models;
+using Shared.Utils;
 
 namespace Features.AgentApi.Services.Lib;
 public class ActivityHistoryRequest
@@ -81,7 +82,7 @@ public class ActivityHistoryService : IActivityHistoryService
     public void Create(ActivityHistoryRequest request)
     {
         _logger.LogInformation("Received request to create activity at: {Time} for {ActivityName}", 
-            DateTime.UtcNow, request.ActivityName);
+            DateTime.UtcNow, LogSanitizer.Sanitize(request.ActivityName));
         var activity = new ActivityHistory
         {
             Id = ObjectId.GenerateNewId().ToString(),

--- a/XiansAi.Server.Src/Features/AgentApi/Services/DefinitionsService.cs
+++ b/XiansAi.Server.Src/Features/AgentApi/Services/DefinitionsService.cs
@@ -7,6 +7,7 @@ using Shared.Auth;
 using Shared.Data.Models;
 using Shared.Repositories;
 using Shared.Services;
+using Shared.Utils;
 
 namespace Features.AgentApi.Services.Lib;
 
@@ -163,7 +164,7 @@ public class DefinitionsService : IDefinitionsService
         }
         catch (ValidationException ex)
         {
-            _logger.LogWarning("Invalid agent name: {AgentName}. Error: {Error}", request.Agent, ex.Message);
+            _logger.LogWarning("Invalid agent name: {AgentName}. Error: {Error}", LogSanitizer.Sanitize(request.Agent), LogSanitizer.Sanitize(ex.Message));
             return Results.Problem(
                 title: "Bad Request",
                 detail: ex.Message,
@@ -175,14 +176,14 @@ public class DefinitionsService : IDefinitionsService
         // Only system admins can create system agents
         if (request.SystemScoped && !_tenantContext.UserRoles.Contains(SystemRoles.SysAdmin))
         {
-            _logger.LogError("User {UserId} attempted to create system agent {AgentName} without system admin permission", currentUser, request.Agent);
+            _logger.LogError("User {UserId} attempted to create system agent {AgentName} without system admin permission", LogSanitizer.Sanitize(currentUser), LogSanitizer.Sanitize(request.Agent));
             throw new InvalidOperationException("User does not have system admin permission to create `system` agents");
         }
 
         // if not systemScoped and there is an systemscoped agent with the same name, throw an error
         if (!request.SystemScoped && await _agentRepository.IsSystemAgent(request.Agent))
         {
-            _logger.LogError("User {UserId} attempted to create non-system agent {AgentName} with the same name as an existing system scoped agent", currentUser, request.Agent);
+            _logger.LogError("User {UserId} attempted to create non-system agent {AgentName} with the same name as an existing system scoped agent", LogSanitizer.Sanitize(currentUser), LogSanitizer.Sanitize(request.Agent));
             return Results.Problem(
                 title: "Internal Server Error",
                 detail: $"An system scoped agent with the same name already exists. Trying to create definition for {request.WorkflowType} for agent {request.Agent}",
@@ -225,7 +226,7 @@ public class DefinitionsService : IDefinitionsService
         {
             if (existingDefinition.Hash != definition.Hash)
             {
-                _logger.LogInformation("Flow definition with workflow type {WorkflowType} has changed hash. Deleting existing and creating new one.", request.WorkflowType);
+                _logger.LogInformation("Flow definition with workflow type {WorkflowType} has changed hash. Deleting existing and creating new one.", LogSanitizer.Sanitize(request.WorkflowType));
                 await _flowDefinitionRepository.DeleteAsync(existingDefinition.Id);
                 await GenerateMarkdown(definition);
                 // Create new definition with fresh ID
@@ -237,7 +238,7 @@ public class DefinitionsService : IDefinitionsService
             return Results.Ok("Definition already up to date");
         }
 
-        _logger.LogInformation("Creating new definition {WorkflowType}", definition.WorkflowType);
+        _logger.LogInformation("Creating new definition {WorkflowType}", LogSanitizer.Sanitize(definition.WorkflowType));
         await GenerateMarkdown(definition);
         await _flowDefinitionRepository.CreateAsync(definition);
         return Results.Ok("New definition created successfully");
@@ -265,7 +266,7 @@ public class DefinitionsService : IDefinitionsService
         }
         catch (ValidationException ex)
         {
-            _logger.LogWarning("Invalid agent name: {AgentName}. Error: {Error}", request.AgentName, ex.Message);
+            _logger.LogWarning("Invalid agent name: {AgentName}. Error: {Error}", LogSanitizer.Sanitize(request.AgentName), LogSanitizer.Sanitize(ex.Message));
             return Results.Problem(
                 title: "Bad Request",
                 detail: ex.Message,
@@ -277,7 +278,7 @@ public class DefinitionsService : IDefinitionsService
         // Only system admins can create system agents
         if (request.SystemScoped && !_tenantContext.UserRoles.Contains(SystemRoles.SysAdmin))
         {
-            _logger.LogError("User {UserId} attempted to create system agent {AgentName} without system admin permission", currentUser, request.AgentName);
+            _logger.LogError("User {UserId} attempted to create system agent {AgentName} without system admin permission", LogSanitizer.Sanitize(currentUser), LogSanitizer.Sanitize(request.AgentName));
             return Results.Problem(
                 title: "Forbidden",
                 detail: "User does not have system admin permission to create `system` agents",
@@ -287,7 +288,7 @@ public class DefinitionsService : IDefinitionsService
         // if not systemScoped and there is a systemscoped agent with the same name, throw an error
         if (!request.SystemScoped && await _agentRepository.IsSystemAgent(request.AgentName))
         {
-            _logger.LogError("User {UserId} attempted to create non-system agent {AgentName} with the same name as an existing system scoped agent", currentUser, request.AgentName);
+            _logger.LogError("User {UserId} attempted to create non-system agent {AgentName} with the same name as an existing system scoped agent", LogSanitizer.Sanitize(currentUser), LogSanitizer.Sanitize(request.AgentName));
             return Results.Problem(
                 title: "Conflict",
                 detail: $"A system scoped agent with the same name already exists. Agent name: {request.AgentName}",
@@ -308,7 +309,7 @@ public class DefinitionsService : IDefinitionsService
             request.Category,
             request.SamplePrompts);
         
-        _logger.LogInformation("Agent {AgentName} created/updated successfully by user {UserId}", request.AgentName, currentUser);
+        _logger.LogInformation("Agent {AgentName} created/updated successfully by user {UserId}", LogSanitizer.Sanitize(request.AgentName), LogSanitizer.Sanitize(currentUser));
         
         return Results.Ok(new 
         { 

--- a/XiansAi.Server.Src/Features/AgentApi/Services/DocumentService.cs
+++ b/XiansAi.Server.Src/Features/AgentApi/Services/DocumentService.cs
@@ -8,6 +8,7 @@ using Shared.Utils.Services;
 using Shared.Auth;
 using Shared.Repositories;
 using Shared.Data;
+using Shared.Utils;
 
 namespace Features.AgentApi.Services;
 
@@ -67,7 +68,7 @@ public class DocumentService : IDocumentService
             if (!hasPermission)
             {
                 _logger.LogWarning("User {UserId} attempted to save document for agent {AgentId} without write permission", 
-                    _tenantContext.LoggedInUser, documentData.AgentId);
+                    LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(documentData.AgentId));
                 return ServiceResult<JsonElement>.Forbidden("Write access required for this agent");
             }
 
@@ -121,7 +122,7 @@ public class DocumentService : IDocumentService
                 {
                     var message = $"UseKeyAsIdentifier requires both Type and Key properties. Missing: {string.Join(", ", missingFields)}";
                     _logger.LogWarning("Document save failed: {Message}. Document Type={Type}, Key={Key}, AgentId={AgentId}", 
-                        message, document.Type, document.Key, document.AgentId);
+                        LogSanitizer.Sanitize(message), LogSanitizer.Sanitize(document.Type), LogSanitizer.Sanitize(document.Key), LogSanitizer.Sanitize(document.AgentId));
                     return ServiceResult<JsonElement>.BadRequest(message);
                 }
 
@@ -219,7 +220,7 @@ public class DocumentService : IDocumentService
             // Validate that AgentId is present
             if (string.IsNullOrEmpty(document.AgentId))
             {
-                _logger.LogWarning("Document {Id} has no AgentId, denying access", id);
+                _logger.LogWarning("Document {Id} has no AgentId, denying access", LogSanitizer.Sanitize(id));
                 return ServiceResult<JsonElement?>.Forbidden("Document has no associated agent");
             }
 
@@ -228,7 +229,7 @@ public class DocumentService : IDocumentService
             if (!hasPermission)
             {
                 _logger.LogWarning("User {UserId} attempted to get document {Id} for agent {AgentId} without read permission", 
-                    _tenantContext.LoggedInUser, id, document.AgentId);
+                    LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(id), LogSanitizer.Sanitize(document.AgentId));
                 return ServiceResult<JsonElement?>.Forbidden("Read access required for this agent");
             }
 
@@ -239,7 +240,7 @@ public class DocumentService : IDocumentService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error getting document with ID: {Id}", id);
+            _logger.LogError(ex, "Error getting document with ID: {Id}", LogSanitizer.Sanitize(id));
             return ServiceResult<JsonElement?>.InternalServerError("Error retrieving document");
         }
     }
@@ -258,7 +259,7 @@ public class DocumentService : IDocumentService
             // Validate that AgentId is present
             if (string.IsNullOrEmpty(document.AgentId))
             {
-                _logger.LogWarning("Document with Type: {Type} and Key: {Key} has no AgentId, denying access", type, key);
+                _logger.LogWarning("Document with Type: {Type} and Key: {Key} has no AgentId, denying access", LogSanitizer.Sanitize(type), LogSanitizer.Sanitize(key));
                 return ServiceResult<JsonElement?>.Forbidden("Document has no associated agent");
             }
 
@@ -267,7 +268,7 @@ public class DocumentService : IDocumentService
             if (!hasPermission)
             {
                 _logger.LogWarning("User {UserId} attempted to get document with Type: {Type} and Key: {Key} for agent {AgentId} without read permission", 
-                    _tenantContext.LoggedInUser, type, key, document.AgentId);
+                    LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(type), LogSanitizer.Sanitize(key), LogSanitizer.Sanitize(document.AgentId));
                 return ServiceResult<JsonElement?>.Forbidden("Read access required for this agent");
             }
 
@@ -278,7 +279,7 @@ public class DocumentService : IDocumentService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error getting document with Type: {Type} and Key: {Key}", type, key);
+            _logger.LogError(ex, "Error getting document with Type: {Type} and Key: {Key}", LogSanitizer.Sanitize(type), LogSanitizer.Sanitize(key));
             return ServiceResult<JsonElement?>.InternalServerError("Error retrieving document");
         }
     }
@@ -293,7 +294,7 @@ public class DocumentService : IDocumentService
             // If user has no access to any agents, return empty result
             if (!authorizedAgentNames.Any())
             {
-                _logger.LogInformation("User {UserId} has no read access to any agents", _tenantContext.LoggedInUser);
+                _logger.LogInformation("User {UserId} has no read access to any agents", LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
                 var emptyResult = JsonSerializer.SerializeToElement(new List<object>());
                 return ServiceResult<JsonElement>.Success(emptyResult);
             }
@@ -306,7 +307,7 @@ public class DocumentService : IDocumentService
                 if (!authorizedAgentNames.Contains(request.Query.AgentId))
                 {
                     _logger.LogWarning("User {UserId} attempted to query agent {AgentId} without permission", 
-                        _tenantContext.LoggedInUser, request.Query.AgentId);
+                        LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(request.Query.AgentId));
                     var emptyResult = JsonSerializer.SerializeToElement(new List<object>());
                     return ServiceResult<JsonElement>.Success(emptyResult);
                 }
@@ -376,7 +377,7 @@ public class DocumentService : IDocumentService
             // Validate that AgentId is present
             if (string.IsNullOrEmpty(existing.AgentId))
             {
-                _logger.LogWarning("Document {Id} has no AgentId, denying update", documentData.Id);
+                _logger.LogWarning("Document {Id} has no AgentId, denying update", LogSanitizer.Sanitize(documentData.Id));
                 return ServiceResult<bool>.Forbidden("Document has no associated agent");
             }
 
@@ -385,7 +386,7 @@ public class DocumentService : IDocumentService
             if (!hasPermission)
             {
                 _logger.LogWarning("User {UserId} attempted to update document {Id} for agent {AgentId} without write permission", 
-                    _tenantContext.LoggedInUser, documentData.Id, existing.AgentId);
+                    LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(documentData.Id), LogSanitizer.Sanitize(existing.AgentId));
                 return ServiceResult<bool>.Forbidden("Write access required for this agent");
             }
 
@@ -452,7 +453,7 @@ public class DocumentService : IDocumentService
             // Validate that AgentId is present
             if (string.IsNullOrEmpty(document.AgentId))
             {
-                _logger.LogWarning("Document {Id} has no AgentId, denying delete", id);
+                _logger.LogWarning("Document {Id} has no AgentId, denying delete", LogSanitizer.Sanitize(id));
                 return ServiceResult<bool>.Forbidden("Document has no associated agent");
             }
 
@@ -461,7 +462,7 @@ public class DocumentService : IDocumentService
             if (!hasPermission)
             {
                 _logger.LogWarning("User {UserId} attempted to delete document {Id} for agent {AgentId} without write permission", 
-                    _tenantContext.LoggedInUser, id, document.AgentId);
+                    LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(id), LogSanitizer.Sanitize(document.AgentId));
                 return ServiceResult<bool>.Forbidden("Write access required for this agent");
             }
 
@@ -476,7 +477,7 @@ public class DocumentService : IDocumentService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error deleting document with ID: {Id}", id);
+            _logger.LogError(ex, "Error deleting document with ID: {Id}", LogSanitizer.Sanitize(id));
             return ServiceResult<bool>.BadRequest("Error deleting document");
         }
     }
@@ -499,7 +500,7 @@ public class DocumentService : IDocumentService
             // If user has no write access to any agents, return 0 deleted
             if (!authorizedAgentNames.Any())
             {
-                _logger.LogWarning("User {UserId} has no write access to any agents, cannot delete documents", _tenantContext.LoggedInUser);
+                _logger.LogWarning("User {UserId} has no write access to any agents, cannot delete documents", LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
                 var zeroResult = new BulkDeleteResult { DeletedCount = 0 };
                 return ServiceResult<BulkDeleteResult>.Success(zeroResult);
             }
@@ -535,7 +536,7 @@ public class DocumentService : IDocumentService
             // If document has no AgentId, deny access
             if (string.IsNullOrEmpty(document.AgentId))
             {
-                _logger.LogWarning("Document {Id} has no AgentId, denying existence check", id);
+                _logger.LogWarning("Document {Id} has no AgentId, denying existence check", LogSanitizer.Sanitize(id));
                 return ServiceResult<ExistsResult>.Forbidden("Document has no associated agent");
             }
 
@@ -544,7 +545,7 @@ public class DocumentService : IDocumentService
             if (!hasPermission)
             {
                 _logger.LogWarning("User {UserId} attempted to check existence of document {Id} for agent {AgentId} without read permission", 
-                    _tenantContext.LoggedInUser, id, document.AgentId);
+                    LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(id), LogSanitizer.Sanitize(document.AgentId));
                 // Return false for documents the user doesn't have access to (don't reveal existence)
                 var result = new ExistsResult { Exists = false };
                 return ServiceResult<ExistsResult>.Success(result);
@@ -555,7 +556,7 @@ public class DocumentService : IDocumentService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error checking document existence with ID: {Id}", id);
+            _logger.LogError(ex, "Error checking document existence with ID: {Id}", LogSanitizer.Sanitize(id));
             return ServiceResult<ExistsResult>.InternalServerError("Error checking document existence");
         }
     }
@@ -636,7 +637,7 @@ public class DocumentService : IDocumentService
         var currentPermissions = await _agentPermissionRepository.GetAgentPermissionsAsync(agentId);
         if (currentPermissions == null)
         {
-            _logger.LogWarning("No permissions found for agent: {AgentId}", agentId);
+            _logger.LogWarning("No permissions found for agent: {AgentId}", LogSanitizer.Sanitize(agentId));
             return false;
         }
 

--- a/XiansAi.Server.Src/Features/AgentApi/Services/LogsService.cs
+++ b/XiansAi.Server.Src/Features/AgentApi/Services/LogsService.cs
@@ -3,6 +3,7 @@ using Features.AgentApi.Models;
 using Features.AgentApi.Repositories;
 using Shared.Data;
 using Shared.Auth;
+using Shared.Utils;
 
 namespace Features.AgentApi.Services.Lib;
 
@@ -141,7 +142,7 @@ public class LogsService : ILogsService
             };
 
             await _logRepository.CreateAsync(log);
-            _logger.LogDebug("Created log: {Log}", log.ToJson());
+            _logger.LogDebug("Created log: {Log}", LogSanitizer.Sanitize(log.ToJson()));
             return Results.Ok(log);
         }
         catch (Exception ex)
@@ -171,7 +172,7 @@ public class LogsService : ILogsService
         if (!requestTenantId.Trim().Equals(_tenantContext.TenantId, StringComparison.OrdinalIgnoreCase))
         {
             _logger.LogWarning("Non-admin user {UserId} attempted to log for tenant {RequestedTenantId} but current tenant is {CurrentTenantId}",
-                _tenantContext.LoggedInUser, requestTenantId, _tenantContext.TenantId);
+                LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(requestTenantId), LogSanitizer.Sanitize(_tenantContext.TenantId));
             return (null, Results.BadRequest("TenantId does not match the current tenant. Only system administrators can log for other tenants."));
         }
 

--- a/XiansAi.Server.Src/Features/AgentApi/Services/ObjectCacheWrapperService.cs
+++ b/XiansAi.Server.Src/Features/AgentApi/Services/ObjectCacheWrapperService.cs
@@ -57,15 +57,15 @@ public class ObjectCacheWrapperService : IObjectCacheWrapperService
     /// <returns>The cached value or NotFound if not found</returns>
     public async Task<IResult> GetValue(string key)
     {
-        _logger.LogInformation("Getting value for key: {Key}", key);
+        _logger.LogInformation("Getting value for key: {Key}", LogSanitizer.Sanitize(key));
         var value = await _objectCache.GetAsync<object>(key);
         if (value == null)
         {
-            _logger.LogWarning("No value found for key: {Key}", key);
+            _logger.LogWarning("No value found for key: {Key}", LogSanitizer.Sanitize(key));
             return Results.NotFound($"No value found for key: {key}");
         }
 
-        _logger.LogInformation("Retrieved value for key {Key}: {Value}", key, JsonSerializer.Serialize(value));
+        _logger.LogInformation("Retrieved value for key {Key}: {Value}", LogSanitizer.Sanitize(key), LogSanitizer.Sanitize(JsonSerializer.Serialize(value)));
         return Results.Ok(value);
     }
 
@@ -79,11 +79,11 @@ public class ObjectCacheWrapperService : IObjectCacheWrapperService
     /// <returns>Success or error result</returns>
     public async Task<IResult> SetValue(string key, [FromBody] JsonElement value, CacheOptions? options = null)
     {
-        _logger.LogInformation("Setting value for key: {Key}, Value: {Value}", key, value.ToString());
+        _logger.LogInformation("Setting value for key: {Key}, Value: {Value}", LogSanitizer.Sanitize(key), LogSanitizer.Sanitize(value.ToString()));
         
         if (value.ValueKind == JsonValueKind.Null)
         {
-            _logger.LogWarning("Attempted to set null value for key: {Key}", key);
+            _logger.LogWarning("Attempted to set null value for key: {Key}", LogSanitizer.Sanitize(key));
             return Results.BadRequest("Value cannot be null");
         }
 
@@ -102,11 +102,11 @@ public class ObjectCacheWrapperService : IObjectCacheWrapperService
         var success = await _objectCache.SetAsync(key, value, relativeExpiration, slidingExpiration);
         if (!success)
         {
-            _logger.LogError("Failed to set value for key: {Key}, Value: {Value}", key, value.ToString());
+            _logger.LogError("Failed to set value for key: {Key}, Value: {Value}", LogSanitizer.Sanitize(key), LogSanitizer.Sanitize(value.ToString()));
             return Results.Json(new { message = "Failed to set value in cache" }, statusCode: 500);
         }
 
-        _logger.LogInformation("Successfully set value for key: {Key}, Value: {Value}", key, value.ToString());
+        _logger.LogInformation("Successfully set value for key: {Key}, Value: {Value}", LogSanitizer.Sanitize(key), LogSanitizer.Sanitize(value.ToString()));
         return Results.Ok(new { message = "Value set successfully" });
     }
 
@@ -117,15 +117,15 @@ public class ObjectCacheWrapperService : IObjectCacheWrapperService
     /// <returns>Success or error result</returns>
     public async Task<IResult> DeleteValue(string key)
     {
-        _logger.LogInformation("Deleting value for key: {Key}", key);
+        _logger.LogInformation("Deleting value for key: {Key}", LogSanitizer.Sanitize(key));
         var success = await _objectCache.RemoveAsync(key);
         if (!success)
         {
-            _logger.LogError("Failed to delete value for key: {Key}", key);
+            _logger.LogError("Failed to delete value for key: {Key}", LogSanitizer.Sanitize(key));
             return Results.Json(new { message = "Failed to delete value from cache" }, statusCode: 500);
         }
 
-        _logger.LogInformation("Successfully deleted value for key: {Key}", key);
+        _logger.LogInformation("Successfully deleted value for key: {Key}", LogSanitizer.Sanitize(key));
         return Results.Ok(new { message = "Value deleted successfully" });
     }
 } 

--- a/XiansAi.Server.Src/Features/AppsApi/Converters/MarkdigSlackConverter.cs
+++ b/XiansAi.Server.Src/Features/AppsApi/Converters/MarkdigSlackConverter.cs
@@ -49,8 +49,10 @@ public static class MarkdigSlackConverter
         }
     }
 
-    private static void ProcessInlines(ContainerInline inlines, StringBuilder sb)
+    private static void ProcessInlines(ContainerInline? inlines, StringBuilder sb)
     {
+        if (inlines == null) return;
+
         foreach (var inline in inlines)
         {
             switch (inline)

--- a/XiansAi.Server.Src/Features/AppsApi/Handlers/SlackWebhookHandler.cs
+++ b/XiansAi.Server.Src/Features/AppsApi/Handlers/SlackWebhookHandler.cs
@@ -6,6 +6,7 @@ using Features.AppsApi.Models;
 using Shared.Services;
 using Shared.Repositories;
 using Shared.Auth;
+using Shared.Utils;
 using Features.AppsApi.Converters;
 
 namespace Features.AppsApi.Handlers;
@@ -610,7 +611,7 @@ public class SlackWebhookHandler : ISlackWebhookHandler
 
             _logger.LogInformation(
                 "Looking up Slack user for email: {Email}",
-                email);
+                LogSanitizer.RedactEmail(email));
 
             var lookupResponse =
                 await httpClient.SendAsync(lookupRequest, cancellationToken);
@@ -652,7 +653,7 @@ public class SlackWebhookHandler : ISlackWebhookHandler
             {
                 _logger.LogWarning(
                     "No Slack user found for email: {Email}",
-                    email);
+                    LogSanitizer.RedactEmail(email));
 
                 return null;
             }
@@ -728,7 +729,7 @@ public class SlackWebhookHandler : ISlackWebhookHandler
             _logger.LogError(
                 ex,
                 "Error getting Slack channel from email: {Email}",
-                email);
+                LogSanitizer.RedactEmail(email));
 
             return null;
         }

--- a/XiansAi.Server.Src/Features/AppsApi/Repositories/AppIntegrationRepository.cs
+++ b/XiansAi.Server.Src/Features/AppsApi/Repositories/AppIntegrationRepository.cs
@@ -131,7 +131,7 @@ public class AppIntegrationRepository : IAppIntegrationRepository
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to create indexes for {Collection}. They may already exist.", CollectionName);
+            _logger.LogWarning(ex, "Failed to create indexes for {Collection}. They may already exist.", LogSanitizer.Sanitize(CollectionName));
         }
     }
 
@@ -256,7 +256,7 @@ public class AppIntegrationRepository : IAppIntegrationRepository
             await _integrations.InsertOneAsync(integration);
             
             _logger.LogInformation("Created app integration {IntegrationId} for tenant {TenantId}", 
-                integration.Id, integration.TenantId);
+                LogSanitizer.Sanitize(integration.Id), LogSanitizer.Sanitize(integration.TenantId));
             
             return integration.Id;
         }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "CreateAppIntegration");
@@ -280,11 +280,11 @@ public class AppIntegrationRepository : IAppIntegrationRepository
             
             if (success)
             {
-                _logger.LogInformation("Updated app integration {IntegrationId}", id);
+                _logger.LogInformation("Updated app integration {IntegrationId}", LogSanitizer.Sanitize(id));
             }
             else
             {
-                _logger.LogWarning("Failed to update app integration {IntegrationId} - not found or tenant mismatch", id);
+                _logger.LogWarning("Failed to update app integration {IntegrationId} - not found or tenant mismatch", LogSanitizer.Sanitize(id));
             }
 
             return success;
@@ -302,11 +302,11 @@ public class AppIntegrationRepository : IAppIntegrationRepository
             
             if (success)
             {
-                _logger.LogInformation("Deleted app integration {IntegrationId}", id);
+                _logger.LogInformation("Deleted app integration {IntegrationId}", LogSanitizer.Sanitize(id));
             }
             else
             {
-                _logger.LogWarning("Failed to delete app integration {IntegrationId} - not found or tenant mismatch", id);
+                _logger.LogWarning("Failed to delete app integration {IntegrationId} - not found or tenant mismatch", LogSanitizer.Sanitize(id));
             }
 
             return success;
@@ -333,7 +333,7 @@ public class AppIntegrationRepository : IAppIntegrationRepository
             }
             else
             {
-                _logger.LogWarning("Failed to set enabled status for app integration {IntegrationId}", id);
+                _logger.LogWarning("Failed to set enabled status for app integration {IntegrationId}", LogSanitizer.Sanitize(id));
             }
 
             return success;
@@ -348,13 +348,13 @@ public class AppIntegrationRepository : IAppIntegrationRepository
         if (integration.Secrets?.HasAnySecrets() == true)
         {
             integration.SecretsEncrypted = _encryptionService.EncryptObject(integration.Secrets);
-            _logger.LogDebug("Encrypted secrets for integration {IntegrationId}", integration.Id ?? "new");
+            _logger.LogDebug("Encrypted secrets for integration {IntegrationId}", LogSanitizer.Sanitize(integration.Id ?? "new"));
         }
         else
         {
             integration.SecretsEncrypted = null;
             _logger.LogWarning("No secrets to encrypt for integration {IntegrationId}. WebhookSecret: {HasWebhook}, Secrets null: {SecretsNull}", 
-                integration.Id ?? "new",
+                LogSanitizer.Sanitize(integration.Id ?? "new"),
                 integration.Secrets?.WebhookSecret != null,
                 integration.Secrets == null);
         }

--- a/XiansAi.Server.Src/Features/AppsApi/Services/AppIntegrationService.cs
+++ b/XiansAi.Server.Src/Features/AppsApi/Services/AppIntegrationService.cs
@@ -5,6 +5,7 @@ using Features.AppsApi.Models;
 using Features.AppsApi.Repositories;
 using Shared.Services;
 using Shared.Utils.Services;
+using Shared.Utils;
 
 namespace Features.AppsApi.Services;
 
@@ -179,7 +180,7 @@ public class AppIntegrationService : IAppIntegrationService
         try
         {
             _logger.LogInformation("Getting integrations for tenant {TenantId}, platform={Platform}, agent={Agent}, activation={Activation}",
-                tenantId, platformId, agentName, activationName);
+                LogSanitizer.Sanitize(tenantId), LogSanitizer.Sanitize(platformId), LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(activationName));
 
             List<AppIntegration> integrations;
 
@@ -212,13 +213,13 @@ public class AppIntegrationService : IAppIntegrationService
                 .Select(i => AppIntegrationResponse.FromEntity(i))
                 .ToList();
 
-            _logger.LogInformation("Found {Count} integrations for tenant {TenantId}", responses.Count, tenantId);
+            _logger.LogInformation("Found {Count} integrations for tenant {TenantId}", responses.Count, LogSanitizer.Sanitize(tenantId));
 
             return ServiceResult<List<AppIntegrationResponse>>.Success(responses);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error getting integrations for tenant {TenantId}", tenantId);
+            _logger.LogError(ex, "Error getting integrations for tenant {TenantId}", LogSanitizer.Sanitize(tenantId));
             return ServiceResult<List<AppIntegrationResponse>>.InternalServerError(
                 "An error occurred while retrieving integrations");
         }
@@ -228,7 +229,7 @@ public class AppIntegrationService : IAppIntegrationService
     {
         try
         {
-            _logger.LogInformation("Getting integration {IntegrationId} for tenant {TenantId}", id, tenantId);
+            _logger.LogInformation("Getting integration {IntegrationId} for tenant {TenantId}", LogSanitizer.Sanitize(id), LogSanitizer.Sanitize(tenantId));
 
             var integration = await _repository.GetByIdAsync(id);
 
@@ -240,7 +241,7 @@ public class AppIntegrationService : IAppIntegrationService
             if (integration.TenantId != tenantId)
             {
                 _logger.LogWarning("Tenant {TenantId} attempted to access integration {IntegrationId} belonging to tenant {OwnerTenant}",
-                    tenantId, id, integration.TenantId);
+                    LogSanitizer.Sanitize(tenantId), LogSanitizer.Sanitize(id), LogSanitizer.Sanitize(integration.TenantId));
                 return ServiceResult<AppIntegrationResponse>.NotFound("Integration not found");
             }
 
@@ -253,7 +254,7 @@ public class AppIntegrationService : IAppIntegrationService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error getting integration {IntegrationId}", id);
+            _logger.LogError(ex, "Error getting integration {IntegrationId}", LogSanitizer.Sanitize(id));
             return ServiceResult<AppIntegrationResponse>.InternalServerError(
                 "An error occurred while retrieving the integration");
         }
@@ -267,7 +268,7 @@ public class AppIntegrationService : IAppIntegrationService
         try
         {
             _logger.LogInformation("Creating integration {Name} for tenant {TenantId}, platform {Platform}",
-                request.Name, tenantId, request.PlatformId);
+                LogSanitizer.Sanitize(request.Name), LogSanitizer.Sanitize(tenantId), LogSanitizer.Sanitize(request.PlatformId));
 
             // Check if name already exists for this agent/activation combination
             if (await _repository.ExistsByNameAsync(tenantId, request.AgentName, request.ActivationName, request.Name))
@@ -329,13 +330,13 @@ public class AppIntegrationService : IAppIntegrationService
             var response = AppIntegrationResponse.FromEntity(integration, maskWebhookUrl: false);
 
             _logger.LogInformation("Created integration {IntegrationId} with webhook URL {WebhookUrl}",
-                id, response.WebhookUrl);
+                LogSanitizer.Sanitize(id), LogSanitizer.Sanitize(response.WebhookUrl));
 
             return ServiceResult<AppIntegrationResponse>.Success(response);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error creating integration for tenant {TenantId}", tenantId);
+            _logger.LogError(ex, "Error creating integration for tenant {TenantId}", LogSanitizer.Sanitize(tenantId));
             return ServiceResult<AppIntegrationResponse>.InternalServerError(
                 "An error occurred while creating the integration");
         }
@@ -349,7 +350,7 @@ public class AppIntegrationService : IAppIntegrationService
     {
         try
         {
-            _logger.LogInformation("Updating integration {IntegrationId} for tenant {TenantId}", id, tenantId);
+            _logger.LogInformation("Updating integration {IntegrationId} for tenant {TenantId}", LogSanitizer.Sanitize(id), LogSanitizer.Sanitize(tenantId));
 
             var existing = await _repository.GetByIdAsync(id);
 
@@ -470,13 +471,13 @@ public class AppIntegrationService : IAppIntegrationService
 
             var response = AppIntegrationResponse.FromEntity(existing);
 
-            _logger.LogInformation("Updated integration {IntegrationId}", id);
+            _logger.LogInformation("Updated integration {IntegrationId}", LogSanitizer.Sanitize(id));
 
             return ServiceResult<AppIntegrationResponse>.Success(response);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error updating integration {IntegrationId}", id);
+            _logger.LogError(ex, "Error updating integration {IntegrationId}", LogSanitizer.Sanitize(id));
             return ServiceResult<AppIntegrationResponse>.InternalServerError(
                 "An error occurred while updating the integration");
         }
@@ -486,7 +487,7 @@ public class AppIntegrationService : IAppIntegrationService
     {
         try
         {
-            _logger.LogInformation("Deleting integration {IntegrationId} for tenant {TenantId}", id, tenantId);
+            _logger.LogInformation("Deleting integration {IntegrationId} for tenant {TenantId}", LogSanitizer.Sanitize(id), LogSanitizer.Sanitize(tenantId));
 
             var existing = await _repository.GetByIdAsync(id);
 
@@ -507,13 +508,13 @@ public class AppIntegrationService : IAppIntegrationService
                 return ServiceResult<bool>.InternalServerError("Failed to delete integration");
             }
 
-            _logger.LogInformation("Deleted integration {IntegrationId}", id);
+            _logger.LogInformation("Deleted integration {IntegrationId}", LogSanitizer.Sanitize(id));
 
             return ServiceResult<bool>.Success(true);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error deleting integration {IntegrationId}", id);
+            _logger.LogError(ex, "Error deleting integration {IntegrationId}", LogSanitizer.Sanitize(id));
             return ServiceResult<bool>.InternalServerError(
                 "An error occurred while deleting the integration");
         }
@@ -646,12 +647,12 @@ public class AppIntegrationService : IAppIntegrationService
             integration.Id = id;
 
             var response = AppIntegrationResponse.FromEntity(integration, maskWebhookUrl: false);
-            _logger.LogInformation("Created builtin webhook integration {IntegrationId} with webhook URL", id);
+            _logger.LogInformation("Created builtin webhook integration {IntegrationId} with webhook URL", LogSanitizer.Sanitize(id));
             return ServiceResult<AppIntegrationResponse>.Success(response);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error creating builtin webhook for tenant {TenantId}", tenantId);
+            _logger.LogError(ex, "Error creating builtin webhook for tenant {TenantId}", LogSanitizer.Sanitize(tenantId));
             return ServiceResult<AppIntegrationResponse>.InternalServerError("An error occurred while creating the builtin webhook");
         }
     }
@@ -678,7 +679,7 @@ public class AppIntegrationService : IAppIntegrationService
             {
                 var revokeResult = await _apiKeyService.RevokeApiKeyAsync(apiKeyId, tenantId);
                 if (!revokeResult.IsSuccess)
-                    _logger.LogWarning("Failed to revoke API key {ApiKeyId} when deleting builtin webhook: {Error}", apiKeyId, revokeResult.ErrorMessage);
+                    _logger.LogWarning("Failed to revoke API key {ApiKeyId} when deleting builtin webhook: {Error}", LogSanitizer.Sanitize(apiKeyId), LogSanitizer.Sanitize(revokeResult.ErrorMessage));
             }
         }
 
@@ -692,7 +693,7 @@ public class AppIntegrationService : IAppIntegrationService
     {
         try
         {
-            _logger.LogInformation("Enabling integration {IntegrationId}", id);
+            _logger.LogInformation("Enabling integration {IntegrationId}", LogSanitizer.Sanitize(id));
 
             var existing = await _repository.GetByIdAsync(id);
 
@@ -720,13 +721,13 @@ public class AppIntegrationService : IAppIntegrationService
 
             var response = AppIntegrationResponse.FromEntity(existing);
 
-            _logger.LogInformation("Enabled integration {IntegrationId}", id);
+            _logger.LogInformation("Enabled integration {IntegrationId}", LogSanitizer.Sanitize(id));
 
             return ServiceResult<AppIntegrationResponse>.Success(response);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error enabling integration {IntegrationId}", id);
+            _logger.LogError(ex, "Error enabling integration {IntegrationId}", LogSanitizer.Sanitize(id));
             return ServiceResult<AppIntegrationResponse>.InternalServerError(
                 "An error occurred while enabling the integration");
         }
@@ -739,7 +740,7 @@ public class AppIntegrationService : IAppIntegrationService
     {
         try
         {
-            _logger.LogInformation("Disabling integration {IntegrationId}", id);
+            _logger.LogInformation("Disabling integration {IntegrationId}", LogSanitizer.Sanitize(id));
 
             var existing = await _repository.GetByIdAsync(id);
 
@@ -767,13 +768,13 @@ public class AppIntegrationService : IAppIntegrationService
 
             var response = AppIntegrationResponse.FromEntity(existing);
 
-            _logger.LogInformation("Disabled integration {IntegrationId}", id);
+            _logger.LogInformation("Disabled integration {IntegrationId}", LogSanitizer.Sanitize(id));
 
             return ServiceResult<AppIntegrationResponse>.Success(response);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error disabling integration {IntegrationId}", id);
+            _logger.LogError(ex, "Error disabling integration {IntegrationId}", LogSanitizer.Sanitize(id));
             return ServiceResult<AppIntegrationResponse>.InternalServerError(
                 "An error occurred while disabling the integration");
         }
@@ -788,7 +789,7 @@ public class AppIntegrationService : IAppIntegrationService
     {
         try
         {
-            _logger.LogInformation("Testing integration {IntegrationId}", id);
+            _logger.LogInformation("Testing integration {IntegrationId}", LogSanitizer.Sanitize(id));
 
             var integration = await _repository.GetByIdAsync(id);
 
@@ -814,7 +815,7 @@ public class AppIntegrationService : IAppIntegrationService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error testing integration {IntegrationId}", id);
+            _logger.LogError(ex, "Error testing integration {IntegrationId}", LogSanitizer.Sanitize(id));
             return ServiceResult<IntegrationTestResult>.InternalServerError(
                 "An error occurred while testing the integration");
         }
@@ -928,7 +929,7 @@ public class AppIntegrationService : IAppIntegrationService
             return; // Already migrated
         }
 
-        _logger.LogInformation("Migrating old integration {IntegrationId} to encrypted secrets format", integration.Id);
+        _logger.LogInformation("Migrating old integration {IntegrationId} to encrypted secrets format", LogSanitizer.Sanitize(integration.Id));
 
         // Migrate secrets from Configuration
         MigrateSecretsFromConfiguration(integration);
@@ -946,7 +947,7 @@ public class AppIntegrationService : IAppIntegrationService
         integration.UpdatedBy = "system-migration";
         await _repository.UpdateAsync(integration.Id, integration);
 
-        _logger.LogInformation("Successfully migrated integration {IntegrationId}", integration.Id);
+        _logger.LogInformation("Successfully migrated integration {IntegrationId}", LogSanitizer.Sanitize(integration.Id));
     }
 
     /// <summary>

--- a/XiansAi.Server.Src/Features/PublicApi/Services/PublicRegistrationService.cs
+++ b/XiansAi.Server.Src/Features/PublicApi/Services/PublicRegistrationService.cs
@@ -116,14 +116,14 @@ public class PublicRegistrationService : IPublicRegistrationService
             var tenant = await _tenantRepository.GetByTenantIdAsync(request.TenantId);
             if (tenant == null)
             {
-                _logger.LogWarning("Tenant join request failed: Tenant {TenantId} not found", request.TenantId);
+                _logger.LogWarning("Tenant join request failed: Tenant {TenantId} not found", LogSanitizer.Sanitize(request.TenantId));
                 return ServiceResult<PublicJoinTenantResponse>.NotFound("Tenant not found");
             }
 
             // Check if tenant is enabled
             if (!tenant.Enabled)
             {
-                _logger.LogWarning("Tenant join request failed: Tenant {TenantId} is disabled", request.TenantId);
+                _logger.LogWarning("Tenant join request failed: Tenant {TenantId} is disabled", LogSanitizer.Sanitize(request.TenantId));
                 return ServiceResult<PublicJoinTenantResponse>.BadRequest("Tenant is not accepting new members");
             }
 
@@ -151,7 +151,7 @@ public class PublicRegistrationService : IPublicRegistrationService
                 if (!createUserResult.IsSuccess)
                 {
                     _logger.LogError("Failed to create user {UserId} for tenant join request: {Error}", 
-                        jwtResult.UserId, createUserResult.ErrorMessage);
+                        LogSanitizer.Sanitize(jwtResult.UserId), LogSanitizer.Sanitize(createUserResult.ErrorMessage));
                     return ServiceResult<PublicJoinTenantResponse>.InternalServerError("Failed to create user account");
                 }
 
@@ -203,12 +203,12 @@ public class PublicRegistrationService : IPublicRegistrationService
             if (!updateResult)
             {
                 _logger.LogError("Failed to update user {UserId} with tenant join request for {TenantId}", 
-                    user.UserId, request.TenantId);
+                    LogSanitizer.Sanitize(user.UserId), LogSanitizer.Sanitize(request.TenantId));
                 return ServiceResult<PublicJoinTenantResponse>.InternalServerError("Failed to submit join request");
             }
 
             _logger.LogInformation("User {UserId} ({Email}) requested to join tenant {TenantId}", 
-                user.UserId, user.Email, request.TenantId);
+                LogSanitizer.Sanitize(user.UserId), LogSanitizer.RedactEmail(user.Email), LogSanitizer.Sanitize(request.TenantId));
 
             return ServiceResult<PublicJoinTenantResponse>.Success(new PublicJoinTenantResponse
             {
@@ -220,7 +220,7 @@ public class PublicRegistrationService : IPublicRegistrationService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error processing tenant join request for tenant {TenantId}", request.TenantId);
+            _logger.LogError(ex, "Error processing tenant join request for tenant {TenantId}", LogSanitizer.Sanitize(request.TenantId));
             return ServiceResult<PublicJoinTenantResponse>.InternalServerError("An error occurred while processing your request");
         }
     }
@@ -258,7 +258,7 @@ public class PublicRegistrationService : IPublicRegistrationService
             }
             catch (ValidationException ex)
             {
-                _logger.LogWarning("Invalid tenant ID provided: {TenantId}, Error: {Error}", request.TenantId, ex.Message);
+                _logger.LogWarning("Invalid tenant ID provided: {TenantId}, Error: {Error}", LogSanitizer.Sanitize(request.TenantId), LogSanitizer.Sanitize(ex.Message));
                 return ServiceResult<PublicCreateTenantResponse>.BadRequest($"Invalid tenant ID: {ex.Message}");
             }
 
@@ -266,7 +266,7 @@ public class PublicRegistrationService : IPublicRegistrationService
             var existingTenant = await _tenantRepository.GetByTenantIdAsync(request.TenantId);
             if (existingTenant != null)
             {
-                _logger.LogWarning("Tenant creation failed: Tenant {TenantId} already exists", request.TenantId);
+                _logger.LogWarning("Tenant creation failed: Tenant {TenantId} already exists", LogSanitizer.Sanitize(request.TenantId));
                 return ServiceResult<PublicCreateTenantResponse>.Conflict("A tenant with this ID already exists");
             }
 
@@ -291,7 +291,7 @@ public class PublicRegistrationService : IPublicRegistrationService
             var tenantResult = await _tenantService.CreateTenant(createTenantRequest, jwtResult.UserId);
             if (!tenantResult.IsSuccess)
             {
-                _logger.LogError("Failed to create tenant {TenantId}: {Error}", request.TenantId, tenantResult.ErrorMessage);
+                _logger.LogError("Failed to create tenant {TenantId}: {Error}", LogSanitizer.Sanitize(request.TenantId), LogSanitizer.Sanitize(tenantResult.ErrorMessage));
                 return ServiceResult<PublicCreateTenantResponse>.BadRequest(tenantResult.ErrorMessage ?? "Failed to create tenant");
             }
 
@@ -311,7 +311,7 @@ public class PublicRegistrationService : IPublicRegistrationService
                 if (!createUserResult.IsSuccess)
                 {
                     _logger.LogError("Failed to create user {UserId} for tenant creation: {Error}", 
-                        jwtResult.UserId, createUserResult.ErrorMessage);
+                        LogSanitizer.Sanitize(jwtResult.UserId), LogSanitizer.Sanitize(createUserResult.ErrorMessage));
                     return ServiceResult<PublicCreateTenantResponse>.InternalServerError("Failed to create user account");
                 }
 
@@ -334,12 +334,12 @@ public class PublicRegistrationService : IPublicRegistrationService
             if (!roleResult.IsSuccess)
             {
                 _logger.LogError("Created tenant {TenantId} but failed to assign admin role to user {UserId}: {Error}", 
-                    request.TenantId, jwtResult.UserId, roleResult.ErrorMessage);
+                    LogSanitizer.Sanitize(request.TenantId), LogSanitizer.Sanitize(jwtResult.UserId), LogSanitizer.Sanitize(roleResult.ErrorMessage));
                 return ServiceResult<PublicCreateTenantResponse>.InternalServerError("Failed to assign admin role to user. Pelase contact support.");
             }
 
             _logger.LogInformation("User {UserId} ({Email}) created new tenant {TenantId} and was assigned as admin", 
-                jwtResult.UserId, jwtResult.Email, request.TenantId);
+                LogSanitizer.Sanitize(jwtResult.UserId), LogSanitizer.RedactEmail(jwtResult.Email), LogSanitizer.Sanitize(request.TenantId));
 
             return ServiceResult<PublicCreateTenantResponse>.Success(new PublicCreateTenantResponse
             {
@@ -350,7 +350,7 @@ public class PublicRegistrationService : IPublicRegistrationService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error creating new tenant {TenantId}", request.TenantId);
+            _logger.LogError(ex, "Error creating new tenant {TenantId}", LogSanitizer.Sanitize(request.TenantId));
             return ServiceResult<PublicCreateTenantResponse>.InternalServerError("An error occurred while creating the tenant");
         }
     }

--- a/XiansAi.Server.Src/Features/UserApi/Auth/EndpointAuthenticationHandler.cs
+++ b/XiansAi.Server.Src/Features/UserApi/Auth/EndpointAuthenticationHandler.cs
@@ -43,15 +43,15 @@ namespace Features.UserApi.Auth
             // Only handle authentication for UserApi endpoints
             var path = Request.Path.Value?.ToLowerInvariant() ?? "";
             
-            _logger.LogDebug("EndpointAuthenticationHandler: Evaluating path '{Path}'", Request.Path);
+            _logger.LogDebug("EndpointAuthenticationHandler: Evaluating path '{Path}'", LogSanitizer.Sanitize(Request.Path));
             
             if (!path.StartsWith("/api/user/"))
             {
-                _logger.LogDebug("Skipping endpoint authentication for non-UserApi path: {Path}", Request.Path);
+                _logger.LogDebug("Skipping endpoint authentication for non-UserApi path: {Path}", LogSanitizer.Sanitize(Request.Path));
                 return AuthenticateResult.NoResult(); // Let other handlers process this request
             }
 
-            _logger.LogDebug("Processing UserApi endpoint request: {Path}", Request.Path);
+            _logger.LogDebug("Processing UserApi endpoint request: {Path}", LogSanitizer.Sanitize(Request.Path));
 
             // Note: Rate limiting is handled by the rate limiting middleware (which runs before authentication)
             // All UserApi endpoints should use .WithAgentUserApiRateLimit() to prevent enumeration attacks
@@ -69,7 +69,7 @@ namespace Features.UserApi.Auth
             // Note: tenantId is now optional. If not provided, it will be derived from the API key.
             // This prevents IDOR vulnerabilities by ensuring the tenant matches the authenticated credential.
 
-            _logger.LogDebug("Processing Endpoint request: {Path}", Request.Path);
+            _logger.LogDebug("Processing Endpoint request: {Path}", LogSanitizer.Sanitize(Request.Path));
             if (_tenantContext != null)
             {
                 string? accessToken = null;
@@ -109,7 +109,7 @@ namespace Features.UserApi.Auth
                     }
                 }
 
-                _logger.LogDebug("Resolved credential from {Source} for {Path}", tokenSource, Request.Path);
+                _logger.LogDebug("Resolved credential from {Source} for {Path}", LogSanitizer.Sanitize(tokenSource), LogSanitizer.Sanitize(Request.Path));
 
                 if (!string.IsNullOrEmpty(apikeyId))
                 {
@@ -136,7 +136,7 @@ namespace Features.UserApi.Auth
                             var identity = new ClaimsIdentity(claims, Scheme.Name);
                             var principal = new ClaimsPrincipal(identity);
                             var ticket = new AuthenticationTicket(principal, Scheme.Name);
-                            _logger.LogInformation("Successfully authenticated Web connection via apikeyId: User={UserId}, Tenant={TenantId}", apiKeyById.CreatedBy, apiKeyById.TenantId);
+                            _logger.LogInformation("Successfully authenticated Web connection via apikeyId: User={UserId}, Tenant={TenantId}", LogSanitizer.Sanitize(apiKeyById.CreatedBy), LogSanitizer.Sanitize(apiKeyById.TenantId));
 
                             return AuthenticateResult.Success(ticket);
                         }
@@ -176,7 +176,7 @@ namespace Features.UserApi.Auth
                                 apiKey = await _apiKeyService.GetApiKeyByRawKeyAsync(accessToken, tenantId);
                                 if (apiKey == null || apiKey.TenantId != tenantId)
                                 {
-                                    _logger.LogWarning("API key does not match provided tenant {TenantId}", tenantId);
+                                    _logger.LogWarning("API key does not match provided tenant {TenantId}", LogSanitizer.Sanitize(tenantId));
                                     return AuthenticateResult.Fail("Invalid API key or Tenant ID");
                                 }
                             }
@@ -195,7 +195,7 @@ namespace Features.UserApi.Auth
                             var identity = new ClaimsIdentity(claims, Scheme.Name);
                             var principal = new ClaimsPrincipal(identity);
                             var ticket = new AuthenticationTicket(principal, Scheme.Name);
-                            _logger.LogInformation("Successfully authenticated Web connection: User={UserId}, Tenant={TenantId}", apiKey.CreatedBy, apiKey.TenantId);
+                            _logger.LogInformation("Successfully authenticated Web connection: User={UserId}, Tenant={TenantId}", LogSanitizer.Sanitize(apiKey.CreatedBy), LogSanitizer.Sanitize(apiKey.TenantId));
 
                             return AuthenticateResult.Success(ticket);
 
@@ -213,7 +213,7 @@ namespace Features.UserApi.Auth
                             var validation = await _dynamicOidcValidator.ValidateAsync(tenantId, accessToken);
                             if (!validation.success || string.IsNullOrEmpty(validation.canonicalUserId))
                             {
-                                _logger.LogWarning("JWT validation failed: {Error}", validation.error);
+                                _logger.LogWarning("JWT validation failed: {Error}", LogSanitizer.Sanitize(validation.error));
                                 return AuthenticateResult.Fail(validation.error ?? "JWT validation failed");
                             }
                             var userId = validation.canonicalUserId;
@@ -231,7 +231,7 @@ namespace Features.UserApi.Auth
 
                             _tenantContext.TenantId = tenantId;
                             _tenantContext.AuthorizedTenantIds = tenantIds;
-                            _logger.LogDebug("UserID-{Id}", userId);
+                            _logger.LogDebug("UserID-{Id}", LogSanitizer.Sanitize(userId));
                             
                             var claims = new List<Claim>
                             {
@@ -241,14 +241,14 @@ namespace Features.UserApi.Auth
                             
                             foreach (var tId in tenantIds)
                             {
-                                _logger.LogDebug("tenantIds-{tId}: ", tId);
+                                _logger.LogDebug("tenantIds-{tId}: ", LogSanitizer.Sanitize(tId));
                                 claims.Add(new Claim("AuthorizedTenantId", tId));
                             }
 
                             var identity = new ClaimsIdentity(claims, Scheme.Name);
                             var principal = new ClaimsPrincipal(identity);
                             var ticket = new AuthenticationTicket(principal, Scheme.Name);
-                            _logger.LogInformation("Successfully authenticated Endpoint JWT: User={UserId}, Tenant={TenantId}", userId, tenantId);
+                            _logger.LogInformation("Successfully authenticated Endpoint JWT: User={UserId}, Tenant={TenantId}", LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(tenantId));
                             
                             return AuthenticateResult.Success(ticket);
                         }
@@ -288,9 +288,9 @@ namespace Features.UserApi.Auth
                 "Credential supplied via query parameter '?{Parameter}=' on {Method} {Path} — DEPRECATED. " +
                 "Send 'Authorization: Bearer <token>' instead. Query-string credentials leak into " +
                 "reverse-proxy access logs, CDN logs, browser history, and Referer headers.",
-                parameterName,
-                Request.Method,
-                Request.Path);
+                LogSanitizer.Sanitize(parameterName),
+                LogSanitizer.Sanitize(Request.Method),
+                LogSanitizer.Sanitize(Request.Path));
         }
     }
 }

--- a/XiansAi.Server.Src/Features/UserApi/Auth/WebsocketAuthenticationHandler.cs
+++ b/XiansAi.Server.Src/Features/UserApi/Auth/WebsocketAuthenticationHandler.cs
@@ -48,7 +48,7 @@ namespace Features.UserApi.Auth
                 return AuthenticateResult.NoResult(); // Let other handlers process this request
             }
 
-            _logger.LogDebug("Processing SignalR/Websocket request: {Path}", Request.Path);
+            _logger.LogDebug("Processing SignalR/Websocket request: {Path}", LogSanitizer.Sanitize(Request.Path));
 
             // Check for access token in multiple locations: apikey query param, access_token query param, or Authorization header
             var accessToken = Request.Query["apikey"].ToString();
@@ -112,7 +112,7 @@ namespace Features.UserApi.Auth
                                 apiKey = await _apiKeyService.GetApiKeyByRawKeyAsync(accessToken, tenantId);
                                 if (apiKey == null || apiKey.TenantId != tenantId)
                                 {
-                                    _logger.LogWarning("API key does not match provided tenant {TenantId}", tenantId);
+                                    _logger.LogWarning("API key does not match provided tenant {TenantId}", LogSanitizer.Sanitize(tenantId));
                                     return AuthenticateResult.Fail("Invalid API key or Tenant ID");
                                 }
                             }
@@ -131,7 +131,7 @@ namespace Features.UserApi.Auth
                             var identity = new ClaimsIdentity(claims, Scheme.Name);
                             var principal = new ClaimsPrincipal(identity);
                             var ticket = new AuthenticationTicket(principal, Scheme.Name);
-                            _logger.LogInformation("Successfully authenticated WebSocket connection: User={UserId}, Tenant={TenantId}", apiKey.CreatedBy, apiKey.TenantId);
+                            _logger.LogInformation("Successfully authenticated WebSocket connection: User={UserId}, Tenant={TenantId}", LogSanitizer.Sanitize(apiKey.CreatedBy), LogSanitizer.Sanitize(apiKey.TenantId));
 
                             return AuthenticateResult.Success(ticket);
                         }
@@ -154,7 +154,7 @@ namespace Features.UserApi.Auth
                             var validation = await _dynamicOidcValidator.ValidateAsync(tenantId, accessToken);
                             if (!validation.success || string.IsNullOrEmpty(validation.canonicalUserId))
                             {
-                                _logger.LogWarning("JWT validation failed: {Error}", validation.error);
+                                _logger.LogWarning("JWT validation failed: {Error}", LogSanitizer.Sanitize(validation.error));
                                 return AuthenticateResult.Fail(validation.error ?? "JWT validation failed");
                             }
                             var userId = validation.canonicalUserId;
@@ -168,7 +168,7 @@ namespace Features.UserApi.Auth
 
                             _tenantContext.TenantId = tenantId;
                             _tenantContext.AuthorizedTenantIds = tenantIds;
-                            _logger.LogDebug("UserID-{Id}", userId);
+                            _logger.LogDebug("UserID-{Id}", LogSanitizer.Sanitize(userId));
                             var claims = new List<Claim>
                             {
                                 new Claim(ClaimTypes.NameIdentifier, userId),
@@ -176,14 +176,14 @@ namespace Features.UserApi.Auth
                             };
                             foreach (var tId in tenantIds)
                             {
-                                _logger.LogDebug("tenantIds-{tId}: ", tId);
+                                _logger.LogDebug("tenantIds-{tId}: ", LogSanitizer.Sanitize(tId));
                                 claims.Add(new Claim("AuthorizedTenantId", tId));
                             }
 
                             var identity = new ClaimsIdentity(claims, Scheme.Name);
                             var principal = new ClaimsPrincipal(identity);
                             var ticket = new AuthenticationTicket(principal, Scheme.Name);
-                            _logger.LogDebug("Successfully authenticated Websocket JWT: User={UserId}, Tenant={TenantId}", userId, tenantId);
+                            _logger.LogDebug("Successfully authenticated Websocket JWT: User={UserId}, Tenant={TenantId}", LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(tenantId));
                             return AuthenticateResult.Success(ticket);
                         }
                         else

--- a/XiansAi.Server.Src/Features/UserApi/Services/WebhookService.cs
+++ b/XiansAi.Server.Src/Features/UserApi/Services/WebhookService.cs
@@ -5,6 +5,7 @@ using Shared.Repositories;
 using Shared.Models;
 using Temporalio.Exceptions;
 using Features.WebApi.Services;
+using Shared.Utils;
 
 namespace Features.UserApi.Services;
 
@@ -52,13 +53,13 @@ public class WebhookReceiverService : IWebhookReceiverService
             // Validate tenant context
             if (_tenantContext.TenantId != tenantId)
             {
-                _logger.LogWarning("Tenant mismatch for webhook {TenantId}, {Workflow}, {MethodName}", tenantId, workflow, methodName);
+                _logger.LogWarning("Tenant mismatch for webhook {TenantId}, {Workflow}, {MethodName}", LogSanitizer.Sanitize(tenantId), LogSanitizer.Sanitize(workflow), LogSanitizer.Sanitize(methodName));
                 return ServiceResult<WebhookResponse>.Forbidden("Tenant mismatch");
             }
 
             _logger.LogInformation(
                 "Processing webhook for tenant {TenantId}, workflow {Workflow}, method {Method}",
-                tenantId, workflow, methodName);
+                LogSanitizer.Sanitize(tenantId), LogSanitizer.Sanitize(workflow), LogSanitizer.Sanitize(methodName));
 
             // Send the webhook update to temporal
             var result = await UpdateService.SendWebhookUpdate(
@@ -72,13 +73,13 @@ public class WebhookReceiverService : IWebhookReceiverService
 
             _logger.LogInformation(
                 "Successfully processed webhook for tenant {TenantId}, workflow {Workflow}, method {Method}",
-                tenantId, workflow, methodName);
+                LogSanitizer.Sanitize(tenantId), LogSanitizer.Sanitize(workflow), LogSanitizer.Sanitize(methodName));
 
             return ServiceResult<WebhookResponse>.Success(result);
         }
         catch (WorkflowUpdateRpcTimeoutOrCanceledException ex)
         {
-            _logger.LogWarning(ex, "Webhook update timed out for workflow {Workflow}, method {Method} - likely no workers available", workflow, methodName);
+            _logger.LogWarning(ex, "Webhook update timed out for workflow {Workflow}, method {Method} - likely no workers available", LogSanitizer.Sanitize(workflow), LogSanitizer.Sanitize(methodName));
             return ServiceResult<WebhookResponse>.RequestTimeout(
                 "The webhook update timed out. This typically means no workflow workers are available to process the request.",
                 StatusCode.RequestTimeout);
@@ -90,7 +91,7 @@ public class WebhookReceiverService : IWebhookReceiverService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error processing webhook for workflow {Workflow}, method {Method}", workflow, methodName);
+            _logger.LogError(ex, "Error processing webhook for workflow {Workflow}, method {Method}", LogSanitizer.Sanitize(workflow), LogSanitizer.Sanitize(methodName));
             return ServiceResult<WebhookResponse>.InternalServerError(
                 "An error occurred while processing the webhook",
                 StatusCode.InternalServerError);

--- a/XiansAi.Server.Src/Features/UserApi/Utils/SSEStreamHandler.cs
+++ b/XiansAi.Server.Src/Features/UserApi/Utils/SSEStreamHandler.cs
@@ -1,5 +1,6 @@
 using Features.UserApi.Services;
 using Shared.Auth;
+using Shared.Utils;
 
 namespace Features.UserApi.Utils;
 
@@ -57,7 +58,7 @@ public class SSEStreamHandler
         try
         {
             _logger.LogInformation("SSE connection established for workflow {WorkflowId}, participant {ParticipantId}, tenant {TenantId}",
-                _workflowId, _participantId, _tenantId);
+                LogSanitizer.Sanitize(_workflowId), LogSanitizer.Sanitize(_participantId), LogSanitizer.Sanitize(_tenantId));
 
             // Set SSE headers
             SSEEventWriter.SetSSEHeaders(_httpContext.Response);
@@ -103,7 +104,7 @@ public class SSEStreamHandler
             {
                 var eventType = message.MessageType?.ToString() ?? "unknown";
                 _logger.LogDebug("Sending SSE event {EventType} for message {MessageId} to workflow {WorkflowId}, participant {ParticipantId}",
-                        eventType, message.Id, _workflowId, _participantId);
+                        LogSanitizer.Sanitize(eventType), LogSanitizer.Sanitize(message.Id), LogSanitizer.Sanitize(_workflowId), LogSanitizer.Sanitize(_participantId));
 
                 await SSEEventWriter.WriteEventAsync(_httpContext.Response, eventType, 
                     MessageEventFilter.CreateMessageEventData(message), 
@@ -112,12 +113,12 @@ public class SSEStreamHandler
         }
         catch (Exception ex) when (ex is OperationCanceledException || _cancellationToken.IsCancellationRequested)
         {
-            _logger.LogDebug("SSE connection cancelled for workflow {WorkflowId}, participant {ParticipantId}", _workflowId, _participantId);
+            _logger.LogDebug("SSE connection cancelled for workflow {WorkflowId}, participant {ParticipantId}", LogSanitizer.Sanitize(_workflowId), LogSanitizer.Sanitize(_participantId));
             _completionSource?.TrySetResult(true);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error handling SSE message event for workflow {WorkflowId}, participant {ParticipantId}", _workflowId, _participantId);
+            _logger.LogError(ex, "Error handling SSE message event for workflow {WorkflowId}, participant {ParticipantId}", LogSanitizer.Sanitize(_workflowId), LogSanitizer.Sanitize(_participantId));
         }
     }
 
@@ -148,6 +149,6 @@ public class SSEStreamHandler
         _messageEventPublisher.MessageReceived -= HandleMessage;
         
         _logger.LogInformation("SSE connection closed for workflow {WorkflowId}, participant {ParticipantId}, tenant {TenantId}",
-            _workflowId, _participantId, _tenantId);
+            LogSanitizer.Sanitize(_workflowId), LogSanitizer.Sanitize(_participantId), LogSanitizer.Sanitize(_tenantId));
     }
 } 

--- a/XiansAi.Server.Src/Features/WebApi/Auth/UnifiedAuthRequirement.cs
+++ b/XiansAi.Server.Src/Features/WebApi/Auth/UnifiedAuthRequirement.cs
@@ -116,11 +116,11 @@ public class AuthRequirementHandler : AuthorizationHandler<AuthRequirement>
         var success = await TryAuthorizeWithRetry(context, httpContext, requirement);
         if (!success)
         {
-            _logger.LogWarning("Authorization failed for requirement: {RequirementType}", requirement.GetType().Name);
+            _logger.LogWarning("Authorization failed for requirement: {RequirementType}", LogSanitizer.Sanitize(requirement.GetType().Name));
             return; // Context.Fail() already called in TryAuthorize methods
         }
         
-        _logger.LogInformation("Authorization succeeded for requirement: {RequirementType}", requirement.GetType().Name);
+        _logger.LogInformation("Authorization succeeded for requirement: {RequirementType}", LogSanitizer.Sanitize(requirement.GetType().Name));
         context.Succeed(requirement);
     }
     
@@ -200,7 +200,7 @@ public class AuthRequirementHandler : AuthorizationHandler<AuthRequirement>
                 var tenantResult = await _tenantService.GetTenantByTenantId(currentTenantId, httpContext.RequestAborted);
                 if (!tenantResult.IsSuccess || tenantResult.Data == null)
                 {
-                    _logger.LogWarning("Tenant configuration not found for tenant ID: {TenantId}", currentTenantId);
+                    _logger.LogWarning("Tenant configuration not found for tenant ID: {TenantId}", LogSanitizer.Sanitize(currentTenantId));
                     context.Fail(new AuthorizationFailureReason(this, 
                         $"Tenant {currentTenantId} configuration not found"));
                     return false;
@@ -209,7 +209,7 @@ public class AuthRequirementHandler : AuthorizationHandler<AuthRequirement>
                 // Check if tenant is enabled
                 if (!tenantResult.Data.Enabled)
                 {
-                    _logger.LogWarning("Tenant {TenantId} is disabled", currentTenantId);
+                    _logger.LogWarning("Tenant {TenantId} is disabled", LogSanitizer.Sanitize(currentTenantId));
                     context.Fail(new AuthorizationFailureReason(this, 
                         $"Tenant {currentTenantId} is disabled"));
                     return false;
@@ -284,7 +284,7 @@ public class AuthRequirementHandler : AuthorizationHandler<AuthRequirement>
             
             if (!userTenants.IsSuccess)
             {
-                _logger.LogWarning("Failed to get or create user tenants for {UserId}: {Error}", tokenUserId, userTenants.ErrorMessage);
+                _logger.LogWarning("Failed to get or create user tenants for {UserId}: {Error}", LogSanitizer.Sanitize(tokenUserId), LogSanitizer.Sanitize(userTenants.ErrorMessage));
                 return (false, null, null);
             }
             

--- a/XiansAi.Server.Src/Features/WebApi/Endpoints/TenantEndpoints.cs
+++ b/XiansAi.Server.Src/Features/WebApi/Endpoints/TenantEndpoints.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Features.WebApi.Auth;
 using Shared.Utils.Services;
 using Shared.Services;
+using Shared.Utils;
 
 namespace Features.WebApi.Endpoints;
 

--- a/XiansAi.Server.Src/Features/WebApi/Services/AgentService.cs
+++ b/XiansAi.Server.Src/Features/WebApi/Services/AgentService.cs
@@ -5,6 +5,7 @@ using Shared.Utils.Services;
 using Features.WebApi.Models;
 using Shared.Services;
 using System.ComponentModel.DataAnnotations;
+using Shared.Utils;
 
 namespace Features.WebApi.Services;
 
@@ -87,13 +88,13 @@ public class AgentService : IAgentService
             var agents = await _agentRepository.GetAgentsWithPermissionAsync(_tenantContext.LoggedInUser, tenantIdToQuery);
             var agentNames = agents.Select(a => a.Name).ToList();
             
-            _logger.LogInformation("Found {Count} agents for scope {Scope}", agentNames.Count, scope ?? "default");
+            _logger.LogInformation("Found {Count} agents for scope {Scope}", agentNames.Count, LogSanitizer.Sanitize(scope ?? "default"));
             
             return ServiceResult<List<string>>.Success(agentNames);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error retrieving agent names for scope {Scope}", scope ?? "default");
+            _logger.LogError(ex, "Error retrieving agent names for scope {Scope}", LogSanitizer.Sanitize(scope ?? "default"));
             return ServiceResult<List<string>>.InternalServerError("An error occurred while retrieving agent names");
         }
     }
@@ -102,7 +103,7 @@ public class AgentService : IAgentService
     {
         try
         {
-            _logger.LogInformation("Getting grouped definitions for user {UserId} in tenant {Tenant}", _tenantContext.LoggedInUser, _tenantContext.TenantId);   
+            _logger.LogInformation("Getting grouped definitions for user {UserId} in tenant {Tenant}", LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(_tenantContext.TenantId));   
             var definitions = await _agentRepository.GetAgentsWithDefinitionsAsync(_tenantContext.LoggedInUser, _tenantContext.TenantId, null, null, basicDataOnly: basicDataOnly);
             return ServiceResult<List<AgentWithDefinitions>>.Success(definitions);
         }
@@ -136,7 +137,7 @@ public class AgentService : IAgentService
                 if (!readPermissionResult.Data)
                 {
                     _logger.LogWarning("User {UserId} attempted to access workflows for agent {AgentName} without read permission",
-                        _tenantContext.LoggedInUser, agentName);
+                        LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(agentName));
                     return ServiceResult<List<WorkflowResponse>>.Forbidden("You do not have permission to access workflows for this agent");
                 }
             }
@@ -155,13 +156,13 @@ public class AgentService : IAgentService
             else
             {
                 _logger.LogWarning("Workflow service returned error for agent {AgentName} and type {TypeName}: {Error}",
-                    agentName, typeName, workflowResult.ErrorMessage);
+                    LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(typeName), LogSanitizer.Sanitize(workflowResult.ErrorMessage));
                 return ServiceResult<List<WorkflowResponse>>.BadRequest(workflowResult.ErrorMessage ?? "Failed to retrieve workflows");
             }
         }
         catch (ValidationException ex)
         {
-            _logger.LogWarning("Validation failed while retrieving workflows: {Message}", ex.Message);
+            _logger.LogWarning("Validation failed while retrieving workflows: {Message}", LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<List<WorkflowResponse>>.BadRequest($"Validation failed: {ex.Message}");
         }
         catch (Exception ex)
@@ -196,7 +197,7 @@ public class AgentService : IAgentService
             if (!ownerPermissionResult.Data)
             {
                 _logger.LogWarning("User {UserId} attempted to delete agent {AgentName} without owner permission",
-                    _tenantContext.LoggedInUser, agentName);
+                    LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(agentName));
                 return ServiceResult<AgentDeleteResult>.Forbidden("You must have owner permission to delete this agent");
             }
 
@@ -204,7 +205,7 @@ public class AgentService : IAgentService
             var agent = await _agentRepository.GetByNameInternalAsync(agentName, _tenantContext.TenantId);
             if (agent == null)
             {
-                _logger.LogWarning("Agent {AgentName} not found for deletion", agentName);
+                _logger.LogWarning("Agent {AgentName} not found for deletion", LogSanitizer.Sanitize(agentName));
                 return ServiceResult<AgentDeleteResult>.NotFound("Agent not found");
             }
 
@@ -212,11 +213,11 @@ public class AgentService : IAgentService
             var agentDeleted = await _agentRepository.DeleteAsync(agent.Id, _tenantContext.LoggedInUser, _tenantContext.UserRoles);
             if (!agentDeleted)
             {
-                _logger.LogError("Failed to delete agent {AgentName} with ID {AgentId}", agentName, agent.Id);
+                _logger.LogError("Failed to delete agent {AgentName} with ID {AgentId}", LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(agent.Id));
                 return ServiceResult<AgentDeleteResult>.BadRequest("Failed to delete the agent");
             }
 
-            _logger.LogInformation("Successfully deleted agent {AgentName} and its associated flow definitions", agentName);
+            _logger.LogInformation("Successfully deleted agent {AgentName} and its associated flow definitions", LogSanitizer.Sanitize(agentName));
 
             var result = new AgentDeleteResult
             {
@@ -227,12 +228,12 @@ public class AgentService : IAgentService
         }
         catch (ValidationException ex)
         {
-            _logger.LogWarning("Validation failed while deleting agent: {Message}", ex.Message);
+            _logger.LogWarning("Validation failed while deleting agent: {Message}", LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<AgentDeleteResult>.BadRequest($"Validation failed: {ex.Message}");
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error deleting agent {AgentName}", agentName);
+            _logger.LogError(ex, "Error deleting agent {AgentName}", LogSanitizer.Sanitize(agentName));
             return ServiceResult<AgentDeleteResult>.InternalServerError("An error occurred while deleting the agent");
         }
     }
@@ -262,7 +263,7 @@ public class AgentService : IAgentService
             if (!readPermissionResult.Data)
             {
                 _logger.LogWarning("User {UserId} attempted to access agent {AgentName} without read permission",
-                    _tenantContext.LoggedInUser, agentName);
+                    LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(agentName));
                 return ServiceResult<List<FlowDefinition>>.Forbidden("You do not have permission to access this agent");
             }
 
@@ -273,12 +274,12 @@ public class AgentService : IAgentService
         }
         catch (ValidationException ex)
         {
-            _logger.LogWarning("Validation failed while retrieving definitions: {Message}", ex.Message);
+            _logger.LogWarning("Validation failed while retrieving definitions: {Message}", LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<List<FlowDefinition>>.BadRequest($"Validation failed: {ex.Message}");
         }   
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error retrieving definitions for agent {AgentName}", agentName);
+            _logger.LogError(ex, "Error retrieving definitions for agent {AgentName}", LogSanitizer.Sanitize(agentName));
             return ServiceResult<List<FlowDefinition>>.InternalServerError("An error occurred while retrieving agent definitions");
         }
     }

--- a/XiansAi.Server.Src/Features/WebApi/Services/AuditingService.cs
+++ b/XiansAi.Server.Src/Features/WebApi/Services/AuditingService.cs
@@ -3,6 +3,7 @@ using MongoDB.Driver;
 using Features.WebApi.Repositories;
 using Features.WebApi.Models;
 using Shared.Utils.Services;
+using Shared.Utils;
 
 namespace Features.WebApi.Services;
 
@@ -80,7 +81,7 @@ public class AuditingService : IAuditingService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error retrieving participants for agent {Agent}", agent);
+            _logger.LogError(ex, "Error retrieving participants for agent {Agent}", LogSanitizer.Sanitize(agent));
             return ServiceResult<(IEnumerable<string?> participants, long totalCount)>.InternalServerError("An error occurred while retrieving participants");
         }
     }
@@ -107,7 +108,7 @@ public class AuditingService : IAuditingService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error retrieving workflow types for agent {Agent} and participant {ParticipantId}", agent, participantId);
+            _logger.LogError(ex, "Error retrieving workflow types for agent {Agent} and participant {ParticipantId}", LogSanitizer.Sanitize(agent), LogSanitizer.Sanitize(participantId));
             return ServiceResult<IEnumerable<string>>.InternalServerError("An error occurred while retrieving workflow types");
         }
     }
@@ -142,7 +143,7 @@ public class AuditingService : IAuditingService
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error retrieving workflow IDs for agent {Agent}, workflow type {WorkflowType}, and participant {ParticipantId}", 
-                agent, workflowType, participantId);
+                LogSanitizer.Sanitize(agent), LogSanitizer.Sanitize(workflowType), LogSanitizer.Sanitize(participantId));
             return ServiceResult<IEnumerable<string>>.InternalServerError("An error occurred while retrieving workflow IDs");
         }
     }
@@ -195,7 +196,7 @@ public class AuditingService : IAuditingService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error retrieving logs for agent {Agent}", agent);
+            _logger.LogError(ex, "Error retrieving logs for agent {Agent}", LogSanitizer.Sanitize(agent));
             return ServiceResult<(IEnumerable<Log> logs, long totalCount)>.InternalServerError("An error occurred while retrieving logs");
         }
     }

--- a/XiansAi.Server.Src/Features/WebApi/Services/DocumentService.cs
+++ b/XiansAi.Server.Src/Features/WebApi/Services/DocumentService.cs
@@ -8,6 +8,7 @@ using Shared.Data.Models;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using System.Text.Json;
+using Shared.Utils;
 
 namespace Features.WebApi.Services;
 
@@ -66,7 +67,7 @@ public class DocumentService : IDocumentService
             var agent = await _agentRepository.GetByNameInternalAsync(agentId, _tenantContext.TenantId);
             if (agent == null)
             {
-                _logger.LogWarning("Agent {AgentId} not found", agentId);
+                _logger.LogWarning("Agent {AgentId} not found", LogSanitizer.Sanitize(agentId));
                 return ServiceResult<List<string>>.NotFound("Agent not found");
             }
 
@@ -75,7 +76,7 @@ public class DocumentService : IDocumentService
             if (!readPermissionResult.IsSuccess)
             {
                 _logger.LogWarning("Permission check failed for agent {AgentName}: {Error}", 
-                    agent.Name, readPermissionResult.ErrorMessage);
+                    LogSanitizer.Sanitize(agent.Name), LogSanitizer.Sanitize(readPermissionResult.ErrorMessage));
                 return ServiceResult<List<string>>.BadRequest(
                     readPermissionResult.ErrorMessage ?? "Failed to check permissions");
             }
@@ -83,7 +84,7 @@ public class DocumentService : IDocumentService
             if (!readPermissionResult.Data)
             {
                 _logger.LogWarning("User {UserId} attempted to access document types for agent {AgentName} without read permission",
-                    _tenantContext.LoggedInUser, agent.Name);
+                    LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(agent.Name));
                 return ServiceResult<List<string>>.Forbidden(
                     "You do not have permission to access documents for this agent");
             }
@@ -95,7 +96,7 @@ public class DocumentService : IDocumentService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error retrieving document types for agent {AgentId}", agentId);
+            _logger.LogError(ex, "Error retrieving document types for agent {AgentId}", LogSanitizer.Sanitize(agentId));
             return ServiceResult<List<string>>.InternalServerError("Error retrieving document types");
         }
     }
@@ -117,7 +118,7 @@ public class DocumentService : IDocumentService
             var agent = await _agentRepository.GetByNameInternalAsync(agentId, _tenantContext.TenantId);
             if (agent == null)
             {
-                _logger.LogWarning("Agent {AgentId} not found", agentId);
+                _logger.LogWarning("Agent {AgentId} not found", LogSanitizer.Sanitize(agentId));
                 return ServiceResult<DocumentTypesAndActivationsResponse>.NotFound("Agent not found");
             }
 
@@ -126,7 +127,7 @@ public class DocumentService : IDocumentService
             if (!readPermissionResult.IsSuccess)
             {
                 _logger.LogWarning("Permission check failed for agent {AgentName}: {Error}", 
-                    agent.Name, readPermissionResult.ErrorMessage);
+                    LogSanitizer.Sanitize(agent.Name), LogSanitizer.Sanitize(readPermissionResult.ErrorMessage));
                 return ServiceResult<DocumentTypesAndActivationsResponse>.BadRequest(
                     readPermissionResult.ErrorMessage ?? "Failed to check permissions");
             }
@@ -134,7 +135,7 @@ public class DocumentService : IDocumentService
             if (!readPermissionResult.Data)
             {
                 _logger.LogWarning("User {UserId} attempted to access document types and activations for agent {AgentName} without read permission",
-                    _tenantContext.LoggedInUser, agent.Name);
+                    LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(agent.Name));
                 return ServiceResult<DocumentTypesAndActivationsResponse>.Forbidden(
                     "You do not have permission to access documents for this agent");
             }
@@ -155,7 +156,7 @@ public class DocumentService : IDocumentService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error retrieving document types and activations for agent {AgentId}", agentId);
+            _logger.LogError(ex, "Error retrieving document types and activations for agent {AgentId}", LogSanitizer.Sanitize(agentId));
             return ServiceResult<DocumentTypesAndActivationsResponse>.InternalServerError("Error retrieving document types and activations");
         }
     }
@@ -187,7 +188,7 @@ public class DocumentService : IDocumentService
             var agent = await _agentRepository.GetByNameInternalAsync(agentId, _tenantContext.TenantId);
             if (agent == null)
             {
-                _logger.LogWarning("Agent {AgentId} not found", agentId);
+                _logger.LogWarning("Agent {AgentId} not found", LogSanitizer.Sanitize(agentId));
                 return ServiceResult<DocumentListResponse>.NotFound("Agent not found");
             }
 
@@ -196,7 +197,7 @@ public class DocumentService : IDocumentService
             if (!readPermissionResult.IsSuccess)
             {
                 _logger.LogWarning("Permission check failed for agent {AgentName}: {Error}", 
-                    agent.Name, readPermissionResult.ErrorMessage);
+                    LogSanitizer.Sanitize(agent.Name), LogSanitizer.Sanitize(readPermissionResult.ErrorMessage));
                 return ServiceResult<DocumentListResponse>.BadRequest(
                     readPermissionResult.ErrorMessage ?? "Failed to check permissions");
             }
@@ -204,7 +205,7 @@ public class DocumentService : IDocumentService
             if (!readPermissionResult.Data)
             {
                 _logger.LogWarning("User {UserId} attempted to access documents for agent {AgentName} without read permission",
-                    _tenantContext.LoggedInUser, agent.Name);
+                    LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(agent.Name));
                 return ServiceResult<DocumentListResponse>.Forbidden(
                     "You do not have permission to access documents for this agent");
             }
@@ -260,7 +261,7 @@ public class DocumentService : IDocumentService
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error retrieving documents for agent {AgentId}, type {Type}, activation {ActivationName}", 
-                agentId, type, activationName ?? "all");
+                LogSanitizer.Sanitize(agentId), LogSanitizer.Sanitize(type), LogSanitizer.Sanitize(activationName ?? "all"));
             return ServiceResult<DocumentListResponse>.InternalServerError("Error retrieving documents");
         }
     }
@@ -289,7 +290,7 @@ public class DocumentService : IDocumentService
             if (!string.IsNullOrEmpty(document.TenantId) && document.TenantId != _tenantContext.TenantId)
             {
                 _logger.LogWarning("User {UserId} attempted to access document {DocumentId} from different tenant",
-                    _tenantContext.LoggedInUser, id);
+                    LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(id));
                 return ServiceResult<DocumentDto<JsonElement>>.Forbidden("Access denied");
             }
 
@@ -300,7 +301,7 @@ public class DocumentService : IDocumentService
                 if (agent == null)
                 {
                     _logger.LogWarning("Agent {AgentId} not found for document {DocumentId}", 
-                        document.AgentId, id);
+                        LogSanitizer.Sanitize(document.AgentId), LogSanitizer.Sanitize(id));
                     return ServiceResult<DocumentDto<JsonElement>>.NotFound("Associated agent not found");
                 }
 
@@ -309,7 +310,7 @@ public class DocumentService : IDocumentService
                 if (!readPermissionResult.IsSuccess)
                 {
                     _logger.LogWarning("Permission check failed for agent {AgentName}: {Error}", 
-                        agent.Name, readPermissionResult.ErrorMessage);
+                        LogSanitizer.Sanitize(agent.Name), LogSanitizer.Sanitize(readPermissionResult.ErrorMessage));
                     return ServiceResult<DocumentDto<JsonElement>>.BadRequest(
                         readPermissionResult.ErrorMessage ?? "Failed to check permissions");
                 }
@@ -317,7 +318,7 @@ public class DocumentService : IDocumentService
                 if (!readPermissionResult.Data)
                 {
                     _logger.LogWarning("User {UserId} attempted to access document {DocumentId} for agent {AgentName} without read permission",
-                        _tenantContext.LoggedInUser, id, agent.Name);
+                        LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(id), LogSanitizer.Sanitize(agent.Name));
                     return ServiceResult<DocumentDto<JsonElement>>.Forbidden(
                         "You do not have permission to access documents for this agent");
                 }
@@ -328,7 +329,7 @@ public class DocumentService : IDocumentService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error retrieving document with ID {Id}", id);
+            _logger.LogError(ex, "Error retrieving document with ID {Id}", LogSanitizer.Sanitize(id));
             return ServiceResult<DocumentDto<JsonElement>>.InternalServerError("Error retrieving document");
         }
     }
@@ -357,7 +358,7 @@ public class DocumentService : IDocumentService
             if (!string.IsNullOrEmpty(existing.TenantId) && existing.TenantId != _tenantContext.TenantId)
             {
                 _logger.LogWarning("User {UserId} attempted to update document {DocumentId} from different tenant",
-                    _tenantContext.LoggedInUser, id);
+                    LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(id));
                 return ServiceResult<DocumentDto<JsonElement>>.Forbidden("Access denied");
             }
 
@@ -368,7 +369,7 @@ public class DocumentService : IDocumentService
                 if (agent == null)
                 {
                     _logger.LogWarning("Agent {AgentId} not found for document {DocumentId}", 
-                        existing.AgentId, id);
+                        LogSanitizer.Sanitize(existing.AgentId), LogSanitizer.Sanitize(id));
                     return ServiceResult<DocumentDto<JsonElement>>.NotFound("Associated agent not found");
                 }
 
@@ -377,7 +378,7 @@ public class DocumentService : IDocumentService
                 if (!writePermissionResult.IsSuccess)
                 {
                     _logger.LogWarning("Permission check failed for agent {AgentName}: {Error}", 
-                        agent.Name, writePermissionResult.ErrorMessage);
+                        LogSanitizer.Sanitize(agent.Name), LogSanitizer.Sanitize(writePermissionResult.ErrorMessage));
                     return ServiceResult<DocumentDto<JsonElement>>.BadRequest(
                         writePermissionResult.ErrorMessage ?? "Failed to check permissions");
                 }
@@ -385,7 +386,7 @@ public class DocumentService : IDocumentService
                 if (!writePermissionResult.Data)
                 {
                     _logger.LogWarning("User {UserId} attempted to update document {DocumentId} for agent {AgentName} without write permission",
-                        _tenantContext.LoggedInUser, id, agent.Name);
+                        LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(id), LogSanitizer.Sanitize(agent.Name));
                     return ServiceResult<DocumentDto<JsonElement>>.Forbidden(
                         "You do not have permission to modify documents for this agent");
                 }
@@ -433,7 +434,7 @@ public class DocumentService : IDocumentService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error updating document with ID {Id}", id);
+            _logger.LogError(ex, "Error updating document with ID {Id}", LogSanitizer.Sanitize(id));
             return ServiceResult<DocumentDto<JsonElement>>.InternalServerError("Error updating document");
         }
     }
@@ -462,7 +463,7 @@ public class DocumentService : IDocumentService
             if (!string.IsNullOrEmpty(document.TenantId) && document.TenantId != _tenantContext.TenantId)
             {
                 _logger.LogWarning("User {UserId} attempted to delete document {DocumentId} from different tenant",
-                    _tenantContext.LoggedInUser, id);
+                    LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(id));
                 return ServiceResult<bool>.Forbidden("Access denied");
             }
 
@@ -473,7 +474,7 @@ public class DocumentService : IDocumentService
                 if (agent == null)
                 {
                     _logger.LogWarning("Agent {AgentId} not found for document {DocumentId}", 
-                        document.AgentId, id);
+                        LogSanitizer.Sanitize(document.AgentId), LogSanitizer.Sanitize(id));
                     return ServiceResult<bool>.NotFound("Associated agent not found");
                 }
 
@@ -482,7 +483,7 @@ public class DocumentService : IDocumentService
                 if (!writePermissionResult.IsSuccess)
                 {
                     _logger.LogWarning("Permission check failed for agent {AgentName}: {Error}", 
-                        agent.Name, writePermissionResult.ErrorMessage);
+                        LogSanitizer.Sanitize(agent.Name), LogSanitizer.Sanitize(writePermissionResult.ErrorMessage));
                     return ServiceResult<bool>.BadRequest(
                         writePermissionResult.ErrorMessage ?? "Failed to check permissions");
                 }
@@ -490,7 +491,7 @@ public class DocumentService : IDocumentService
                 if (!writePermissionResult.Data)
                 {
                     _logger.LogWarning("User {UserId} attempted to delete document {DocumentId} for agent {AgentName} without write permission",
-                        _tenantContext.LoggedInUser, id, agent.Name);
+                        LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(id), LogSanitizer.Sanitize(agent.Name));
                     return ServiceResult<bool>.Forbidden(
                         "You do not have permission to delete documents for this agent");
                 }
@@ -506,7 +507,7 @@ public class DocumentService : IDocumentService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error deleting document with ID {Id}", id);
+            _logger.LogError(ex, "Error deleting document with ID {Id}", LogSanitizer.Sanitize(id));
             return ServiceResult<bool>.InternalServerError("Error deleting document");
         }
     }
@@ -533,7 +534,7 @@ public class DocumentService : IDocumentService
                 var document = await _repository.GetByIdAsync(id);
                 if (document == null)
                 {
-                    _logger.LogWarning("Document {DocumentId} not found, skipping", id);
+                    _logger.LogWarning("Document {DocumentId} not found, skipping", LogSanitizer.Sanitize(id));
                     continue;
                 }
 
@@ -541,7 +542,7 @@ public class DocumentService : IDocumentService
                 if (!string.IsNullOrEmpty(document.TenantId) && document.TenantId != _tenantContext.TenantId)
                 {
                     _logger.LogWarning("User {UserId} attempted to delete document {DocumentId} from different tenant",
-                        _tenantContext.LoggedInUser, id);
+                        LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(id));
                     permissionDenied.Add(id);
                     continue;
                 }
@@ -553,7 +554,7 @@ public class DocumentService : IDocumentService
                     if (agent == null)
                     {
                         _logger.LogWarning("Agent {AgentId} not found for document {DocumentId}", 
-                            document.AgentId, id);
+                            LogSanitizer.Sanitize(document.AgentId), LogSanitizer.Sanitize(id));
                         permissionDenied.Add(id);
                         continue;
                     }
@@ -563,7 +564,7 @@ public class DocumentService : IDocumentService
                     if (!writePermissionResult.IsSuccess || !writePermissionResult.Data)
                     {
                         _logger.LogWarning("User {UserId} does not have write permission for agent {AgentName} (document {DocumentId})",
-                            _tenantContext.LoggedInUser, agent.Name, id);
+                            LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(agent.Name), LogSanitizer.Sanitize(id));
                         permissionDenied.Add(id);
                         continue;
                     }
@@ -575,7 +576,7 @@ public class DocumentService : IDocumentService
             if (permissionDenied.Any())
             {
                 _logger.LogWarning("User {UserId} was denied permission to delete {Count} documents",
-                    _tenantContext.LoggedInUser, permissionDenied.Count);
+                    LogSanitizer.Sanitize(_tenantContext.LoggedInUser), permissionDenied.Count);
                 return ServiceResult<BulkDeleteResult>.Forbidden(
                     $"Permission denied for {permissionDenied.Count} document(s)");
             }

--- a/XiansAi.Server.Src/Features/WebApi/Services/LogsService.cs
+++ b/XiansAi.Server.Src/Features/WebApi/Services/LogsService.cs
@@ -1,6 +1,7 @@
 using Features.WebApi.Repositories;
 using Shared.Utils.Services;
 using Features.WebApi.Models;
+using Shared.Utils;
 
 namespace Features.WebApi.Services;
 
@@ -46,12 +47,12 @@ public class LogsService : ILogsService
                 request.Limit, 
                 request.LogLevel
             );
-            _logger.LogInformation("Found {Count} logs for workflow {WorkflowRunId}", logs.Count, request.WorkflowRunId);
+            _logger.LogInformation("Found {Count} logs for workflow {WorkflowRunId}", logs.Count, LogSanitizer.Sanitize(request.WorkflowRunId));
             return ServiceResult<List<Log>>.Success(logs);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error getting logs by workflow run id: {WorkflowRunId}", request.WorkflowRunId);
+            _logger.LogError(ex, "Error getting logs by workflow run id: {WorkflowRunId}", LogSanitizer.Sanitize(request.WorkflowRunId));
             return ServiceResult<List<Log>>.InternalServerError("An error occurred while retrieving the logs");
         }
     }

--- a/XiansAi.Server.Src/Features/WebApi/Services/MessagingService.cs
+++ b/XiansAi.Server.Src/Features/WebApi/Services/MessagingService.cs
@@ -4,6 +4,7 @@ using Shared.Repositories;
 using Shared.Services;
 using Shared.Utils.Services;
 using System.ComponentModel.DataAnnotations;
+using Shared.Utils;
 
 namespace Features.WebApi.Services;
 
@@ -131,13 +132,13 @@ public class MessagingService : IMessagingService
 
             var result = await _conversationRepository.GetTopicsByThreadIdAsync(tenantId, threadId, page, pageSize);
             
-            _logger.LogDebug("GetTopics returned {Count} topics for thread {ThreadId}", result.Topics.Count, threadId);
+            _logger.LogDebug("GetTopics returned {Count} topics for thread {ThreadId}", result.Topics.Count, LogSanitizer.Sanitize(threadId));
             
             return ServiceResult<TopicsResult>.Success(result);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error retrieving topics for thread {ThreadId}", threadId);
+            _logger.LogError(ex, "Error retrieving topics for thread {ThreadId}", LogSanitizer.Sanitize(threadId));
             return ServiceResult<TopicsResult>.InternalServerError("An error occurred while retrieving topics");
         }
     }
@@ -179,13 +180,13 @@ public class MessagingService : IMessagingService
 
             var threads = await _conversationRepository.GetByTenantAndAgentAsync(tenantId, validatedAgentName, page, pageSize);
             
-            _logger.LogDebug("GetThreads returned {Count} threads for agent {Agent}", threads.Count, validatedAgentName);
+            _logger.LogDebug("GetThreads returned {Count} threads for agent {Agent}", threads.Count, LogSanitizer.Sanitize(validatedAgentName));
             
             return ServiceResult<List<ConversationThread>>.Success(threads);
         }
         catch (ValidationException ex)
         {
-            _logger.LogWarning("Validation failed while retrieving threads: {Message}", ex.Message);
+            _logger.LogWarning("Validation failed while retrieving threads: {Message}", LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<List<ConversationThread>>.BadRequest($"Validation failed: {ex.Message}");
         }
     }
@@ -208,7 +209,7 @@ public class MessagingService : IMessagingService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error deleting thread {ThreadId}", threadId);
+            _logger.LogError(ex, "Error deleting thread {ThreadId}", LogSanitizer.Sanitize(threadId));
             return ServiceResult<bool>.InternalServerError("An error occurred while deleting the thread");
         }
     }

--- a/XiansAi.Server.Src/Features/WebApi/Services/RoleManagementService.cs
+++ b/XiansAi.Server.Src/Features/WebApi/Services/RoleManagementService.cs
@@ -5,6 +5,7 @@ using Shared.Data.Models;
 using Shared.Providers.Auth;
 using Shared.Services;
 using Shared.Repositories;
+using Shared.Utils;
 
 namespace Features.WebApi.Services
 {
@@ -93,7 +94,7 @@ namespace Features.WebApi.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error assigning bootstrap sysadmin roles to user {UserId}", _tenantContext.LoggedInUser);
+                _logger.LogError(ex, "Error assigning bootstrap sysadmin roles to user {UserId}", LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
                 return ServiceResult<bool>.InternalServerError("An error occurred while assigning bootstrap sysadmin roles.");
             }
         }
@@ -125,7 +126,7 @@ namespace Features.WebApi.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error assigning roles to user {UserId}", userId);
+                _logger.LogError(ex, "Error assigning roles to user {UserId}", LogSanitizer.Sanitize(userId));
                 return ServiceResult<bool>.InternalServerError("Error assigning roles");
             }
         }
@@ -152,7 +153,7 @@ namespace Features.WebApi.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error removing roles from user {UserId}", userId);
+                _logger.LogError(ex, "Error removing roles from user {UserId}", LogSanitizer.Sanitize(userId));
                 return ServiceResult<bool>.InternalServerError("Error removing roles");
             }
         }
@@ -325,7 +326,7 @@ namespace Features.WebApi.Services
                 else if (tenantEntry.Roles.Contains(roleToAssign))
                 {
                     _logger.LogWarning("Role {Role} already assigned to user {UserId} in tenant {TenantId}",
-                        roleToAssign, roleDto.UserId, roleDto.TenantId);
+                        LogSanitizer.Sanitize(roleToAssign), LogSanitizer.Sanitize(roleDto.UserId), LogSanitizer.Sanitize(roleDto.TenantId));
                     return ServiceResult<bool>.Success(true); // Role already exists, no action needed
                 }
                 else if (!tenantEntry.Roles.Contains(roleToAssign))
@@ -360,7 +361,7 @@ namespace Features.WebApi.Services
                 if (string.IsNullOrEmpty(_tenantContext.TenantId))
                 {
                     _logger.LogWarning("No tenant ID found in context for user {UserId}",
-                        _tenantContext.LoggedInUser);
+                        LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
                     return ServiceResult<List<string>>.BadRequest("No tenant ID found in context");
                 }
 
@@ -384,8 +385,8 @@ namespace Features.WebApi.Services
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error retrieving current user roles for user {UserId} in tenant {TenantId}",
-                    _tenantContext.LoggedInUser,
-                    _tenantContext.TenantId);
+                    LogSanitizer.Sanitize(_tenantContext.LoggedInUser),
+                    LogSanitizer.Sanitize(_tenantContext.TenantId));
                 return ServiceResult<List<string>>.InternalServerError("An error occurred while retrieving current user roles");
             }
         }
@@ -404,7 +405,7 @@ namespace Features.WebApi.Services
                 if (!_tenantContext.TenantId.Equals(tenantId, StringComparison.OrdinalIgnoreCase))
                 {
                     _logger.LogWarning("Tenant admin {UserId} attempted to {Operation} in different tenant {TenantId}",
-                        _tenantContext.LoggedInUser, operation, tenantId);
+                        LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(operation), LogSanitizer.Sanitize(tenantId));
                     return ServiceResult.Failure("Tenant admins can only access their own tenant", StatusCode.Forbidden);
                 }
                 return ServiceResult.Success();
@@ -412,7 +413,7 @@ namespace Features.WebApi.Services
 
             // Regular users need to be at least tenant admin
             _logger.LogWarning("User {UserId} attempted to {Operation} without proper permissions",
-                _tenantContext.LoggedInUser, operation);
+                LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(operation));
             return ServiceResult.Failure("Insufficient permissions to manage roles", StatusCode.Forbidden);
         }
 

--- a/XiansAi.Server.Src/Features/WebApi/Services/ScheduleService.cs
+++ b/XiansAi.Server.Src/Features/WebApi/Services/ScheduleService.cs
@@ -6,6 +6,7 @@ using Shared.Services;
 using Shared.Repositories;
 using Temporalio.Client;
 using System.Text.Json;
+using Shared.Utils;
 
 namespace Features.WebApi.Services;
 
@@ -151,7 +152,7 @@ public class ScheduleService : IScheduleService
                         if (!hasPermission)
                         {
                             _logger.LogDebug("Skipping schedule {ScheduleId} - user lacks permission for agent {AgentName}", 
-                                scheduleId, scheduleModel.AgentName);
+                                LogSanitizer.Sanitize(scheduleId), LogSanitizer.Sanitize(scheduleModel.AgentName));
                             continue;
                         }
                     }
@@ -182,12 +183,12 @@ public class ScheduleService : IScheduleService
                 }
                 catch (Exception ex) when (ex.Message.Contains("not found") || ex.Message.Contains("NotFound"))
                 {
-                    _logger.LogDebug("Schedule {ScheduleId} was found in listing but not found when describing - likely recently deleted or stale cache", schedule.Id);
+                    _logger.LogDebug("Schedule {ScheduleId} was found in listing but not found when describing - likely recently deleted or stale cache", LogSanitizer.Sanitize(schedule.Id));
                     // Continue with other schedules - this is normal when schedules are recently deleted
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogWarning(ex, "Failed to process schedule {ScheduleId}", schedule.Id);
+                    _logger.LogWarning(ex, "Failed to process schedule {ScheduleId}", LogSanitizer.Sanitize(schedule.Id));
                     // Continue with other schedules instead of failing completely
                 }
             }
@@ -230,12 +231,12 @@ public class ScheduleService : IScheduleService
                 });
             }
             
-            _logger.LogInformation("Retrieved {Count} upcoming runs for schedule {ScheduleId}", upcomingRuns.Count, scheduleId);
+            _logger.LogInformation("Retrieved {Count} upcoming runs for schedule {ScheduleId}", upcomingRuns.Count, LogSanitizer.Sanitize(scheduleId));
             return ServiceResult<List<ScheduleRunModel>>.Success(upcomingRuns);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to get upcoming runs for schedule {ScheduleId}", scheduleId);
+            _logger.LogError(ex, "Failed to get upcoming runs for schedule {ScheduleId}", LogSanitizer.Sanitize(scheduleId));
             return ServiceResult<List<ScheduleRunModel>>.InternalServerError($"Failed to retrieve upcoming runs: {ex.Message}");
         }
     }
@@ -275,12 +276,12 @@ public class ScheduleService : IScheduleService
             // Sort by scheduled time descending (most recent first)
             historyRuns = historyRuns.OrderByDescending(r => r.ScheduledTime).ToList();
             
-            _logger.LogInformation("Retrieved {Count} history runs for schedule {ScheduleId}", historyRuns.Count, scheduleId);
+            _logger.LogInformation("Retrieved {Count} history runs for schedule {ScheduleId}", historyRuns.Count, LogSanitizer.Sanitize(scheduleId));
             return ServiceResult<List<ScheduleRunModel>>.Success(historyRuns);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to get schedule history for schedule {ScheduleId}", scheduleId);
+            _logger.LogError(ex, "Failed to get schedule history for schedule {ScheduleId}", LogSanitizer.Sanitize(scheduleId));
             return ServiceResult<List<ScheduleRunModel>>.InternalServerError($"Failed to retrieve schedule history: {ex.Message}");
         }
     }
@@ -296,17 +297,17 @@ public class ScheduleService : IScheduleService
             // Create a simple mock entry for mapping
             var schedule = MapToScheduleModel(scheduleId, description);
             
-            _logger.LogInformation("Retrieved schedule {ScheduleId}", scheduleId);
+            _logger.LogInformation("Retrieved schedule {ScheduleId}", LogSanitizer.Sanitize(scheduleId));
             return ServiceResult<ScheduleModel>.Success(schedule);
         }
         catch (Exception ex) when (ex.Message.Contains("not found") || ex.Message.Contains("NotFound"))
         {
-            _logger.LogWarning("Schedule {ScheduleId} not found", scheduleId);
+            _logger.LogWarning("Schedule {ScheduleId} not found", LogSanitizer.Sanitize(scheduleId));
             return ServiceResult<ScheduleModel>.NotFound($"Schedule {scheduleId} not found");
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to get schedule {ScheduleId}", scheduleId);
+            _logger.LogError(ex, "Failed to get schedule {ScheduleId}", LogSanitizer.Sanitize(scheduleId));
             return ServiceResult<ScheduleModel>.InternalServerError($"Failed to retrieve schedule: {ex.Message}");
         }
     }
@@ -358,7 +359,7 @@ public class ScheduleService : IScheduleService
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Failed to calculate last run time for schedule {ScheduleId}", scheduleId);
+                _logger.LogWarning(ex, "Failed to calculate last run time for schedule {ScheduleId}", LogSanitizer.Sanitize(scheduleId));
                 lastRunTime = null;
             }
         }
@@ -393,7 +394,7 @@ public class ScheduleService : IScheduleService
             if (!readPermissionResult.IsSuccess)
             {
                 _logger.LogWarning("Permission check failed for agent {AgentName}: {Error}", 
-                    agentName, readPermissionResult.ErrorMessage);
+                    LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(readPermissionResult.ErrorMessage));
                 return false;
             }
             
@@ -401,7 +402,7 @@ public class ScheduleService : IScheduleService
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Error checking schedule access for agent {AgentName}", agentName);
+            _logger.LogWarning(ex, "Error checking schedule access for agent {AgentName}", LogSanitizer.Sanitize(agentName));
             return false;
         }
     }
@@ -662,7 +663,7 @@ public class ScheduleService : IScheduleService
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to parse cron expression: {CronExpression}", cronExpression);
+            _logger.LogWarning(ex, "Failed to parse cron expression: {CronExpression}", LogSanitizer.Sanitize(cronExpression));
         }
         
         return from.AddHours(1);
@@ -822,7 +823,7 @@ public class ScheduleService : IScheduleService
                 scheduleModel.TenantId != _tenantContext.TenantId)
             {
                 _logger.LogWarning("Attempted to delete schedule {ScheduleId} from different tenant. Schedule tenant: {ScheduleTenant}, Current tenant: {CurrentTenant}", 
-                    scheduleId, scheduleModel.TenantId, _tenantContext.TenantId);
+                    LogSanitizer.Sanitize(scheduleId), LogSanitizer.Sanitize(scheduleModel.TenantId), LogSanitizer.Sanitize(_tenantContext.TenantId));
                 return ServiceResult<bool>.Forbidden("You do not have permission to delete this schedule");
             }
             
@@ -833,7 +834,7 @@ public class ScheduleService : IScheduleService
                 if (!hasWritePermission.IsSuccess || !hasWritePermission.Data)
                 {
                     _logger.LogWarning("User lacks write permission for agent {AgentName} when attempting to delete schedule {ScheduleId}", 
-                        scheduleModel.AgentName, scheduleId);
+                        LogSanitizer.Sanitize(scheduleModel.AgentName), LogSanitizer.Sanitize(scheduleId));
                     return ServiceResult<bool>.Forbidden($"You do not have permission to delete schedules for agent {scheduleModel.AgentName}");
                 }
             }
@@ -842,18 +843,18 @@ public class ScheduleService : IScheduleService
             await scheduleHandle.DeleteAsync();
             
             _logger.LogInformation("Successfully deleted schedule {ScheduleId} for agent {AgentName}", 
-                scheduleId, scheduleModel.AgentName);
+                LogSanitizer.Sanitize(scheduleId), LogSanitizer.Sanitize(scheduleModel.AgentName));
             
             return ServiceResult<bool>.Success(true);
         }
         catch (Exception ex) when (ex.Message.Contains("not found") || ex.Message.Contains("NotFound"))
         {
-            _logger.LogWarning("Schedule {ScheduleId} not found", scheduleId);
+            _logger.LogWarning("Schedule {ScheduleId} not found", LogSanitizer.Sanitize(scheduleId));
             return ServiceResult<bool>.NotFound($"Schedule {scheduleId} not found");
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to delete schedule {ScheduleId}", scheduleId);
+            _logger.LogError(ex, "Failed to delete schedule {ScheduleId}", LogSanitizer.Sanitize(scheduleId));
             return ServiceResult<bool>.InternalServerError($"Failed to delete schedule: {ex.Message}");
         }
     }
@@ -871,7 +872,7 @@ public class ScheduleService : IScheduleService
             var hasWritePermission = await _permissionsService.HasWritePermission(agentName);
             if (!hasWritePermission.IsSuccess || !hasWritePermission.Data)
             {
-                _logger.LogWarning("User lacks write permission for agent {AgentName}", agentName);
+                _logger.LogWarning("User lacks write permission for agent {AgentName}", LogSanitizer.Sanitize(agentName));
                 return ServiceResult<ScheduleDeleteResult>.Forbidden($"You do not have permission to delete schedules for agent {agentName}");
             }
             
@@ -884,7 +885,7 @@ public class ScheduleService : IScheduleService
             
             if (agent == null)
             {
-                _logger.LogWarning("Agent {AgentName} not found in tenant {TenantId}", agentName, _tenantContext.TenantId);
+                _logger.LogWarning("Agent {AgentName} not found in tenant {TenantId}", LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(_tenantContext.TenantId));
                 return ServiceResult<ScheduleDeleteResult>.NotFound($"Agent {agentName} not found");
             }
             
@@ -905,7 +906,7 @@ public class ScheduleService : IScheduleService
             
             var query = string.Join(" AND ", queryParts);
             
-            _logger.LogInformation("Deleting all schedules for agent {AgentName} with query: {Query}", agentName, query);
+            _logger.LogInformation("Deleting all schedules for agent {AgentName} with query: {Query}", LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(query));
             
             var listOptions = !string.IsNullOrEmpty(query) 
                 ? new Temporalio.Client.Schedules.ScheduleListOptions { Query = query }
@@ -918,7 +919,7 @@ public class ScheduleService : IScheduleService
                 scheduleIds.Add(schedule.Id);
             }
             
-            _logger.LogInformation("Found {Count} schedules to delete for agent {AgentName}", scheduleIds.Count, agentName);
+            _logger.LogInformation("Found {Count} schedules to delete for agent {AgentName}", scheduleIds.Count, LogSanitizer.Sanitize(agentName));
             
             // Delete each schedule
             foreach (var scheduleId in scheduleIds)
@@ -931,23 +932,23 @@ public class ScheduleService : IScheduleService
                     result.DeletedScheduleIds.Add(scheduleId);
                     result.DeletedCount++;
                     
-                    _logger.LogInformation("Successfully deleted schedule {ScheduleId}", scheduleId);
+                    _logger.LogInformation("Successfully deleted schedule {ScheduleId}", LogSanitizer.Sanitize(scheduleId));
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogWarning(ex, "Failed to delete schedule {ScheduleId}", scheduleId);
+                    _logger.LogWarning(ex, "Failed to delete schedule {ScheduleId}", LogSanitizer.Sanitize(scheduleId));
                     result.FailedScheduleIds.Add(scheduleId);
                 }
             }
             
             _logger.LogInformation("Deleted {DeletedCount} schedules for agent {AgentName}. Failed: {FailedCount}", 
-                result.DeletedCount, agentName, result.FailedScheduleIds.Count);
+                result.DeletedCount, LogSanitizer.Sanitize(agentName), result.FailedScheduleIds.Count);
             
             return ServiceResult<ScheduleDeleteResult>.Success(result);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to delete schedules for agent {AgentName}", agentName);
+            _logger.LogError(ex, "Failed to delete schedules for agent {AgentName}", LogSanitizer.Sanitize(agentName));
             return ServiceResult<ScheduleDeleteResult>.InternalServerError($"Failed to delete schedules: {ex.Message}");
         }
     }
@@ -968,7 +969,7 @@ public class ScheduleService : IScheduleService
 
             var query = queryParts.Count > 0 ? string.Join(" AND ", queryParts) : string.Empty;
 
-            _logger.LogInformation("Deleting all schedules for tenant {TenantId}", _tenantContext.TenantId);
+            _logger.LogInformation("Deleting all schedules for tenant {TenantId}", LogSanitizer.Sanitize(_tenantContext.TenantId));
 
             var listOptions = !string.IsNullOrEmpty(query)
                 ? new Temporalio.Client.Schedules.ScheduleListOptions { Query = query }
@@ -980,7 +981,7 @@ public class ScheduleService : IScheduleService
                 scheduleIds.Add(schedule.Id);
             }
 
-            _logger.LogInformation("Found {Count} schedules to delete for tenant {TenantId}", scheduleIds.Count, _tenantContext.TenantId);
+            _logger.LogInformation("Found {Count} schedules to delete for tenant {TenantId}", scheduleIds.Count, LogSanitizer.Sanitize(_tenantContext.TenantId));
 
             foreach (var scheduleId in scheduleIds)
             {
@@ -992,23 +993,23 @@ public class ScheduleService : IScheduleService
                     result.DeletedScheduleIds.Add(scheduleId);
                     result.DeletedCount++;
 
-                    _logger.LogInformation("Successfully deleted schedule {ScheduleId}", scheduleId);
+                    _logger.LogInformation("Successfully deleted schedule {ScheduleId}", LogSanitizer.Sanitize(scheduleId));
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogWarning(ex, "Failed to delete schedule {ScheduleId}", scheduleId);
+                    _logger.LogWarning(ex, "Failed to delete schedule {ScheduleId}", LogSanitizer.Sanitize(scheduleId));
                     result.FailedScheduleIds.Add(scheduleId);
                 }
             }
 
             _logger.LogInformation("Deleted {DeletedCount} schedules for tenant {TenantId}. Failed: {FailedCount}",
-                result.DeletedCount, _tenantContext.TenantId, result.FailedScheduleIds.Count);
+                result.DeletedCount, LogSanitizer.Sanitize(_tenantContext.TenantId), result.FailedScheduleIds.Count);
 
             return ServiceResult<ScheduleDeleteResult>.Success(result);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to delete all schedules for tenant {TenantId}", _tenantContext.TenantId);
+            _logger.LogError(ex, "Failed to delete all schedules for tenant {TenantId}", LogSanitizer.Sanitize(_tenantContext.TenantId));
             return ServiceResult<ScheduleDeleteResult>.InternalServerError($"Failed to delete all schedules: {ex.Message}");
         }
     }

--- a/XiansAi.Server.Src/Features/WebApi/Services/TaskService.cs
+++ b/XiansAi.Server.Src/Features/WebApi/Services/TaskService.cs
@@ -190,7 +190,7 @@ public class TaskService : ITaskService
             }
 
             var listQuery = string.Join(" and ", queryParts);
-            _logger.LogDebug("Executing paginated tasks query: {Query}", listQuery);
+            _logger.LogDebug("Executing paginated tasks query: {Query}", LogSanitizer.Sanitize(listQuery));
 
             // Calculate pagination parameters
             int skipCount = 0;
@@ -264,7 +264,7 @@ public class TaskService : ITaskService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to retrieve paginated tasks. Error: {ErrorMessage}", ex.Message);
+            _logger.LogError(ex, "Failed to retrieve paginated tasks. Error: {ErrorMessage}", LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<PaginatedTasksResponse>.InternalServerError("Failed to retrieve tasks");
         }
     }

--- a/XiansAi.Server.Src/Features/WebApi/Services/WorkflowEventsService.cs
+++ b/XiansAi.Server.Src/Features/WebApi/Services/WorkflowEventsService.cs
@@ -4,6 +4,7 @@ using Temporalio.Api.Enums.V1;
 using Temporalio.Api.History.V1;
 using Temporalio.Client;
 using Shared.Utils.Services;
+using Shared.Utils;
 
 namespace Features.WebApi.Services;
 
@@ -81,7 +82,7 @@ public class WorkflowEventsService : IWorkflowEventsService
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error streaming workflow events for workflow {WorkflowId}", workflowId);
+                _logger.LogError(ex, "Error streaming workflow events for workflow {WorkflowId}", LogSanitizer.Sanitize(workflowId));
             }
         }, "text/event-stream");
     }
@@ -214,13 +215,13 @@ public class WorkflowEventsService : IWorkflowEventsService
             var activityEvents = ExtractActivityEvents(events);
 
             _logger.LogInformation("Successfully extracted {Count} activity events for workflow {WorkflowId}", 
-                activityEvents.Count, workflowId);
+                activityEvents.Count, LogSanitizer.Sanitize(workflowId));
 
             return ServiceResult<List<WorkflowActivityEvent>>.Success(activityEvents);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error fetching workflow events for workflow {WorkflowId}", workflowId);
+            _logger.LogError(ex, "Error fetching workflow events for workflow {WorkflowId}", LogSanitizer.Sanitize(workflowId));
             return ServiceResult<List<WorkflowActivityEvent>>.InternalServerError("Failed to fetch workflow events");
         }
     }

--- a/XiansAi.Server.Src/Features/WebApi/Services/WorkflowFinderService.cs
+++ b/XiansAi.Server.Src/Features/WebApi/Services/WorkflowFinderService.cs
@@ -98,7 +98,7 @@ public class WorkflowFinderService : IWorkflowFinderService
 
         try
         {
-            _logger.LogInformation("Retrieving workflow with ID: {WorkflowId} and workflowRunId: {WorkflowRunId}", workflowId, workflowRunId);
+            _logger.LogInformation("Retrieving workflow with ID: {WorkflowId} and workflowRunId: {WorkflowRunId}", LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(workflowRunId));
             var client = await _clientFactory.GetClientAsync();
             var workflowHandle = client.GetWorkflowHandle(workflowId, workflowRunId);
 
@@ -116,7 +116,7 @@ public class WorkflowFinderService : IWorkflowFinderService
             }
 
             //log the workflow description object
-            _logger.LogDebug("Workflow description: {Description}", JsonSerializer.Serialize(workflowDescription));
+            _logger.LogDebug("Workflow description: {Description}", LogSanitizer.Sanitize(JsonSerializer.Serialize(workflowDescription)));
             string recentWorkerCount = await GetRecentWorkerCount(client, workflowDescription.TaskQueue!);
 
             var history = await workflowHandle.FetchHistoryAsync();
@@ -127,13 +127,13 @@ public class WorkflowFinderService : IWorkflowFinderService
             }
 
             _logger.LogInformation("Successfully retrieved workflow {WorkflowId} of type {WorkflowType}",
-                workflow.WorkflowId, workflow.WorkflowType);
+                LogSanitizer.Sanitize(workflow.WorkflowId), LogSanitizer.Sanitize(workflow.WorkflowType));
             return ServiceResult<WorkflowResponse>.Success(workflow);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to retrieve workflow {WorkflowId}. Error: {ErrorMessage}",
-                workflowId, ex.Message);
+                LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<WorkflowResponse>.BadRequest("Failed to retrieve workflow");
         }
     }
@@ -261,7 +261,7 @@ public class WorkflowFinderService : IWorkflowFinderService
             }
 
             var listQuery = string.Join(" and ", queryParts);
-            _logger.LogDebug("Executing paginated workflow query: {Query}", listQuery);
+            _logger.LogDebug("Executing paginated workflow query: {Query}", LogSanitizer.Sanitize(listQuery));
 
             // Pagination uses a page-number token; for page N we fetch and discard (N-1)*pageSize records.
             // This becomes expensive for deep pages. Temporal exposes ListWorkflowsPaginatedAsync with
@@ -355,7 +355,7 @@ public class WorkflowFinderService : IWorkflowFinderService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to retrieve paginated workflows. Error: {ErrorMessage}", ex.Message);
+            _logger.LogError(ex, "Failed to retrieve paginated workflows. Error: {ErrorMessage}", LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<PaginatedWorkflowsResponse>.InternalServerError("Failed to retrieve workflows");
         }
     }
@@ -367,7 +367,7 @@ public class WorkflowFinderService : IWorkflowFinderService
     /// <returns>A result containing the list of filtered workflows.</returns>
     public async Task<ServiceResult<List<WorkflowsWithAgent>>> GetWorkflows(string? status)
     {
-        _logger.LogInformation("Retrieving workflows with filters - Status: {Status}", status ?? "null");
+        _logger.LogInformation("Retrieving workflows with filters - Status: {Status}", LogSanitizer.Sanitize(status ?? "null"));
 
         var loggedInUser = _tenantContext.LoggedInUser;
         if (string.IsNullOrEmpty(loggedInUser))
@@ -391,7 +391,7 @@ public class WorkflowFinderService : IWorkflowFinderService
 
             var listQuery = BuildQuery(agentNames, status);
 
-            _logger.LogDebug("Executing workflow query: {Query}", string.IsNullOrEmpty(listQuery) ? "No date filters" : listQuery);
+            _logger.LogDebug("Executing workflow query: {Query}", LogSanitizer.Sanitize(string.IsNullOrEmpty(listQuery) ? "No date filters" : listQuery));
 
             await foreach (var workflow in client.ListWorkflowsAsync(listQuery))
             {
@@ -454,7 +454,7 @@ public class WorkflowFinderService : IWorkflowFinderService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to retrieve workflows. Error: {ErrorMessage}", ex.Message);
+            _logger.LogError(ex, "Failed to retrieve workflows. Error: {ErrorMessage}", LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<List<WorkflowsWithAgent>>.InternalServerError("Failed to retrieve workflows");
         }
     }
@@ -479,7 +479,7 @@ public class WorkflowFinderService : IWorkflowFinderService
             return ServiceResult<List<string>>.BadRequest("Agent cannot be empty");
         }
 
-        _logger.LogInformation("Retrieving workflow types for agent: {Agent}", agent);
+        _logger.LogInformation("Retrieving workflow types for agent: {Agent}", LogSanitizer.Sanitize(agent));
 
         try
         {
@@ -508,7 +508,7 @@ public class WorkflowFinderService : IWorkflowFinderService
             };
 
             var listQuery = string.Join(" and ", queryParts);
-            _logger.LogDebug("Executing workflow types query: {Query}", listQuery);
+            _logger.LogDebug("Executing workflow types query: {Query}", LogSanitizer.Sanitize(listQuery));
 
             await foreach (var workflow in client.ListWorkflowsAsync(listQuery))
             {
@@ -519,7 +519,7 @@ public class WorkflowFinderService : IWorkflowFinderService
             }
 
             var sortedTypes = workflowTypes.OrderBy(t => t).ToList();
-            _logger.LogInformation("Retrieved {Count} unique workflow types for agent {Agent}", sortedTypes.Count, agent);
+            _logger.LogInformation("Retrieved {Count} unique workflow types for agent {Agent}", sortedTypes.Count, LogSanitizer.Sanitize(agent));
             return ServiceResult<List<string>>.Success(sortedTypes);
         }
         catch (ArgumentException ex)
@@ -529,7 +529,7 @@ public class WorkflowFinderService : IWorkflowFinderService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to retrieve workflow types for agent {Agent}. Error: {ErrorMessage}", agent, ex.Message);
+            _logger.LogError(ex, "Failed to retrieve workflow types for agent {Agent}. Error: {ErrorMessage}", LogSanitizer.Sanitize(agent), LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<List<string>>.InternalServerError("Failed to retrieve workflow types");
         }
     }
@@ -613,7 +613,7 @@ public class WorkflowFinderService : IWorkflowFinderService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to get distinct idPostfix values from Temporal. Error: {ErrorMessage}", ex.Message);
+            _logger.LogError(ex, "Failed to get distinct idPostfix values from Temporal. Error: {ErrorMessage}", LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<List<string>>.InternalServerError("Failed to get distinct idPostfix values");
         }
     }
@@ -634,7 +634,7 @@ public class WorkflowFinderService : IWorkflowFinderService
         }
 
         _logger.LogInformation("Retrieving workflows with filters - AgentName: {AgentName}, TypeName: {TypeName}",
-            agentName ?? "null", typeName ?? "null");
+            LogSanitizer.Sanitize(agentName ?? "null"), LogSanitizer.Sanitize(typeName ?? "null"));
 
         try
         {
@@ -675,7 +675,7 @@ public class WorkflowFinderService : IWorkflowFinderService
             }
 
             string listQuery = string.Join(" and ", queryParts);
-            _logger.LogDebug("Executing workflow query: {Query}", listQuery);
+            _logger.LogDebug("Executing workflow query: {Query}", LogSanitizer.Sanitize(listQuery));
 
             await foreach (var workflow in client.ListWorkflowsAsync(listQuery))
             {
@@ -696,7 +696,7 @@ public class WorkflowFinderService : IWorkflowFinderService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to retrieve workflows by agent and type. Error: {ErrorMessage}", ex.Message);
+            _logger.LogError(ex, "Failed to retrieve workflows by agent and type. Error: {ErrorMessage}", LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<List<WorkflowResponse>>.InternalServerError("Failed to retrieve workflows by agent and type");
         }
     }
@@ -772,7 +772,7 @@ public class WorkflowFinderService : IWorkflowFinderService
         // Join all query parts with AND operator
         var andParts = string.Join(" and ", queryParts);
 
-        _logger.LogDebug("Built query: {Query}", andParts);
+        _logger.LogDebug("Built query: {Query}", LogSanitizer.Sanitize(andParts));
 
         return andParts;
     }
@@ -850,7 +850,7 @@ public class WorkflowFinderService : IWorkflowFinderService
             if (currentActivity != null)
             {
                 _logger.LogDebug("Current activity: Type = {ActivityType}, ActivityId = {ActivityId}",
-                    currentActivity.ActivityType?.Name, currentActivity.ActivityId);
+                    LogSanitizer.Sanitize(currentActivity.ActivityType?.Name), LogSanitizer.Sanitize(currentActivity.ActivityId));
             }
             else
             {
@@ -930,15 +930,15 @@ public class WorkflowFinderService : IWorkflowFinderService
             string recentWorkerCount = recentWorkers.Count.ToString();
             _logger.LogInformation(
                 "TaskQueue {TaskQueue} has {WorkerCount} worker(s) polling it within the last minute",
-                taskQueueName,
-                recentWorkerCount
+                LogSanitizer.Sanitize(taskQueueName),
+                LogSanitizer.Sanitize(recentWorkerCount)
             );
 
             return recentWorkerCount;
         }
         catch (Exception)
         {
-            _logger.LogWarning("Failed to retrieve recent worker count for TaskQueue {TaskQueue}", taskQueueName);
+            _logger.LogWarning("Failed to retrieve recent worker count for TaskQueue {TaskQueue}", LogSanitizer.Sanitize(taskQueueName));
             return "N/A"; // Return "N/A" if unable to retrieve the count
         }
 

--- a/XiansAi.Server.Src/Features/WebApi/Services/WorkflowStarterService.cs
+++ b/XiansAi.Server.Src/Features/WebApi/Services/WorkflowStarterService.cs
@@ -7,6 +7,7 @@ using Shared.Utils.Temporal;
 using Shared.Utils.Services;
 using Shared.Repositories;
 using Features.WebApi.Utils;
+using Shared.Utils;
 
 namespace Features.WebApi.Services;
 
@@ -86,7 +87,7 @@ public class WorkflowStarterService : IWorkflowStarterService
     public async Task<ServiceResult<WorkflowStartResult>> HandleStartWorkflow(WorkflowRequest request, string? userId = null)
     {
         _logger.LogInformation("Received workflow start request of type {WorkflowType} with data {Request}", 
-            request?.WorkflowType ?? "null", JsonSerializer.Serialize(request));
+            LogSanitizer.Sanitize(request?.WorkflowType ?? "null"), LogSanitizer.Sanitize(JsonSerializer.Serialize(request)));
         
         if (request == null)
         {
@@ -99,7 +100,7 @@ public class WorkflowStarterService : IWorkflowStarterService
             if (validationResults.Count > 0)
             {
                 _logger.LogWarning("Invalid workflow request: {Errors}", 
-                    string.Join(", ", validationResults));
+                    LogSanitizer.Sanitize(string.Join(", ", validationResults)));
                 return ServiceResult<WorkflowStartResult>.BadRequest(string.Join(", ", validationResults));
             }
 
@@ -113,7 +114,7 @@ public class WorkflowStarterService : IWorkflowStarterService
 
             if (flowDefinition == null)
             {
-                _logger.LogWarning("Flow definition not found for workflow type: {WorkflowType}", request.WorkflowType);
+                _logger.LogWarning("Flow definition not found for workflow type: {WorkflowType}", LogSanitizer.Sanitize(request.WorkflowType));
                 return ServiceResult<WorkflowStartResult>.NotFound($"Workflow definition not found for type: {request.WorkflowType}");
             }
 
@@ -127,11 +128,11 @@ public class WorkflowStarterService : IWorkflowStarterService
                     flowDefinition.ParameterDefinitions);
                 
                 _logger.LogDebug("Converted {Count} parameters for workflow {WorkflowType}", 
-                    convertedParameters.Length, request.WorkflowType);
+                    convertedParameters.Length, LogSanitizer.Sanitize(request.WorkflowType));
             }
             catch (ArgumentException ex)
             {
-                _logger.LogWarning(ex, "Parameter conversion failed for workflow {WorkflowType}", request.WorkflowType);
+                _logger.LogWarning(ex, "Parameter conversion failed for workflow {WorkflowType}", LogSanitizer.Sanitize(request.WorkflowType));
                 return ServiceResult<WorkflowStartResult>.BadRequest($"Parameter conversion error: {ex.Message}");
             }
 
@@ -143,7 +144,7 @@ public class WorkflowStarterService : IWorkflowStarterService
                 _tenantContext,
                 userId);
             
-            _logger.LogDebug("Starting workflow with options: {Options}", JsonSerializer.Serialize(options));
+            _logger.LogDebug("Starting workflow with options: {Options}", LogSanitizer.Sanitize(JsonSerializer.Serialize(options)));
             var handle = await StartWorkflowAsync(convertedParameters, options, request.WorkflowType);
             
             var result = new WorkflowStartResult
@@ -157,7 +158,7 @@ public class WorkflowStarterService : IWorkflowStarterService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error starting workflow of type {WorkflowType}", request?.WorkflowType);
+            _logger.LogError(ex, "Error starting workflow of type {WorkflowType}", LogSanitizer.Sanitize(request?.WorkflowType));
             return ServiceResult<WorkflowStartResult>.InternalServerError("Workflow start failed");
         }
     }
@@ -171,7 +172,7 @@ public class WorkflowStarterService : IWorkflowStarterService
         string workflowType)
     {
         _logger.LogDebug("Starting workflow {WorkflowType} with {ParamCount} parameters", 
-            workflowType, parameters.Length);
+            LogSanitizer.Sanitize(workflowType), parameters.Length);
         
         var client = await _clientFactory.GetClientAsync();
         return await client.StartWorkflowAsync(

--- a/XiansAi.Server.Src/Features/WebApi/Utils/WebApiSSEStreamHandler.cs
+++ b/XiansAi.Server.Src/Features/WebApi/Utils/WebApiSSEStreamHandler.cs
@@ -1,6 +1,7 @@
 using Features.UserApi.Services;
 using Features.UserApi.Utils;
 using Shared.Auth;
+using Shared.Utils;
 
 namespace Features.WebApi.Utils;
 
@@ -47,7 +48,7 @@ public class WebApiSSEStreamHandler
         try
         {
             _logger.LogInformation("WebAPI SSE connection established for thread {ThreadId}, tenant {TenantId}",
-                _threadId, _tenantId);
+                LogSanitizer.Sanitize(_threadId), LogSanitizer.Sanitize(_tenantId));
 
             // Set SSE headers
             SSEEventWriter.SetSSEHeaders(_httpContext.Response);
@@ -93,7 +94,7 @@ public class WebApiSSEStreamHandler
             {
                 var eventType = message.MessageType?.ToString() ?? "unknown";
                 _logger.LogDebug("Sending WebAPI SSE event {EventType} for message {MessageId} to thread {ThreadId}",
-                        eventType, message.Id, _threadId);
+                        LogSanitizer.Sanitize(eventType), LogSanitizer.Sanitize(message.Id), LogSanitizer.Sanitize(_threadId));
 
                 await SSEEventWriter.WriteEventAsync(_httpContext.Response, eventType, 
                     MessageEventFilter.CreateMessageEventData(message), 
@@ -102,12 +103,12 @@ public class WebApiSSEStreamHandler
         }
         catch (Exception ex) when (ex is OperationCanceledException || _cancellationToken.IsCancellationRequested)
         {
-            _logger.LogDebug("WebAPI SSE connection cancelled for thread {ThreadId}", _threadId);
+            _logger.LogDebug("WebAPI SSE connection cancelled for thread {ThreadId}", LogSanitizer.Sanitize(_threadId));
             _completionSource?.TrySetResult(true);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error handling WebAPI SSE message event for thread {ThreadId}", _threadId);
+            _logger.LogError(ex, "Error handling WebAPI SSE message event for thread {ThreadId}", LogSanitizer.Sanitize(_threadId));
         }
     }
 
@@ -149,7 +150,7 @@ public class WebApiSSEStreamHandler
         _messageEventPublisher.MessageReceived -= HandleMessage;
         
         _logger.LogInformation("WebAPI SSE connection closed for thread {ThreadId}, tenant {TenantId}",
-            _threadId, _tenantId);
+            LogSanitizer.Sanitize(_threadId), LogSanitizer.Sanitize(_tenantId));
     }
 }
 

--- a/XiansAi.Server.Src/Shared/Configuration/ExceptionHandlingConfiguration.cs
+++ b/XiansAi.Server.Src/Shared/Configuration/ExceptionHandlingConfiguration.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authorization.Policy;
 using Shared.Exceptions;
 using System.Text;
 using System.Text.Json;
+using Shared.Utils;
 
 namespace Features.Shared.Configuration;
 
@@ -104,7 +105,7 @@ public class AuthorizationMiddlewareResultHandler : IAuthorizationMiddlewareResu
             // Check if response has already started
             if (context.Response.HasStarted)
             {
-                _logger.LogWarning("Cannot write 401 response - response has already started for path: {Path}", context.Request.Path);
+                _logger.LogWarning("Cannot write 401 response - response has already started for path: {Path}", LogSanitizer.Sanitize(context.Request.Path));
                 return;
             }
 
@@ -131,7 +132,7 @@ public class AuthorizationMiddlewareResultHandler : IAuthorizationMiddlewareResu
             await context.Response.CompleteAsync();
             
             _logger.LogWarning("Authentication challenge returned for path: {Path}, wrote response body ({Length} bytes): {JsonString}", 
-                context.Request.Path, bytes.Length, jsonString);
+                LogSanitizer.Sanitize(context.Request.Path), bytes.Length, LogSanitizer.Sanitize(jsonString));
             return;
         }
 
@@ -141,7 +142,7 @@ public class AuthorizationMiddlewareResultHandler : IAuthorizationMiddlewareResu
             // Check if response has already started
             if (context.Response.HasStarted)
             {
-                _logger.LogWarning("Cannot write 403 response - response has already started for path: {Path}", context.Request.Path);
+                _logger.LogWarning("Cannot write 403 response - response has already started for path: {Path}", LogSanitizer.Sanitize(context.Request.Path));
                 return;
             }
 
@@ -156,8 +157,8 @@ public class AuthorizationMiddlewareResultHandler : IAuthorizationMiddlewareResu
                 : "You do not have permission to access this resource";
 
             _logger.LogInformation("Authorization forbidden for path: {Path}, Reasons: {Reasons}", 
-                context.Request.Path, 
-                string.Join("; ", failureReasons));
+                LogSanitizer.Sanitize(context.Request.Path), 
+                LogSanitizer.Sanitize(string.Join("; ", failureReasons)));
 
             var responseBody = new
             {
@@ -181,7 +182,7 @@ public class AuthorizationMiddlewareResultHandler : IAuthorizationMiddlewareResu
             await context.Response.Body.FlushAsync();
             await context.Response.CompleteAsync();
             
-            _logger.LogInformation("Wrote 403 response body ({Length} bytes): {JsonString}", bytes.Length, jsonString);
+            _logger.LogInformation("Wrote 403 response body ({Length} bytes): {JsonString}", bytes.Length, LogSanitizer.Sanitize(jsonString));
             
             return;
         }

--- a/XiansAi.Server.Src/Shared/Data/Migrations/NormalizeEmailsMigration.cs
+++ b/XiansAi.Server.Src/Shared/Data/Migrations/NormalizeEmailsMigration.cs
@@ -1,5 +1,6 @@
 using MongoDB.Driver;
 using Shared.Data.Models;
+using Shared.Utils;
 
 namespace Shared.Data.Migrations;
 
@@ -60,7 +61,7 @@ public class NormalizeEmailsMigration
                         {
                             updateCount++;
                             _logger.LogInformation("Normalized email: {Original} -> {Normalized}", 
-                                originalEmail, normalizedEmail);
+                                LogSanitizer.RedactEmail(originalEmail), LogSanitizer.RedactEmail(normalizedEmail));
                         }
                     }
                 }

--- a/XiansAi.Server.Src/Shared/Providers/Auth/Auth0/Auth0TokenService.cs
+++ b/XiansAi.Server.Src/Shared/Providers/Auth/Auth0/Auth0TokenService.cs
@@ -57,7 +57,7 @@ public class Auth0TokenService : ITokenService
             var validationResult = await ValidateJwtWithJwks(token);
             if (!validationResult.success)
             {
-                _logger.LogWarning("JWT token validation failed: {Error}", validationResult.errorMessage);
+                _logger.LogWarning("JWT token validation failed: {Error}", LogSanitizer.Sanitize(validationResult.errorMessage));
                 return (false, null);
             }
 
@@ -66,7 +66,7 @@ public class Auth0TokenService : ITokenService
 
             if (jsonToken == null)
             {
-                _logger.LogWarning("Invalid JWT token format: {Token}", token);
+                _logger.LogWarning("Invalid JWT token format: {Token}", LogSanitizer.Sanitize(token));
                 return (false, null);
             }
 
@@ -174,24 +174,24 @@ public class Auth0TokenService : ITokenService
 
             // Validate the token
             _logger.LogDebug("Validating JWT token with issuer: {Issuer}, audience: {Audience}",
-                validationParameters.ValidIssuer, validationParameters.ValidAudience);
+                LogSanitizer.Sanitize(validationParameters.ValidIssuer), LogSanitizer.Sanitize(validationParameters.ValidAudience));
 
             var result = await handler.ValidateTokenAsync(token, validationParameters);
 
             if (!result.IsValid)
             {
                 var errorMessage = result.Exception?.Message ?? "Token validation failed";
-                _logger.LogWarning("JWT validation failed: {ErrorMessage}", errorMessage);
+                _logger.LogWarning("JWT validation failed: {ErrorMessage}", LogSanitizer.Sanitize(errorMessage));
                 if (result.Exception != null)
                 {
                     _logger.LogWarning("JWT validation exception details: {ExceptionType}: {ExceptionMessage}",
-                        result.Exception.GetType().Name, result.Exception.Message);
+                        LogSanitizer.Sanitize(result.Exception.GetType().Name), LogSanitizer.Sanitize(result.Exception.Message));
                 }
                 return (false, errorMessage);
             }
 
             _logger.LogDebug("JWT token validated successfully with issuer: {Issuer} and audience: {Audience}",
-                validationParameters.ValidIssuer, validationParameters.ValidAudience);
+                LogSanitizer.Sanitize(validationParameters.ValidIssuer), LogSanitizer.Sanitize(validationParameters.ValidAudience));
             return (true, null);
         }
         catch (Exception ex)
@@ -226,7 +226,7 @@ public class Auth0TokenService : ITokenService
             }
 
             // Fetch fresh JWKS
-            _logger.LogDebug("Fetching JWKS from: {JwksUrl}", jwksUri);
+            _logger.LogDebug("Fetching JWKS from: {JwksUrl}", LogSanitizer.Sanitize(jwksUri));
 
             var response = await _httpClient.GetAsync(jwksUri);
             if (!response.IsSuccessStatusCode)
@@ -297,7 +297,7 @@ public class Auth0TokenService : ITokenService
     {
         if (!response.IsSuccessful)
         {
-            _logger.LogError("Failed to {Operation}: {ErrorMessage}", operation, response.ErrorMessage);
+            _logger.LogError("Failed to {Operation}: {ErrorMessage}", LogSanitizer.Sanitize(operation), LogSanitizer.Sanitize(response.ErrorMessage));
             throw new Exception($"Failed to {operation}: {response.ErrorMessage}");
         }
     }

--- a/XiansAi.Server.Src/Shared/Providers/Auth/GitHub/GitHubProvider.cs
+++ b/XiansAi.Server.Src/Shared/Providers/Auth/GitHub/GitHubProvider.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using Shared.Providers.Auth.Auth0;
 using Shared.Services;
+using Shared.Utils;
 
 namespace Shared.Providers.Auth.GitHub;
 
@@ -160,7 +161,7 @@ public class GitHubProvider : IAuthProvider
                         }
 
                         _logger.LogDebug("Added {RoleCount} roles for GitHub user {UserId} in tenant {TenantId}",
-                            uniqueRoles.Count, userId, tenantId);
+                            uniqueRoles.Count, LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(tenantId));
                     }
                     else
                     {
@@ -168,7 +169,7 @@ public class GitHubProvider : IAuthProvider
                         if (!identity.Claims.Any(c => c.Type == ClaimTypes.Role && c.Value == SystemRoles.TenantUser))
                         {
                             identity.AddClaim(new Claim(ClaimTypes.Role, SystemRoles.TenantUser));
-                            _logger.LogDebug("No X-Tenant-Id header, assigned default TenantUser role to {UserId}", userId);
+                            _logger.LogDebug("No X-Tenant-Id header, assigned default TenantUser role to {UserId}", LogSanitizer.Sanitize(userId));
                         }
                     }
 
@@ -179,14 +180,14 @@ public class GitHubProvider : IAuthProvider
 
             OnAuthenticationFailed = context =>
             {
-                _logger.LogError("GitHub JWT authentication failed: {Exception}", context.Exception?.Message);
+                _logger.LogError("GitHub JWT authentication failed: {Exception}", LogSanitizer.Sanitize(context.Exception?.Message));
                 return Task.CompletedTask;
             },
 
             OnChallenge = context =>
             {
                 _logger.LogWarning("GitHub JWT challenge triggered: {Error}, {ErrorDescription}",
-                    context.Error, context.ErrorDescription);
+                    LogSanitizer.Sanitize(context.Error), LogSanitizer.Sanitize(context.ErrorDescription));
                 return Task.CompletedTask;
             }
         };
@@ -201,7 +202,7 @@ public class GitHubProvider : IAuthProvider
     {
         // For GitHub, user info is embedded in the JWT claims
         // We could optionally call GitHub API here if needed
-        _logger.LogInformation("GetUserInfo called for GitHub user {UserId}", userId);
+        _logger.LogInformation("GetUserInfo called for GitHub user {UserId}", LogSanitizer.Sanitize(userId));
 
         // Return minimal user info (could be enhanced to call GitHub API)
         return Task.FromResult(new UserInfo
@@ -225,7 +226,7 @@ public class GitHubProvider : IAuthProvider
     {
         // Tenants are managed in the database, not in GitHub
         _logger.LogInformation("SetNewTenant called for GitHub user {UserId}, tenant {TenantId}",
-            userId, tenantId);
+            LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(tenantId));
         return Task.FromResult("Tenant association managed via database");
     }
 }

--- a/XiansAi.Server.Src/Shared/Providers/Auth/GitHub/GitHubTokenService.cs
+++ b/XiansAi.Server.Src/Shared/Providers/Auth/GitHub/GitHubTokenService.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
 using RestSharp;
+using Shared.Utils;
 using JwtClaims = System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames;
 
 namespace Shared.Providers.Auth.GitHub;
@@ -197,7 +198,7 @@ public class GitHubTokenService : ITokenService
             var primaryEmail = emails?.FirstOrDefault(e => e.Primary && e.Verified)?.Email;
             if (!string.IsNullOrEmpty(primaryEmail))
             {
-                _logger.LogDebug("Found primary verified email: {Email}", primaryEmail);
+                _logger.LogDebug("Found primary verified email: {Email}", LogSanitizer.RedactEmail(primaryEmail));
             }
 
             return primaryEmail;

--- a/XiansAi.Server.Src/Shared/Providers/Auth/Oidc/OidcTokenService.cs
+++ b/XiansAi.Server.Src/Shared/Providers/Auth/Oidc/OidcTokenService.cs
@@ -4,6 +4,7 @@ using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
+using Shared.Utils;
 
 namespace Shared.Providers.Auth.Oidc;
 
@@ -100,13 +101,13 @@ public class OidcTokenService : ITokenService
             
             if (string.IsNullOrEmpty(userId))
             {
-                _logger.LogWarning("User ID claim '{UserIdClaim}' not found in token", _config.ClaimMappings.UserIdClaim);
+                _logger.LogWarning("User ID claim '{UserIdClaim}' not found in token", LogSanitizer.Sanitize(_config.ClaimMappings.UserIdClaim));
                 var result = (false, (string?)null);
                 // Don't cache failed validations
                 return result;
             }
 
-            _logger.LogInformation("Successfully validated OIDC token for user: {UserId}", userId);
+            _logger.LogInformation("Successfully validated OIDC token for user: {UserId}", LogSanitizer.Sanitize(userId));
             var successResult = (true, (string?)userId);
             
             // Cache successful validation for 5 minutes
@@ -120,12 +121,12 @@ public class OidcTokenService : ITokenService
         }
         catch (SecurityTokenExpiredException ex)
         {
-            _logger.LogWarning("Token expired: {Message}", ex.Message);
+            _logger.LogWarning("Token expired: {Message}", LogSanitizer.Sanitize(ex.Message));
             return (false, null);
         }
         catch (SecurityTokenException ex)
         {
-            _logger.LogError("Token validation failed: {Message}", ex.Message);
+            _logger.LogError("Token validation failed: {Message}", LogSanitizer.Sanitize(ex.Message));
             return (false, null);
         }
         catch (Exception ex)
@@ -141,7 +142,7 @@ public class OidcTokenService : ITokenService
         var userId = token.Claims.FirstOrDefault(c => c.Type == _config.ClaimMappings.UserIdClaim)?.Value;
         if (!string.IsNullOrEmpty(userId))
         {
-            _logger.LogDebug("Found user ID in '{ClaimType}' claim: {UserId}", _config.ClaimMappings.UserIdClaim, userId);
+            _logger.LogDebug("Found user ID in '{ClaimType}' claim: {UserId}", LogSanitizer.Sanitize(_config.ClaimMappings.UserIdClaim), LogSanitizer.Sanitize(userId));
             return userId;
         }
 
@@ -149,7 +150,7 @@ public class OidcTokenService : ITokenService
         userId = token.Claims.FirstOrDefault(c => c.Type == "sub")?.Value;
         if (!string.IsNullOrEmpty(userId))
         {
-            _logger.LogDebug("Found user ID in 'sub' claim: {UserId}", userId);
+            _logger.LogDebug("Found user ID in 'sub' claim: {UserId}", LogSanitizer.Sanitize(userId));
             return userId;
         }
 
@@ -160,7 +161,7 @@ public class OidcTokenService : ITokenService
             userId = token.Claims.FirstOrDefault(c => c.Type == claimType)?.Value;
             if (!string.IsNullOrEmpty(userId))
             {
-                _logger.LogInformation("Found user ID in '{ClaimType}' claim: {UserId}", claimType, userId);
+                _logger.LogInformation("Found user ID in '{ClaimType}' claim: {UserId}", LogSanitizer.Sanitize(claimType), LogSanitizer.Sanitize(userId));
                 return userId;
             }
         }

--- a/XiansAi.Server.Src/Shared/Providers/Auth/TokenValidationCache.cs
+++ b/XiansAi.Server.Src/Shared/Providers/Auth/TokenValidationCache.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Caching.Memory;
 using System.Security.Cryptography;
 using System.Text;
 using System.Collections.Concurrent;
+using Shared.Utils;
 
 namespace Shared.Providers.Auth;
 
@@ -147,7 +148,7 @@ public class MemoryTokenValidationCache : ITokenValidationCache
         var tokens = _userTokens.GetOrAdd(userId, _ => new ConcurrentBag<string>());
         tokens.Add(cacheKey);
 
-        _logger.LogDebug("Cached successful token validation result for user {UserId}", userId);
+        _logger.LogDebug("Cached successful token validation result for user {UserId}", LogSanitizer.Sanitize(userId));
         return Task.CompletedTask;
     }
 
@@ -193,7 +194,7 @@ public class MemoryTokenValidationCache : ITokenValidationCache
         // Try to remove and get the token bag for this user atomically
         if (!_userTokens.TryRemove(userId, out var tokenBag))
         {
-            _logger.LogDebug("No cached tokens found for user {UserId}", userId);
+            _logger.LogDebug("No cached tokens found for user {UserId}", LogSanitizer.Sanitize(userId));
             return Task.CompletedTask;
         }
 
@@ -215,7 +216,7 @@ public class MemoryTokenValidationCache : ITokenValidationCache
             }
         }
 
-        _logger.LogInformation("Invalidated {Count} cached tokens for user {UserId}", tokenKeys.Length, userId);
+        _logger.LogInformation("Invalidated {Count} cached tokens for user {UserId}", tokenKeys.Length, LogSanitizer.Sanitize(userId));
         return Task.CompletedTask;
     }
 

--- a/XiansAi.Server.Src/Shared/Providers/Cache/InMemoryCacheProvider.cs
+++ b/XiansAi.Server.Src/Shared/Providers/Cache/InMemoryCacheProvider.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Text.Json;
 using Microsoft.Extensions.Caching.Memory;
+using Shared.Utils;
 
 namespace Shared.Providers;
 
@@ -55,7 +56,7 @@ public class InMemoryCacheProvider : ICacheProvider
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error retrieving value from memory cache for key: {Key}", key);
+            _logger.LogError(ex, "Error retrieving value from memory cache for key: {Key}", LogSanitizer.Sanitize(key));
             return Task.FromResult<T?>(default);
         }
     }
@@ -102,7 +103,7 @@ public class InMemoryCacheProvider : ICacheProvider
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error setting value in memory cache for key: {Key}", key);
+            _logger.LogError(ex, "Error setting value in memory cache for key: {Key}", LogSanitizer.Sanitize(key));
             return Task.FromResult(false);
         }
     }
@@ -128,7 +129,7 @@ public class InMemoryCacheProvider : ICacheProvider
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error removing value from memory cache for key: {Key}", key);
+            _logger.LogError(ex, "Error removing value from memory cache for key: {Key}", LogSanitizer.Sanitize(key));
             return Task.FromResult(false);
         }
     }

--- a/XiansAi.Server.Src/Shared/Providers/Cache/RedisCacheProvider.cs
+++ b/XiansAi.Server.Src/Shared/Providers/Cache/RedisCacheProvider.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Microsoft.Extensions.Caching.Distributed;
+using Shared.Utils;
 
 namespace Shared.Providers;
 
@@ -42,7 +43,7 @@ public class RedisCacheProvider : ICacheProvider
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error retrieving value from Redis cache for key: {Key}", key);
+            _logger.LogError(ex, "Error retrieving value from Redis cache for key: {Key}", LogSanitizer.Sanitize(key));
             return default;
         }
     }
@@ -78,7 +79,7 @@ public class RedisCacheProvider : ICacheProvider
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error setting value in Redis cache for key: {Key}", key);
+            _logger.LogError(ex, "Error setting value in Redis cache for key: {Key}", LogSanitizer.Sanitize(key));
             return false;
         }
     }
@@ -97,7 +98,7 @@ public class RedisCacheProvider : ICacheProvider
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error removing value from Redis cache for key: {Key}", key);
+            _logger.LogError(ex, "Error removing value from Redis cache for key: {Key}", LogSanitizer.Sanitize(key));
             return false;
         }
     }

--- a/XiansAi.Server.Src/Shared/Providers/Email/ConsoleEmailProvider.cs
+++ b/XiansAi.Server.Src/Shared/Providers/Email/ConsoleEmailProvider.cs
@@ -1,3 +1,4 @@
+using Shared.Utils;
 namespace Shared.Providers;
 
 /// <summary>
@@ -41,14 +42,14 @@ public class ConsoleEmailProvider : IEmailProvider
     {
         await Task.Delay(1); // Simulate async operation
 
-        var recipients = string.Join(", ", to);
+        var recipients = string.Join(", ", to.Select(LogSanitizer.RedactEmail));
         var contentType = isHtml ? "HTML" : "Plain Text";
 
         _logger.LogInformation("=== EMAIL SENT (Console Provider) ===");
         _logger.LogInformation("To: {Recipients}", recipients);
-        _logger.LogInformation("Subject: {Subject}", subject);
-        _logger.LogInformation("Content Type: {ContentType}", contentType);
-        _logger.LogInformation("Body: {Body}", body);
+        _logger.LogInformation("Subject: {Subject}", LogSanitizer.Sanitize(subject));
+        _logger.LogInformation("Content Type: {ContentType}", LogSanitizer.Sanitize(contentType));
+        _logger.LogInformation("Body: {Body}", LogSanitizer.Sanitize(body));
         _logger.LogInformation("=====================================");
 
         return true;

--- a/XiansAi.Server.Src/Shared/Providers/Llm/DummyLlmProvider.cs
+++ b/XiansAi.Server.Src/Shared/Providers/Llm/DummyLlmProvider.cs
@@ -1,5 +1,6 @@
 using Shared.Auth;
 using Shared.Utils.GenAi;
+using Shared.Utils;
 
 namespace Shared.Providers;
 
@@ -86,7 +87,7 @@ public class DummyLlmProvider : ILlmProvider
     public Task<string> GetChatCompletionAsync(List<ChatMessage> messages, string model = "dummy-echo-model")
     {
         _logger.LogInformation("DummyLlmProvider: Processing {MessageCount} messages with model {Model}", 
-            messages.Count, model);
+            messages.Count, LogSanitizer.Sanitize(model));
 
         if (messages == null || messages.Count == 0)
         {
@@ -99,7 +100,7 @@ public class DummyLlmProvider : ILlmProvider
         if (lastUserMessage != null)
         {
             var response = $"Echo from Dummy LLM: {lastUserMessage.Content}";
-            _logger.LogInformation("DummyLlmProvider: Echoing user message: {Message}", lastUserMessage.Content);
+            _logger.LogInformation("DummyLlmProvider: Echoing user message: {Message}", LogSanitizer.Sanitize(lastUserMessage.Content));
             return Task.FromResult(response);
         }
 

--- a/XiansAi.Server.Src/Shared/Providers/SecretStore/AzureKeyVaultSecretStoreProvider.cs
+++ b/XiansAi.Server.Src/Shared/Providers/SecretStore/AzureKeyVaultSecretStoreProvider.cs
@@ -2,6 +2,7 @@ using System.Text.RegularExpressions;
 using Azure;
 using Azure.Core;
 using Azure.Security.KeyVault.Secrets;
+using Shared.Utils;
 
 namespace Shared.Providers;
 

--- a/XiansAi.Server.Src/Shared/Repositories/AgentPermissionRepository.cs
+++ b/XiansAi.Server.Src/Shared/Repositories/AgentPermissionRepository.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Shared.Data;
 using Shared.Auth;
+using Shared.Utils;
 
 namespace Shared.Repositories;
 
@@ -40,12 +41,12 @@ public class AgentPermissionRepository : IAgentPermissionRepository
 
     public async Task<Permission?> GetAgentPermissionsAsync(string agentName)
     {
-        _logger.LogInformation("Getting permissions for agent: {AgentName}", agentName);
+        _logger.LogInformation("Getting permissions for agent: {AgentName}", LogSanitizer.Sanitize(agentName));
 
         // Check cache first (request-scoped cache to avoid repeated DB calls)
         if (_permissionsCache.TryGetValue(agentName, out var cachedPermissions))
         {
-            _logger.LogDebug("Agent permissions cache hit for agent: {AgentName}", agentName);
+            _logger.LogDebug("Agent permissions cache hit for agent: {AgentName}", LogSanitizer.Sanitize(agentName));
             return cachedPermissions;
         }
 
@@ -53,7 +54,7 @@ public class AgentPermissionRepository : IAgentPermissionRepository
 
         if (agent == null)
         {
-            _logger.LogWarning("Agent not found: {AgentName}", agentName);
+            _logger.LogWarning("Agent not found: {AgentName}", LogSanitizer.Sanitize(agentName));
             _permissionsCache[agentName] = null;
             return null;
         }
@@ -66,13 +67,13 @@ public class AgentPermissionRepository : IAgentPermissionRepository
         };
 
         _permissionsCache[agentName] = permission;
-        _logger.LogDebug("Agent permissions cache miss for agent: {AgentName}, loaded from DB", agentName);
+        _logger.LogDebug("Agent permissions cache miss for agent: {AgentName}, loaded from DB", LogSanitizer.Sanitize(agentName));
         return permission;
     }
 
     public async Task<string?> GetAgentTenantAsync(string agentName)
     {
-        _logger.LogInformation("Getting tenant for agent: {AgentName}", agentName);
+        _logger.LogInformation("Getting tenant for agent: {AgentName}", LogSanitizer.Sanitize(agentName));
 
         if (_agentTenantCache.TryGetValue(agentName, out var cachedTenant))
         {
@@ -82,7 +83,7 @@ public class AgentPermissionRepository : IAgentPermissionRepository
         var agent = await _agentRepository.GetByNameInternalAsync(agentName, _tenantContext.TenantId);
         if (agent == null)
         {
-            _logger.LogWarning("Agent not found: {AgentName}", agentName);
+            _logger.LogWarning("Agent not found: {AgentName}", LogSanitizer.Sanitize(agentName));
             _agentTenantCache[agentName] = string.Empty;
             return string.Empty;
         }
@@ -93,7 +94,7 @@ public class AgentPermissionRepository : IAgentPermissionRepository
 
     public async Task<bool> UpdateAgentPermissionsAsync(string agentName, Permission permissions)
     {
-        _logger.LogInformation("Updating permissions for agent: {AgentName}", agentName);
+        _logger.LogInformation("Updating permissions for agent: {AgentName}", LogSanitizer.Sanitize(agentName));
 
         // Use permission-aware method that checks if user has owner permission
         var agentUpdated = await _agentRepository.UpdatePermissionsAsync(
@@ -105,13 +106,13 @@ public class AgentPermissionRepository : IAgentPermissionRepository
 
         if (!agentUpdated)
         {
-            _logger.LogWarning("Failed to update permissions for agent {AgentName} - either not found or insufficient permissions", agentName);
+            _logger.LogWarning("Failed to update permissions for agent {AgentName} - either not found or insufficient permissions", LogSanitizer.Sanitize(agentName));
             return false;
         }
 
         // Invalidate cache since permissions have changed
         _permissionsCache.Remove(agentName);
-        _logger.LogDebug("Invalidated permissions cache for agent: {AgentName}", agentName);
+        _logger.LogDebug("Invalidated permissions cache for agent: {AgentName}", LogSanitizer.Sanitize(agentName));
 
         return true;
     }
@@ -125,7 +126,7 @@ public class AgentPermissionRepository : IAgentPermissionRepository
         var agent = await _agentRepository.GetByNameInternalAsync(agentName, _tenantContext.TenantId);
         if (agent == null)
         {
-            _logger.LogWarning("Agent not found: {AgentName}", agentName);
+            _logger.LogWarning("Agent not found: {AgentName}", LogSanitizer.Sanitize(agentName));
             return false;
         }
 
@@ -133,7 +134,7 @@ public class AgentPermissionRepository : IAgentPermissionRepository
         if (!CheckPermissions(agent, PermissionLevel.Owner))
         {
             _logger.LogWarning("User {UserId} attempted to add user to agent {AgentName} without owner permission",
-                _tenantContext.LoggedInUser, agentName);
+                LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(agentName));
             return false;
         }
 
@@ -163,7 +164,7 @@ public class AgentPermissionRepository : IAgentPermissionRepository
         {
             // Invalidate cache since permissions have changed
             _permissionsCache.Remove(agentName);
-            _logger.LogDebug("Invalidated permissions cache for agent: {AgentName}", agentName);
+            _logger.LogDebug("Invalidated permissions cache for agent: {AgentName}", LogSanitizer.Sanitize(agentName));
         }
 
         return result;
@@ -171,13 +172,13 @@ public class AgentPermissionRepository : IAgentPermissionRepository
 
     public async Task<bool> RemoveUserFromAgentAsync(string agentName, string userId)
     {
-        _logger.LogInformation("Removing user {UserId} from agent {AgentName}", userId, agentName);
+        _logger.LogInformation("Removing user {UserId} from agent {AgentName}", LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(agentName));
 
         // Get the agent without permission check first, then check owner permission explicitly
         var agent = await _agentRepository.GetByNameInternalAsync(agentName, _tenantContext.TenantId);
         if (agent == null)
         {
-            _logger.LogWarning("Agent not found: {AgentName}", agentName);
+            _logger.LogWarning("Agent not found: {AgentName}", LogSanitizer.Sanitize(agentName));
             return false;
         }
 
@@ -185,7 +186,7 @@ public class AgentPermissionRepository : IAgentPermissionRepository
         if (!CheckPermissions(agent, PermissionLevel.Owner))
         {
             _logger.LogWarning("User {UserId} attempted to remove user from agent {AgentName} without owner permission",
-                _tenantContext.LoggedInUser, agentName);
+                LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(agentName));
             return false;
         }
 
@@ -206,13 +207,13 @@ public class AgentPermissionRepository : IAgentPermissionRepository
         {
             // Invalidate cache since permissions have changed
             _permissionsCache.Remove(agentName);
-            _logger.LogDebug("Invalidated permissions cache for agent: {AgentName}", agentName);
+            _logger.LogDebug("Invalidated permissions cache for agent: {AgentName}", LogSanitizer.Sanitize(agentName));
         }
 
         // If the user wasn't found in any permission list, still consider it successful (idempotent operation)
         if (!wasUserFound)
         {
-            _logger.LogInformation("User {UserId} was not found in any permission lists for agent {AgentName}, operation considered successful", userId, agentName);
+            _logger.LogInformation("User {UserId} was not found in any permission lists for agent {AgentName}, operation considered successful", LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(agentName));
             return true;
         }
 
@@ -235,7 +236,7 @@ public class AgentPermissionRepository : IAgentPermissionRepository
     {
         // Flow definitions no longer have permissions - they inherit from agent permissions
         // This method is no longer needed but kept for backward compatibility
-        _logger.LogInformation("Permission sync to flow definitions is no longer needed for agent {AgentName}", agentName);
+        _logger.LogInformation("Permission sync to flow definitions is no longer needed for agent {AgentName}", LogSanitizer.Sanitize(agentName));
     }
 
     private Permission CleanPermissionLevels(Permission permissions)

--- a/XiansAi.Server.Src/Shared/Repositories/AgentRepository.cs
+++ b/XiansAi.Server.Src/Shared/Repositories/AgentRepository.cs
@@ -73,7 +73,7 @@ public class AgentRepository : IAgentRepository
         // Check if user has at least read permission
         if (!CheckPermissions(agent, PermissionLevel.Read))
         {
-            _logger.LogWarning("User {UserId} attempted to access agent {AgentName} without read permission", userId, name);
+            _logger.LogWarning("User {UserId} attempted to access agent {AgentName} without read permission", LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(name));
             return null;
         }
 
@@ -104,7 +104,7 @@ public class AgentRepository : IAgentRepository
         // Check if user has at least read permission
         if (!CheckPermissions(agent, PermissionLevel.Read))
         {
-            _logger.LogWarning("User {UserId} attempted to access agent {AgentId} without read permission", userId, id);
+            _logger.LogWarning("User {UserId} attempted to access agent {AgentId} without read permission", LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(id));
             return null;
         }
 
@@ -188,14 +188,14 @@ public class AgentRepository : IAgentRepository
         var existingAgent = await _agents.Find(x => x.Id == id).FirstOrDefaultAsync();
         if (existingAgent == null)
         {
-            _logger.LogWarning("Agent with ID {AgentId} not found", id);
+            _logger.LogWarning("Agent with ID {AgentId} not found", LogSanitizer.Sanitize(id));
             return false;
         }
 
         // Check if user has write permission
         if (!CheckPermissions(existingAgent, PermissionLevel.Write))
         {
-            _logger.LogWarning("User {UserId} attempted to update agent {AgentName} without write permission", userId, existingAgent.Name);
+            _logger.LogWarning("User {UserId} attempted to update agent {AgentName} without write permission", LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(existingAgent.Name));
             return false;
         }
 
@@ -218,14 +218,14 @@ public class AgentRepository : IAgentRepository
             var agent = await GetByNameInternalAsync(name, tenant);
             if (agent == null)
             {
-                _logger.LogWarning("Agent {AgentName} not found in tenant {Tenant}", name, tenant);
+                _logger.LogWarning("Agent {AgentName} not found in tenant {Tenant}", LogSanitizer.Sanitize(name), LogSanitizer.Sanitize(tenant));
                 return false;
             }   
 
             // Check if user has owner permission
             if (!CheckPermissions(agent, PermissionLevel.Owner))
             {
-                _logger.LogWarning("User {UserId} attempted to update permissions for agent {AgentName} without owner permission", userId, name);
+                _logger.LogWarning("User {UserId} attempted to update permissions for agent {AgentName} without owner permission", LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(name));
                 return false;
             }
 
@@ -254,14 +254,14 @@ public class AgentRepository : IAgentRepository
             var agent = await _agents.Find(x => x.Id == id).FirstOrDefaultAsync();
             if (agent == null)
             {
-                _logger.LogWarning("Agent with ID {AgentId} not found", id);
+                _logger.LogWarning("Agent with ID {AgentId} not found", LogSanitizer.Sanitize(id));
                 return false;
             }
 
             // Check if user has owner permission
             if (!CheckPermissions(agent, PermissionLevel.Owner))
             {
-                _logger.LogWarning("User {UserId} attempted to delete agent {AgentName} without owner permission", userId, agent.Name);
+                _logger.LogWarning("User {UserId} attempted to delete agent {AgentName} without owner permission", LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(agent.Name));
                 return false;
             }
 
@@ -273,7 +273,7 @@ public class AgentRepository : IAgentRepository
             );
 
             var definitionDeleteResult = await _definitions.DeleteManyAsync(definitionFilter);
-            _logger.LogInformation("Deleted {Count} flow definitions for agent {AgentName}", definitionDeleteResult.DeletedCount, agent.Name);
+            _logger.LogInformation("Deleted {Count} flow definitions for agent {AgentName}", definitionDeleteResult.DeletedCount, LogSanitizer.Sanitize(agent.Name));
 
             // Delete the agent
             var result = await _agents.DeleteOneAsync(x => x.Id == id);
@@ -290,7 +290,7 @@ public class AgentRepository : IAgentRepository
         
         if (!allowedAgents.Any())
         {
-            _logger.LogInformation("User {UserId} has no access to any agents in tenant {Tenant}", userId, tenant);
+            _logger.LogInformation("User {UserId} has no access to any agents in tenant {Tenant}", LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(tenant));
             return new List<AgentWithDefinitions>();
         }
 
@@ -342,7 +342,7 @@ public class AgentRepository : IAgentRepository
             Definitions = definitionsByAgent.TryGetValue(agent.Name, out var defs) ? defs : new List<FlowDefinition>()
         }).ToList();
 
-        _logger.LogInformation("Returning {Count} agents with their definitions for user {UserId}", result.Count, userId);
+        _logger.LogInformation("Returning {Count} agents with their definitions for user {UserId}", result.Count, LogSanitizer.Sanitize(userId));
         return result;
     }
 
@@ -449,7 +449,7 @@ public class AgentRepository : IAgentRepository
         return await MongoRetryHelper.ExecuteWithRetryAsync(async () =>
         {
             _logger.LogInformation("Upserting agent: {AgentName} for user: {UserId} in tenant: {Tenant}. Summary: {Summary}, Description: {Description}, Version: {Version}, Author: {Author}, Category: {Category}", 
-                agentName, createdBy, tenant, summary ?? "NULL", description ?? "NULL", version ?? "NULL", author ?? "NULL", category ?? "NULL");
+                LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(createdBy), LogSanitizer.Sanitize(tenant), LogSanitizer.Sanitize(summary ?? "NULL"), LogSanitizer.Sanitize(description ?? "NULL"), LogSanitizer.Sanitize(version ?? "NULL"), LogSanitizer.Sanitize(author ?? "NULL"), LogSanitizer.Sanitize(category ?? "NULL"));
             
             // Create new agent object
             var newAgent = new Agent
@@ -477,12 +477,12 @@ public class AgentRepository : IAgentRepository
             {
                 // Try to insert the new agent - will fail if duplicate exists due to unique index
                 await _agents.InsertOneAsync(newAgent);
-                _logger.LogInformation("Agent {AgentName} created successfully", agentName);
+                _logger.LogInformation("Agent {AgentName} created successfully", LogSanitizer.Sanitize(agentName));
                 return newAgent;
             }
             catch (MongoWriteException ex) when (ex.WriteError?.Code == 11000) // Duplicate key error
             {
-                _logger.LogInformation("Agent {AgentName} already exists, will update. Provided Summary: {Summary}", agentName, summary ?? "NULL");
+                _logger.LogInformation("Agent {AgentName} already exists, will update. Provided Summary: {Summary}", LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(summary ?? "NULL"));
                 
                 // Agent already exists, get the existing one
                 // Use the actual tenant value from the new agent (which is null for system-scoped agents)
@@ -511,7 +511,7 @@ public class AgentRepository : IAgentRepository
                     if (summary != null)
                     {
                         _logger.LogInformation("Updating summary from '{OldSummary}' to '{NewSummary}' for agent {AgentName}", 
-                            existingAgent.Summary ?? "NULL", summary, agentName);
+                            LogSanitizer.Sanitize(existingAgent.Summary ?? "NULL"), LogSanitizer.Sanitize(summary), LogSanitizer.Sanitize(agentName));
                         updates.Add(updateBuilder.Set(x => x.Summary, summary));
                         existingAgent.Summary = summary;
                         hasUpdates = true;
@@ -519,7 +519,7 @@ public class AgentRepository : IAgentRepository
                     else
                     {
                         _logger.LogInformation("Summary is null, skipping update for agent {AgentName}. Current value: '{CurrentSummary}'", 
-                            agentName, existingAgent.Summary ?? "NULL");
+                            LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(existingAgent.Summary ?? "NULL"));
                     }
                     
                     if (version != null)
@@ -552,7 +552,7 @@ public class AgentRepository : IAgentRepository
                     
                     if (hasUpdates)
                     {
-                        _logger.LogInformation("Updating {Count} fields for existing agent {AgentName}", updates.Count, agentName);
+                        _logger.LogInformation("Updating {Count} fields for existing agent {AgentName}", updates.Count, LogSanitizer.Sanitize(agentName));
                         
                         var tenantFilter = existingAgent.Tenant == null
                             ? Builders<Agent>.Filter.Eq(x => x.Tenant, null)
@@ -566,23 +566,23 @@ public class AgentRepository : IAgentRepository
                         var combinedUpdate = updateBuilder.Combine(updates);
                         var updateResult = await _agents.UpdateOneAsync(filter, combinedUpdate);
                         _logger.LogInformation("Update result for agent {AgentName}: Matched={Matched}, Modified={Modified}", 
-                            agentName, updateResult.MatchedCount, updateResult.ModifiedCount);
+                            LogSanitizer.Sanitize(agentName), updateResult.MatchedCount, updateResult.ModifiedCount);
                     }
                     else
                     {
-                        _logger.LogInformation("No updates to apply for agent {AgentName}", agentName);
+                        _logger.LogInformation("No updates to apply for agent {AgentName}", LogSanitizer.Sanitize(agentName));
                     }
                     
                     return existingAgent;
                 }
                 
                 // This shouldn't happen, but if it does, throw the original exception
-                _logger.LogError(ex, "Agent {AgentName} duplicate key error but could not retrieve existing agent", agentName);
+                _logger.LogError(ex, "Agent {AgentName} duplicate key error but could not retrieve existing agent", LogSanitizer.Sanitize(agentName));
                 throw new InvalidOperationException($"Agent {agentName} creation failed due to duplicate key, but existing agent could not be retrieved", ex);
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Unexpected error while upserting agent {AgentName}", agentName);
+                _logger.LogError(ex, "Unexpected error while upserting agent {AgentName}", LogSanitizer.Sanitize(agentName));
                 throw;
             }
         }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "UpsertAgent");

--- a/XiansAi.Server.Src/Shared/Repositories/ApiKeyRepository.cs
+++ b/XiansAi.Server.Src/Shared/Repositories/ApiKeyRepository.cs
@@ -67,7 +67,7 @@ namespace Shared.Repositories
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Error creating API key for tenant {TenantId}", tenantId);
+                    _logger.LogError(ex, "Error creating API key for tenant {TenantId}", LogSanitizer.Sanitize(tenantId));
                     throw;
                 }
             }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "CreateApiKey");
@@ -86,7 +86,7 @@ namespace Shared.Repositories
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Error revoking API key {ApiKeyId} for tenant {TenantId}", id, tenantId);
+                    _logger.LogError(ex, "Error revoking API key {ApiKeyId} for tenant {TenantId}", LogSanitizer.Sanitize(id), LogSanitizer.Sanitize(tenantId));
                     return false;
                 }
             }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "RevokeApiKey");
@@ -106,7 +106,7 @@ namespace Shared.Repositories
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Error getting API keys for tenant {TenantId}", tenantId);
+                    _logger.LogError(ex, "Error getting API keys for tenant {TenantId}", LogSanitizer.Sanitize(tenantId));
                     return new List<ApiKey>();
                 }
             }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "GetApiKeysByTenant");
@@ -127,7 +127,7 @@ namespace Shared.Repositories
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Error getting API keys for tenant {TenantId} with type {Type}", tenantId, type);
+                    _logger.LogError(ex, "Error getting API keys for tenant {TenantId} with type {Type}", LogSanitizer.Sanitize(tenantId), LogSanitizer.Sanitize(type));
                     return new List<ApiKey>();
                 }
             }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "GetApiKeysByTenantAndType");
@@ -155,7 +155,7 @@ namespace Shared.Repositories
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Error rotating API key {ApiKeyId} for tenant {TenantId}", id, tenantId);
+                    _logger.LogError(ex, "Error rotating API key {ApiKeyId} for tenant {TenantId}", LogSanitizer.Sanitize(id), LogSanitizer.Sanitize(tenantId));
                     return ((string apiKey, ApiKey meta)?)null;
                 }
             }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "RotateApiKey");
@@ -171,7 +171,7 @@ namespace Shared.Repositories
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Error getting API key {ApiKeyId} for tenant {TenantId}", id, tenantId);
+                    _logger.LogError(ex, "Error getting API key {ApiKeyId} for tenant {TenantId}", LogSanitizer.Sanitize(id), LogSanitizer.Sanitize(tenantId));
                     return null;
                 }
             }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "GetApiKeyById");
@@ -187,7 +187,7 @@ namespace Shared.Repositories
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Error getting API key {ApiKeyId}", id);
+                    _logger.LogError(ex, "Error getting API key {ApiKeyId}", LogSanitizer.Sanitize(id));
                     return null;
                 }
             }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "GetApiKeyByIdNoTenant");
@@ -204,7 +204,7 @@ namespace Shared.Repositories
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Error getting API key by raw key for tenant {TenantId}", tenantId);
+                    _logger.LogError(ex, "Error getting API key by raw key for tenant {TenantId}", LogSanitizer.Sanitize(tenantId));
                     return null;
                 }
             }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "GetApiKeyByRawKey");

--- a/XiansAi.Server.Src/Shared/Repositories/ConversationRepository.cs
+++ b/XiansAi.Server.Src/Shared/Repositories/ConversationRepository.cs
@@ -314,7 +314,7 @@ public class ConversationRepository : IConversationRepository
             if (existingThread != null)
             {
                 _logger.LogInformation("Found existing thread {ThreadId} for tenantId {TenantId}, workflowId {WorkflowId}, and participantId {ParticipantId}", 
-                    existingThread.Id, thread.TenantId, thread.WorkflowId, thread.ParticipantId);
+                    LogSanitizer.Sanitize(existingThread.Id), LogSanitizer.Sanitize(thread.TenantId), LogSanitizer.Sanitize(thread.WorkflowId), LogSanitizer.Sanitize(thread.ParticipantId));
                 return existingThread.Id;
             }
 
@@ -325,7 +325,7 @@ public class ConversationRepository : IConversationRepository
             {
                 await _threadsCollection.InsertOneAsync(thread);
                 _logger.LogInformation("Created new thread {ThreadId} for tenantId {TenantId}, workflowId {WorkflowId}, and participantId {ParticipantId}", 
-                    thread.Id, thread.TenantId, thread.WorkflowId, thread.ParticipantId);
+                    LogSanitizer.Sanitize(thread.Id), LogSanitizer.Sanitize(thread.TenantId), LogSanitizer.Sanitize(thread.WorkflowId), LogSanitizer.Sanitize(thread.ParticipantId));
                 return thread.Id;
             }
             catch (MongoWriteException ex) when (ex.WriteError?.Code == 11000)
@@ -367,7 +367,7 @@ public class ConversationRepository : IConversationRepository
 
             var results = await query.ToListAsync();
             _logger.LogDebug("GetByTenantAndAgentAsync returned {Count} threads for tenant {TenantId} and agent {Agent}", 
-                results.Count, tenantId, agent);
+                results.Count, LogSanitizer.Sanitize(tenantId), LogSanitizer.Sanitize(agent));
             
             return results;
         }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "GetByTenantAndAgent");
@@ -381,14 +381,14 @@ public class ConversationRepository : IConversationRepository
             var thread = await _threadsCollection.Find(x => x.Id == id).FirstOrDefaultAsync();
             if (thread == null)
             {
-                _logger.LogWarning("Thread {ThreadId} not found", id);
+                _logger.LogWarning("Thread {ThreadId} not found", LogSanitizer.Sanitize(id));
                 return false;
             }
 
             // Validate tenant ownership (skip check if tenantId is null - SysAdmin action)
             if (tenantId != null && thread.TenantId != tenantId)
             {
-                _logger.LogWarning("Thread {ThreadId} does not belong to tenant {TenantId}. IDOR attempt detected.", id, tenantId);
+                _logger.LogWarning("Thread {ThreadId} does not belong to tenant {TenantId}. IDOR attempt detected.", LogSanitizer.Sanitize(id), LogSanitizer.Sanitize(tenantId));
                 return false;
             }
 
@@ -406,7 +406,7 @@ public class ConversationRepository : IConversationRepository
                         cancellationToken: cancellationToken);
                     
                     _logger.LogInformation("Deleted {MessageCount} messages from thread {ThreadId}", 
-                        messageDeleteResult.DeletedCount, id);
+                        messageDeleteResult.DeletedCount, LogSanitizer.Sanitize(id));
 
                     // Delete the thread
                     var threadDeleteResult = await _threadsCollection.DeleteOneAsync(
@@ -421,7 +421,7 @@ public class ConversationRepository : IConversationRepository
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error deleting thread {ThreadId}", id);
+                _logger.LogError(ex, "Error deleting thread {ThreadId}", LogSanitizer.Sanitize(id));
                 throw;
             }
         }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "DeleteThread");
@@ -448,7 +448,7 @@ public class ConversationRepository : IConversationRepository
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to encrypt message text for message {MessageId}", message.Id);
+                _logger.LogError(ex, "Failed to encrypt message text for message {MessageId}", LogSanitizer.Sanitize(message.Id));
                 throw new InvalidOperationException("Failed to encrypt message text", ex);
             }
         }
@@ -552,7 +552,7 @@ string tenantId, string threadId, int? page = null, int? pageSize = null, string
                 }
                 else
                 {
-                    _logger.LogDebug("Filtering messages by scope `{Scope}`", scope);
+                    _logger.LogDebug("Filtering messages by scope `{Scope}`", LogSanitizer.Sanitize(scope));
                     messageFilter = Builders<ConversationMessage>.Filter.And(
                         messageFilter, 
                         Builders<ConversationMessage>.Filter.Eq(x => x.Scope, scope));
@@ -612,7 +612,7 @@ string tenantId, string threadId, int? page = null, int? pageSize = null, string
                 DecryptMessageText(message);
             }
             
-            _logger.LogDebug("Found history of {Count} messages for thread {ThreadId}", messages.Count, threadId);
+            _logger.LogDebug("Found history of {Count} messages for thread {ThreadId}", messages.Count, LogSanitizer.Sanitize(threadId));
             return messages;
         }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "GetMessagesByThreadId");
     }
@@ -635,12 +635,12 @@ string tenantId, string threadId, int? page = null, int? pageSize = null, string
             // - If scope has a value: return only messages with that exact scope
             if (string.IsNullOrEmpty(scope))
             {
-                _logger.LogDebug("Filtering messages with no scope (null) for workflowId {WorkflowId}", workflowId);
+                _logger.LogDebug("Filtering messages with no scope (null) for workflowId {WorkflowId}", LogSanitizer.Sanitize(workflowId));
                 filter = filterBuilder.And(filter, filterBuilder.Eq(x => x.Scope, null));
             }
             else
             {
-                _logger.LogDebug("Filtering messages by scope `{Scope}` for workflowId {WorkflowId}", scope, workflowId);
+                _logger.LogDebug("Filtering messages by scope `{Scope}` for workflowId {WorkflowId}", LogSanitizer.Sanitize(scope), LogSanitizer.Sanitize(workflowId));
                 filter = filterBuilder.And(filter, filterBuilder.Eq(x => x.Scope, scope));
             }
 
@@ -704,13 +704,13 @@ string tenantId, string threadId, int? page = null, int? pageSize = null, string
                 operationName: "DeleteMessagesByThreadId");
 
             _logger.LogInformation("Deleted {DeletedCount} messages for thread {ThreadId}", 
-                result.DeletedCount, threadId);
+                result.DeletedCount, LogSanitizer.Sanitize(threadId));
             
             return result.DeletedCount >= 0; // Return true even if no messages were found
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error deleting messages for thread {ThreadId}", threadId);
+            _logger.LogError(ex, "Error deleting messages for thread {ThreadId}", LogSanitizer.Sanitize(threadId));
             throw;
         }
     }
@@ -728,7 +728,7 @@ string tenantId, string threadId, int? page = null, int? pageSize = null, string
             catch (KeyNotFoundException)
             {
                 _logger.LogWarning("Thread not found for workflowId {WorkflowId}, participant {ParticipantId}, tenant {TenantId}. No messages to delete.", 
-                    workflowId, participantId, tenantId);
+                    LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(participantId), LogSanitizer.Sanitize(tenantId));
                 return true; // Consider success if thread doesn't exist
             }
 
@@ -757,14 +757,14 @@ string tenantId, string threadId, int? page = null, int? pageSize = null, string
                 operationName: "DeleteMessagesByWorkflowParticipantAndScope");
 
             _logger.LogInformation("Deleted {DeletedCount} messages for workflowId {WorkflowId}, participant {ParticipantId}, scope {Scope}", 
-                result.DeletedCount, workflowId, participantId, scope ?? "null");
+                result.DeletedCount, LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(participantId), LogSanitizer.Sanitize(scope ?? "null"));
             
             return result.DeletedCount >= 0; // Return true even if no messages were found
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error deleting messages for workflowId {WorkflowId}, participant {ParticipantId}, scope {Scope}", 
-                workflowId, participantId, scope ?? "null");
+                LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(participantId), LogSanitizer.Sanitize(scope ?? "null"));
             throw;
         }
     }
@@ -927,7 +927,7 @@ string tenantId, string threadId, int? page = null, int? pageSize = null, string
                 .FirstOrDefaultAsync();
 
             _logger.LogDebug("Last incoming origin for thread {ThreadId} scope {Scope}: {Origin}",
-                threadId, scope ?? "null", message?.Origin ?? "none");
+                LogSanitizer.Sanitize(threadId), LogSanitizer.Sanitize(scope ?? "null"), LogSanitizer.Sanitize(message?.Origin ?? "none"));
 
             return message?.Origin;
         }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "GetLastIncomingOrigin");
@@ -962,7 +962,7 @@ string tenantId, string threadId, int? page = null, int? pageSize = null, string
                 .FirstOrDefaultAsync();
 
             _logger.LogDebug("Last incoming data for thread {ThreadId} scope {Scope}: {HasData}",
-                threadId, scope ?? "null", message?.Data != null ? "yes" : "none");
+                LogSanitizer.Sanitize(threadId), LogSanitizer.Sanitize(scope ?? "null"), message?.Data != null ? "yes" : "none");
 
             return message?.Data;
         }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "GetLastIncomingData");
@@ -1005,7 +1005,7 @@ string tenantId, string threadId, int? page = null, int? pageSize = null, string
             }
 
             _logger.LogDebug("Last incoming origin+data for thread {ThreadId} scope {Scope}: origin={Origin}, hasData={HasData}",
-                threadId, scope ?? "null", origin ?? "none", data != null ? "yes" : "no");
+                LogSanitizer.Sanitize(threadId), LogSanitizer.Sanitize(scope ?? "null"), LogSanitizer.Sanitize(origin ?? "none"), data != null ? "yes" : "no");
 
             return (origin, data);
         }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "GetLastIncomingOriginAndData");
@@ -1063,7 +1063,7 @@ string tenantId, string threadId, int? page = null, int? pageSize = null, string
                 }
                 else
                 {
-                    _logger.LogDebug("Filtering messages by scope `{Scope}` for last task id", scope);
+                    _logger.LogDebug("Filtering messages by scope `{Scope}` for last task id", LogSanitizer.Sanitize(scope));
                     filter = filterBuilder.And(filter, filterBuilder.Eq(x => x.Scope, scope));
                 }
             }
@@ -1078,7 +1078,7 @@ string tenantId, string threadId, int? page = null, int? pageSize = null, string
                 .FirstOrDefaultAsync();
 
             _logger.LogDebug("Last task id for workflow {WorkflowId}, participant {ParticipantId}, scope {Scope}: {TaskId}",
-                workflowId, participantId, scope ?? "null", message?.TaskId ?? "none");
+                LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(participantId), LogSanitizer.Sanitize(scope ?? "null"), LogSanitizer.Sanitize(message?.TaskId ?? "none"));
 
             return message?.TaskId;
         }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "GetLastTaskId");
@@ -1154,23 +1154,23 @@ string tenantId, string threadId, int? page = null, int? pageSize = null, string
                 var messageSpecificSecret = $"{_uniqueSecret}";
                 var decryptedText = _encryptionService.Decrypt(message.Text, messageSpecificSecret);
                 message.Text = decryptedText;
-                _logger.LogTrace("Successfully decrypted message {MessageId}", message.Id);
+                _logger.LogTrace("Successfully decrypted message {MessageId}", LogSanitizer.Sanitize(message.Id));
             }
             catch (FormatException)
             {
                 // Not a valid Base64 string - this is plain text
-                _logger.LogDebug("Message {MessageId} is not encrypted (invalid Base64), treating as plain text", message.Id);
+                _logger.LogDebug("Message {MessageId} is not encrypted (invalid Base64), treating as plain text", LogSanitizer.Sanitize(message.Id));
                 // Leave message.Text as-is
             }
             catch (System.Security.Cryptography.AuthenticationTagMismatchException)
             {
                 // This might be Base64 data that wasn't encrypted by our system
-                _logger.LogWarning("Message {MessageId} appears to be Base64 but decryption failed (authentication tag mismatch). This might be legacy data or corrupted encryption.", message.Id);
+                _logger.LogWarning("Message {MessageId} appears to be Base64 but decryption failed (authentication tag mismatch). This might be legacy data or corrupted encryption.", LogSanitizer.Sanitize(message.Id));
                 // Leave message.Text as-is
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Unexpected error decrypting message {MessageId}. Text will remain as-is.", message.Id);
+                _logger.LogError(ex, "Unexpected error decrypting message {MessageId}. Text will remain as-is.", LogSanitizer.Sanitize(message.Id));
                 // Leave message.Text as-is
             }
         }

--- a/XiansAi.Server.Src/Shared/Repositories/FlowDefinitionRepository.cs
+++ b/XiansAi.Server.Src/Shared/Repositories/FlowDefinitionRepository.cs
@@ -162,7 +162,7 @@ public class FlowDefinitionRepository : IFlowDefinitionRepository
     {
         return await MongoRetryHelper.ExecuteWithRetryAsync(async () =>
         {
-            _logger.LogInformation("Deleting all flow definitions for agent: {AgentName} in tenant: {Tenant}", agentName, tenant);
+            _logger.LogInformation("Deleting all flow definitions for agent: {AgentName} in tenant: {Tenant}", LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(tenant));
             
             // Build filter to match agent name, tenant, and system scoped value
             var filter = Builders<FlowDefinition>.Filter.And(
@@ -172,7 +172,7 @@ public class FlowDefinitionRepository : IFlowDefinitionRepository
             );
             
             var result = await _definitions.DeleteManyAsync(filter);
-            _logger.LogInformation("Deleted {Count} flow definitions for agent: {AgentName} in tenant: {Tenant}", result.DeletedCount, agentName, tenant);
+            _logger.LogInformation("Deleted {Count} flow definitions for agent: {AgentName} in tenant: {Tenant}", result.DeletedCount, LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(tenant));
             return result.DeletedCount;
         }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "DeleteFlowDefinitionsByAgent");
     }

--- a/XiansAi.Server.Src/Shared/Repositories/KnowledgeRepository.cs
+++ b/XiansAi.Server.Src/Shared/Repositories/KnowledgeRepository.cs
@@ -129,7 +129,7 @@ public class KnowledgeRepository : IKnowledgeRepository
 
     public async Task<List<T>> GetByNameAsync<T>(string name, string? agent, string tenantId) where T : IKnowledge
     {
-        _logger.LogInformation("GetByNameAsync: name: {Name}, agent: {Agent}, tenantId: {TenantId}", name, agent, tenantId);
+        _logger.LogInformation("GetByNameAsync: name: {Name}, agent: {Agent}, tenantId: {TenantId}", LogSanitizer.Sanitize(name), LogSanitizer.Sanitize(agent), LogSanitizer.Sanitize(tenantId));
         var collection = GetTypedCollection<T>();
         
         var nameFilter = Builders<T>.Filter.Eq(x => x.Name, name);

--- a/XiansAi.Server.Src/Shared/Repositories/ProcessedEventRepository.cs
+++ b/XiansAi.Server.Src/Shared/Repositories/ProcessedEventRepository.cs
@@ -14,7 +14,7 @@ namespace Shared.Repositories;
 public class ProcessedEvent
 {
     [BsonId]
-    public string DocumentId { get; set; } // ResumeToken string
+    public required string DocumentId { get; set; } // ResumeToken string
     public DateTime ProcessedAt { get; set; }
 }
 

--- a/XiansAi.Server.Src/Shared/Repositories/SecretVaultRepository.cs
+++ b/XiansAi.Server.Src/Shared/Repositories/SecretVaultRepository.cs
@@ -1,6 +1,7 @@
 using MongoDB.Driver;
 using Shared.Data;
 using Shared.Data.Models;
+using Shared.Utils;
 
 namespace Shared.Repositories;
 
@@ -36,7 +37,7 @@ public class SecretVaultRepository : ISecretVaultRepository
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error retrieving secret vault by id {Id}", id);
+            _logger.LogError(ex, "Error retrieving secret vault by id {Id}", LogSanitizer.Sanitize(id));
             return null;
         }
     }
@@ -62,7 +63,7 @@ public class SecretVaultRepository : ISecretVaultRepository
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error retrieving secret vault by key {Key}", key);
+            _logger.LogError(ex, "Error retrieving secret vault by key {Key}", LogSanitizer.Sanitize(key));
             return null;
         }
     }
@@ -91,7 +92,7 @@ public class SecretVaultRepository : ISecretVaultRepository
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error checking existence for key {Key}", key);
+            _logger.LogError(ex, "Error checking existence for key {Key}", LogSanitizer.Sanitize(key));
             return false;
         }
     }
@@ -134,7 +135,7 @@ public class SecretVaultRepository : ISecretVaultRepository
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error finding secret for access key {Key}", key);
+            _logger.LogError(ex, "Error finding secret for access key {Key}", LogSanitizer.Sanitize(key));
             return null;
         }
     }
@@ -168,7 +169,7 @@ public class SecretVaultRepository : ISecretVaultRepository
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error creating secret vault key {Key}", entity.Key);
+            _logger.LogError(ex, "Error creating secret vault key {Key}", LogSanitizer.Sanitize(entity.Key));
             throw;
         }
     }
@@ -182,7 +183,7 @@ public class SecretVaultRepository : ISecretVaultRepository
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error updating secret vault id {Id}", entity.Id);
+            _logger.LogError(ex, "Error updating secret vault id {Id}", LogSanitizer.Sanitize(entity.Id));
             return false;
         }
     }
@@ -196,7 +197,7 @@ public class SecretVaultRepository : ISecretVaultRepository
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error deleting secret vault id {Id}", id);
+            _logger.LogError(ex, "Error deleting secret vault id {Id}", LogSanitizer.Sanitize(id));
             return false;
         }
     }

--- a/XiansAi.Server.Src/Shared/Repositories/TenantOidcConfigRepository.cs
+++ b/XiansAi.Server.Src/Shared/Repositories/TenantOidcConfigRepository.cs
@@ -1,6 +1,7 @@
 using MongoDB.Driver;
 using Shared.Data;
 using Shared.Data.Models;
+using Shared.Utils;
 
 namespace Shared.Repositories;
 
@@ -32,7 +33,7 @@ public class TenantOidcConfigRepository : ITenantOidcConfigRepository
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error retrieving OIDC config for tenant {TenantId}", tenantId);
+            _logger.LogError(ex, "Error retrieving OIDC config for tenant {TenantId}", LogSanitizer.Sanitize(tenantId));
             return null;
         }
     }
@@ -46,7 +47,7 @@ public class TenantOidcConfigRepository : ITenantOidcConfigRepository
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error upserting OIDC config for tenant {TenantId}", config.TenantId);
+            _logger.LogError(ex, "Error upserting OIDC config for tenant {TenantId}", LogSanitizer.Sanitize(config.TenantId));
             throw;
         }
     }
@@ -60,7 +61,7 @@ public class TenantOidcConfigRepository : ITenantOidcConfigRepository
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error deleting OIDC config for tenant {TenantId}", tenantId);
+            _logger.LogError(ex, "Error deleting OIDC config for tenant {TenantId}", LogSanitizer.Sanitize(tenantId));
             return false;
         }
     }

--- a/XiansAi.Server.Src/Shared/Repositories/UsageEventRepository.cs
+++ b/XiansAi.Server.Src/Shared/Repositories/UsageEventRepository.cs
@@ -1355,7 +1355,7 @@ public class UsageEventRepository : IUsageEventRepository
         {
             _logger.LogInformation(
                 "Getting admin metrics timeseries for tenant={TenantId}, agent={AgentName}, category={Category}, type={Type}, groupBy={GroupBy}",
-                request.TenantId, request.AgentName, request.Category, request.Type, request.GroupBy);
+                LogSanitizer.Sanitize(request.TenantId), LogSanitizer.Sanitize(request.AgentName), LogSanitizer.Sanitize(request.Category), LogSanitizer.Sanitize(request.Type), LogSanitizer.Sanitize(request.GroupBy));
 
             // Build filter as BsonDocument to ensure proper field name mapping
             var matchFilter = new BsonDocument
@@ -1521,7 +1521,7 @@ public class UsageEventRepository : IUsageEventRepository
         {
             _logger.LogInformation(
                 "Getting admin metrics categories for tenant={TenantId}, agent={AgentName}, activation={ActivationName}",
-                request.TenantId, request.AgentName ?? "all", request.ActivationName ?? "all");
+                LogSanitizer.Sanitize(request.TenantId), LogSanitizer.Sanitize(request.AgentName ?? "all"), LogSanitizer.Sanitize(request.ActivationName ?? "all"));
 
             // Build filter as BsonDocument to ensure proper field name mapping
             var matchFilter = new BsonDocument

--- a/XiansAi.Server.Src/Shared/Repositories/UserRepository.cs
+++ b/XiansAi.Server.Src/Shared/Repositories/UserRepository.cs
@@ -291,7 +291,7 @@ public class UserRepository : IUserRepository
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Error fetching tenants for user {UserId}", userId);
+            _logger.LogWarning(ex, "Error fetching tenants for user {UserId}", LogSanitizer.Sanitize(userId));
             return new List<TenantInfoDto>();
         }
     }
@@ -336,12 +336,12 @@ public class UserRepository : IUserRepository
             }
             catch (MongoWriteException ex) when (ex.WriteError.Category == ServerErrorCategory.DuplicateKey)
             {
-                _logger.LogWarning(ex, "User {UserId} already exists - duplicate key error", user.UserId);
+                _logger.LogWarning(ex, "User {UserId} already exists - duplicate key error", LogSanitizer.Sanitize(user.UserId));
                 return false;
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error creating user {UserId}", user.UserId);
+                _logger.LogError(ex, "Error creating user {UserId}", LogSanitizer.Sanitize(user.UserId));
                 return false;
             }
         }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "CreateUser");
@@ -442,7 +442,7 @@ public class UserRepository : IUserRepository
             
             if (user == null)
             {
-                _logger.LogWarning("User {UserId} not found", userId);
+                _logger.LogWarning("User {UserId} not found", LogSanitizer.Sanitize(userId));
                 return false;
             }
 
@@ -452,7 +452,7 @@ public class UserRepository : IUserRepository
                 var belongsToTenant = user.TenantRoles.Any(tr => tr.Tenant == tenantId);
                 if (!belongsToTenant)
                 {
-                    _logger.LogWarning("User {UserId} does not belong to tenant {TenantId}. IDOR attempt detected.", userId, tenantId);
+                    _logger.LogWarning("User {UserId} does not belong to tenant {TenantId}. IDOR attempt detected.", LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(tenantId));
                     return false;
                 }
             }

--- a/XiansAi.Server.Src/Shared/Services/ActivationService.cs
+++ b/XiansAi.Server.Src/Shared/Services/ActivationService.cs
@@ -5,6 +5,7 @@ using Shared.Repositories;
 using Shared.Utils.Services;
 using Shared.Utils.Temporal;
 using Features.WebApi.Services;
+using Shared.Utils;
 
 namespace Shared.Services;
 
@@ -81,7 +82,7 @@ public class ActivationService : IActivationService
         try
         {
             _logger.LogInformation("Creating activation {Name} for agent {AgentName} in tenant {TenantId}", 
-                request.Name, request.AgentName, tenantId);
+                LogSanitizer.Sanitize(request.Name), LogSanitizer.Sanitize(request.AgentName), LogSanitizer.Sanitize(tenantId));
 
             if (string.IsNullOrWhiteSpace(request.Name))
             {
@@ -97,14 +98,14 @@ public class ActivationService : IActivationService
             var agent = await _agentRepository.GetByNameInternalAsync(request.AgentName, tenantId);
             if (agent == null)
             {
-                _logger.LogWarning("Agent with name {AgentName} not found in tenant {TenantId}", request.AgentName, tenantId);
+                _logger.LogWarning("Agent with name {AgentName} not found in tenant {TenantId}", LogSanitizer.Sanitize(request.AgentName), LogSanitizer.Sanitize(tenantId));
                 return ServiceResult<AgentActivation>.NotFound($"Agent with name '{request.AgentName}' not found in tenant");
             }
 
             // Verify the agent belongs to the correct tenant
             if (agent.Tenant != tenantId)
             {
-                _logger.LogWarning("Agent {AgentName} does not belong to tenant {TenantId}", request.AgentName, tenantId);
+                _logger.LogWarning("Agent {AgentName} does not belong to tenant {TenantId}", LogSanitizer.Sanitize(request.AgentName), LogSanitizer.Sanitize(tenantId));
                 return ServiceResult<AgentActivation>.Forbidden("Agent does not belong to this tenant");
             }
 
@@ -128,27 +129,27 @@ public class ActivationService : IActivationService
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Validation failed for activation {Name}", request.Name);
+                _logger.LogWarning(ex, "Validation failed for activation {Name}", LogSanitizer.Sanitize(request.Name));
                 return ServiceResult<AgentActivation>.BadRequest($"Validation error: {ex.Message}");
             }
 
             await _activationRepository.CreateAsync(activation);
 
-            _logger.LogInformation("Successfully created activation {ActivationId}", activation.Id);
+            _logger.LogInformation("Successfully created activation {ActivationId}", LogSanitizer.Sanitize(activation.Id));
             return ServiceResult<AgentActivation>.Success(activation);
         }
         catch (MongoWriteException ex) when (ex.WriteError?.Code == 11000)
         {
             // Duplicate key error - activation with same name, agent, and participant already exists
             _logger.LogWarning(ex, "Duplicate activation detected for Name={Name}, AgentName={AgentName}, ParticipantId={ParticipantId}, TenantId={TenantId}", 
-                request.Name, request.AgentName, request.ParticipantId, tenantId);
+                LogSanitizer.Sanitize(request.Name), LogSanitizer.Sanitize(request.AgentName), LogSanitizer.Sanitize(request.ParticipantId), LogSanitizer.Sanitize(tenantId));
             
             return ServiceResult<AgentActivation>.Conflict(
                 $"An activation with the name '{request.Name}' already exists for agent '{request.AgentName}' and participant '{request.ParticipantId}'. Please use a different name or delete the existing activation first.");
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error creating activation {Name}", request.Name);
+            _logger.LogError(ex, "Error creating activation {Name}", LogSanitizer.Sanitize(request.Name));
             return ServiceResult<AgentActivation>.InternalServerError(
                 "An error occurred while creating the activation");
         }
@@ -165,7 +166,7 @@ public class ActivationService : IActivationService
     {
         try
         {
-            _logger.LogInformation("Updating activation {ActivationId}", activationId);
+            _logger.LogInformation("Updating activation {ActivationId}", LogSanitizer.Sanitize(activationId));
 
             if (string.IsNullOrWhiteSpace(activationId))
             {
@@ -175,13 +176,13 @@ public class ActivationService : IActivationService
             var activation = await _activationRepository.GetByIdAsync(activationId);
             if (activation == null)
             {
-                _logger.LogWarning("Activation with ID {ActivationId} not found", activationId);
+                _logger.LogWarning("Activation with ID {ActivationId} not found", LogSanitizer.Sanitize(activationId));
                 return ServiceResult<AgentActivation>.NotFound($"Activation with ID '{activationId}' not found");
             }
 
             if (activation.TenantId != tenantId)
             {
-                _logger.LogWarning("Activation {ActivationId} does not belong to tenant {TenantId}", activationId, tenantId);
+                _logger.LogWarning("Activation {ActivationId} does not belong to tenant {TenantId}", LogSanitizer.Sanitize(activationId), LogSanitizer.Sanitize(tenantId));
                 return ServiceResult<AgentActivation>.Forbidden("Activation does not belong to this tenant");
             }
 
@@ -207,7 +208,7 @@ public class ActivationService : IActivationService
                     _logger.LogWarning(
                         "Attempting to update active activation {ActivationId} with {Count} workflows running. " +
                         "Only description updates are allowed for active activations.",
-                        activationId, activation.WorkflowIds!.Count);
+                        LogSanitizer.Sanitize(activationId), activation.WorkflowIds!.Count);
                     return ServiceResult<AgentActivation>.Conflict(
                         "Cannot update name, participantId, or workflowConfiguration on an activation with running workflows. " +
                         "Only description can be updated. Please deactivate it first to update other fields.");
@@ -215,7 +216,7 @@ public class ActivationService : IActivationService
 
                 _logger.LogInformation(
                     "Allowing description-only update for active activation {ActivationId} with {Count} running workflows",
-                    activationId, activation.WorkflowIds!.Count);
+                    LogSanitizer.Sanitize(activationId), activation.WorkflowIds!.Count);
             }
 
             // Update only the fields that are provided
@@ -243,7 +244,7 @@ public class ActivationService : IActivationService
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogWarning(ex, "Invalid workflow configuration provided for activation {ActivationId}", activationId);
+                    _logger.LogWarning(ex, "Invalid workflow configuration provided for activation {ActivationId}", LogSanitizer.Sanitize(activationId));
                     return ServiceResult<AgentActivation>.BadRequest($"Invalid workflow configuration: {ex.Message}");
                 }
 
@@ -257,24 +258,24 @@ public class ActivationService : IActivationService
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Validation failed for activation {ActivationId}", activationId);
+                _logger.LogWarning(ex, "Validation failed for activation {ActivationId}", LogSanitizer.Sanitize(activationId));
                 return ServiceResult<AgentActivation>.BadRequest($"Validation error: {ex.Message}");
             }
 
             await _activationRepository.UpdateAsync(activationId, activation);
 
-            _logger.LogInformation("Successfully updated activation {ActivationId}", activationId);
+            _logger.LogInformation("Successfully updated activation {ActivationId}", LogSanitizer.Sanitize(activationId));
             return ServiceResult<AgentActivation>.Success(activation);
         }
         catch (MongoDB.Driver.MongoWriteException ex) when (ex.WriteError?.Code == 11000)
         {
-            _logger.LogWarning(ex, "Duplicate activation detected when updating {ActivationId}", activationId);
+            _logger.LogWarning(ex, "Duplicate activation detected when updating {ActivationId}", LogSanitizer.Sanitize(activationId));
             return ServiceResult<AgentActivation>.Conflict(
                 "An activation with this name already exists for the same agent and participant. Please use a different name.");
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error updating activation {ActivationId}", activationId);
+            _logger.LogError(ex, "Error updating activation {ActivationId}", LogSanitizer.Sanitize(activationId));
             return ServiceResult<AgentActivation>.InternalServerError(
                 "An error occurred while updating the activation");
         }
@@ -287,7 +288,7 @@ public class ActivationService : IActivationService
     {
         try
         {
-            _logger.LogInformation("Retrieving activation by ID {ActivationId}", id);
+            _logger.LogInformation("Retrieving activation by ID {ActivationId}", LogSanitizer.Sanitize(id));
 
             if (string.IsNullOrWhiteSpace(id))
             {
@@ -297,7 +298,7 @@ public class ActivationService : IActivationService
             var activation = await _activationRepository.GetByIdAsync(id);
             if (activation == null)
             {
-                _logger.LogWarning("Activation with ID {ActivationId} not found", id);
+                _logger.LogWarning("Activation with ID {ActivationId} not found", LogSanitizer.Sanitize(id));
                 return ServiceResult<AgentActivation>.NotFound($"Activation with ID '{id}' not found");
             }
 
@@ -305,7 +306,7 @@ public class ActivationService : IActivationService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error retrieving activation by ID {ActivationId}", id);
+            _logger.LogError(ex, "Error retrieving activation by ID {ActivationId}", LogSanitizer.Sanitize(id));
             return ServiceResult<AgentActivation>.InternalServerError(
                 "An error occurred while retrieving the activation");
         }
@@ -320,22 +321,22 @@ public class ActivationService : IActivationService
         {
             if (string.IsNullOrWhiteSpace(agentName))
             {
-                _logger.LogInformation("Retrieving all activations for tenant {TenantId}", tenantId);
+                _logger.LogInformation("Retrieving all activations for tenant {TenantId}", LogSanitizer.Sanitize(tenantId));
                 var activations = await _activationRepository.GetByTenantIdAsync(tenantId);
-                _logger.LogInformation("Found {Count} activations for tenant {TenantId}", activations.Count, tenantId);
+                _logger.LogInformation("Found {Count} activations for tenant {TenantId}", activations.Count, LogSanitizer.Sanitize(tenantId));
                 return ServiceResult<List<AgentActivation>>.Success(activations);
             }
             else
             {
-                _logger.LogInformation("Retrieving activations for tenant {TenantId} filtered by agent name {AgentName}", tenantId, agentName);
+                _logger.LogInformation("Retrieving activations for tenant {TenantId} filtered by agent name {AgentName}", LogSanitizer.Sanitize(tenantId), LogSanitizer.Sanitize(agentName));
                 var activations = await _activationRepository.GetByAgentNameAsync(agentName, tenantId);
-                _logger.LogInformation("Found {Count} activations for tenant {TenantId} with agent name {AgentName}", activations.Count, tenantId, agentName);
+                _logger.LogInformation("Found {Count} activations for tenant {TenantId} with agent name {AgentName}", activations.Count, LogSanitizer.Sanitize(tenantId), LogSanitizer.Sanitize(agentName));
                 return ServiceResult<List<AgentActivation>>.Success(activations);
             }
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error retrieving activations for tenant {TenantId}", tenantId);
+            _logger.LogError(ex, "Error retrieving activations for tenant {TenantId}", LogSanitizer.Sanitize(tenantId));
             return ServiceResult<List<AgentActivation>>.InternalServerError(
                 "An error occurred while retrieving activations");
         }
@@ -351,25 +352,25 @@ public class ActivationService : IActivationService
     {
         try
         {
-            _logger.LogInformation("Activating agent for activation {ActivationId}", activationId);
+            _logger.LogInformation("Activating agent for activation {ActivationId}", LogSanitizer.Sanitize(activationId));
 
             var activation = await _activationRepository.GetByIdAsync(activationId);
             if (activation == null)
             {
-                _logger.LogWarning("Activation with ID {ActivationId} not found", activationId);
+                _logger.LogWarning("Activation with ID {ActivationId} not found", LogSanitizer.Sanitize(activationId));
                 return ServiceResult<AgentActivation>.NotFound($"Activation with ID '{activationId}' not found");
             }
 
             if (activation.TenantId != tenantId)
             {
-                _logger.LogWarning("Activation {ActivationId} does not belong to tenant {TenantId}", activationId, tenantId);
+                _logger.LogWarning("Activation {ActivationId} does not belong to tenant {TenantId}", LogSanitizer.Sanitize(activationId), LogSanitizer.Sanitize(tenantId));
                 return ServiceResult<AgentActivation>.Forbidden("Activation does not belong to this tenant");
             }
 
             // If workflow configuration is provided in the request, update the activation with it
             if (workflowConfiguration != null)
             {
-                _logger.LogInformation("Updating activation {ActivationId} with workflow configuration from request", activationId);
+                _logger.LogInformation("Updating activation {ActivationId} with workflow configuration from request", LogSanitizer.Sanitize(activationId));
                 
                 // Validate the workflow configuration
                 try
@@ -378,7 +379,7 @@ public class ActivationService : IActivationService
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogWarning(ex, "Invalid workflow configuration provided for activation {ActivationId}", activationId);
+                    _logger.LogWarning(ex, "Invalid workflow configuration provided for activation {ActivationId}", LogSanitizer.Sanitize(activationId));
                     return ServiceResult<AgentActivation>.BadRequest($"Invalid workflow configuration: {ex.Message}");
                 }
 
@@ -386,14 +387,14 @@ public class ActivationService : IActivationService
                 activation.WorkflowConfiguration = workflowConfiguration;
                 await _activationRepository.UpdateAsync(activationId, activation);
                 
-                _logger.LogInformation("Successfully updated workflow configuration for activation {ActivationId}", activationId);
+                _logger.LogInformation("Successfully updated workflow configuration for activation {ActivationId}", LogSanitizer.Sanitize(activationId));
             }
 
             // Get the agent details
             var agent = await _agentRepository.GetByNameInternalAsync(activation.AgentName, tenantId);
             if (agent == null)
             {
-                _logger.LogWarning("Agent with name {AgentName} not found in tenant {TenantId}", activation.AgentName, tenantId);
+                _logger.LogWarning("Agent with name {AgentName} not found in tenant {TenantId}", LogSanitizer.Sanitize(activation.AgentName), LogSanitizer.Sanitize(tenantId));
                 return ServiceResult<AgentActivation>.NotFound($"Agent with name '{activation.AgentName}' not found in tenant");
             }
 
@@ -405,12 +406,12 @@ public class ActivationService : IActivationService
 
             if (flowDefinitions == null || flowDefinitions.Count == 0)
             {
-                _logger.LogWarning("No workflow definitions found for agent {AgentName}", activation.AgentName);
+                _logger.LogWarning("No workflow definitions found for agent {AgentName}", LogSanitizer.Sanitize(activation.AgentName));
                 return ServiceResult<AgentActivation>.BadRequest($"No workflow definitions found for agent '{activation.AgentName}'");
             }
 
             _logger.LogInformation("Found {Count} workflow definitions for agent {AgentName}", 
-                flowDefinitions.Count, activation.AgentName);
+                flowDefinitions.Count, LogSanitizer.Sanitize(activation.AgentName));
 
             // Start all workflows using WorkflowStarterService
             try
@@ -424,7 +425,7 @@ public class ActivationService : IActivationService
                     {
                         if (!flowDefinition.Activable)
                         {
-                            _logger.LogWarning("Workflow {WorkflowType} is not activable", flowDefinition.WorkflowType);
+                            _logger.LogWarning("Workflow {WorkflowType} is not activable", LogSanitizer.Sanitize(flowDefinition.WorkflowType));
                             continue;
                         }
 
@@ -469,18 +470,18 @@ public class ActivationService : IActivationService
                             startedCount++;
                             
                             _logger.LogInformation("Started workflow {WorkflowType} with ID {WorkflowId} for activation {ActivationId}", 
-                                flowDefinition.WorkflowType, result.Data.WorkflowId, activationId);
+                                LogSanitizer.Sanitize(flowDefinition.WorkflowType), LogSanitizer.Sanitize(result.Data.WorkflowId), LogSanitizer.Sanitize(activationId));
                         }
                         else
                         {
                             _logger.LogWarning("Failed to start workflow {WorkflowType} for activation {ActivationId}: {Error}", 
-                                flowDefinition.WorkflowType, activationId, result.ErrorMessage);
+                                LogSanitizer.Sanitize(flowDefinition.WorkflowType), LogSanitizer.Sanitize(activationId), LogSanitizer.Sanitize(result.ErrorMessage));
                         }
                     }
                     catch (Exception ex)
                     {
                         _logger.LogError(ex, "Error starting workflow {WorkflowType} for activation {ActivationId}", 
-                            flowDefinition.WorkflowType, activationId);
+                            LogSanitizer.Sanitize(flowDefinition.WorkflowType), LogSanitizer.Sanitize(activationId));
                         // stop here and return the error
                         return ServiceResult<AgentActivation>.InternalServerError(
                             $"Failed to start workflow {flowDefinition.WorkflowType} for activation {activationId}: {ex.Message}");
@@ -489,7 +490,7 @@ public class ActivationService : IActivationService
 
                 if (workflowIds.Count == 0)
                 {
-                    _logger.LogWarning("No workflows were started for activation {ActivationId} (none activable or all failed). Activating with empty workflow list.", activationId);
+                    _logger.LogWarning("No workflows were started for activation {ActivationId} (none activable or all failed). Activating with empty workflow list.", LogSanitizer.Sanitize(activationId));
                 }
 
                 // Update activation with workflow IDs and timestamp
@@ -509,14 +510,14 @@ public class ActivationService : IActivationService
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error starting workflows for activation {ActivationId}", activationId);
+                _logger.LogError(ex, "Error starting workflows for activation {ActivationId}", LogSanitizer.Sanitize(activationId));
                 return ServiceResult<AgentActivation>.InternalServerError(
                     $"Failed to start workflows: {ex.Message}");
             }
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error activating agent for activation {ActivationId}", activationId);
+            _logger.LogError(ex, "Error activating agent for activation {ActivationId}", LogSanitizer.Sanitize(activationId));
             return ServiceResult<AgentActivation>.InternalServerError(
                 "An error occurred while activating the agent");
         }
@@ -536,25 +537,25 @@ public class ActivationService : IActivationService
     {
         try
         {
-            _logger.LogInformation("Deactivating agent for activation {ActivationId}", activationId);
+            _logger.LogInformation("Deactivating agent for activation {ActivationId}", LogSanitizer.Sanitize(activationId));
 
             var activation = await _activationRepository.GetByIdAsync(activationId);
             if (activation == null)
             {
-                _logger.LogWarning("Activation with ID {ActivationId} not found", activationId);
+                _logger.LogWarning("Activation with ID {ActivationId} not found", LogSanitizer.Sanitize(activationId));
                 return ServiceResult<AgentActivation>.NotFound($"Activation with ID '{activationId}' not found");
             }
 
             if (activation.TenantId != tenantId)
             {
-                _logger.LogWarning("Activation {ActivationId} does not belong to tenant {TenantId}", activationId, tenantId);
+                _logger.LogWarning("Activation {ActivationId} does not belong to tenant {TenantId}", LogSanitizer.Sanitize(activationId), LogSanitizer.Sanitize(tenantId));
                 return ServiceResult<AgentActivation>.Forbidden("Activation does not belong to this tenant");
             }
 
             // Perform comprehensive cleanup of all workflows and schedules associated with this activation
             _logger.LogInformation(
                 "Starting comprehensive cleanup for activation {ActivationId} (Name: {Name}, Agent: {Agent})",
-                activationId, activation.Name, activation.AgentName);
+                LogSanitizer.Sanitize(activationId), LogSanitizer.Sanitize(activation.Name), LogSanitizer.Sanitize(activation.AgentName));
 
             var cleanupResult = await _cleanupService.CleanupActivationResourcesAsync(activation);
 
@@ -562,7 +563,7 @@ public class ActivationService : IActivationService
             {
                 _logger.LogError(
                     "Failed to cleanup resources for activation {ActivationId}: {Error}",
-                    activationId, cleanupResult.ErrorMessage);
+                    LogSanitizer.Sanitize(activationId), LogSanitizer.Sanitize(cleanupResult.ErrorMessage));
                 return ServiceResult<AgentActivation>.InternalServerError(
                     $"Failed to cleanup activation resources: {cleanupResult.ErrorMessage}");
             }
@@ -574,7 +575,7 @@ public class ActivationService : IActivationService
                 "Cleanup completed for activation {ActivationId}. " +
                 "Workflows: {CancelledWorkflows}/{TotalWorkflows} cancelled ({FailedWorkflows} failed), " +
                 "Schedules: {DeletedSchedules}/{TotalSchedules} deleted ({FailedSchedules} failed)",
-                activationId,
+                LogSanitizer.Sanitize(activationId),
                 cleanup.WorkflowCleanup.CancelledCount,
                 cleanup.WorkflowCleanup.TotalWorkflows,
                 cleanup.WorkflowCleanup.FailedCount,
@@ -588,7 +589,7 @@ public class ActivationService : IActivationService
                 _logger.LogWarning(
                     "Activation {ActivationId} cleanup had failures. " +
                     "Failed workflows: {FailedWorkflows}, Failed schedules: {FailedSchedules}",
-                    activationId,
+                    LogSanitizer.Sanitize(activationId),
                     cleanup.WorkflowCleanup.FailedCount,
                     cleanup.ScheduleCleanup.FailedCount);
                 
@@ -608,7 +609,7 @@ public class ActivationService : IActivationService
             _logger.LogInformation(
                 "Successfully deactivated activation {ActivationId}. " +
                 "Total resources cleaned: {TotalWorkflows} workflows, {TotalSchedules} schedules",
-                activationId,
+                LogSanitizer.Sanitize(activationId),
                 cleanup.WorkflowCleanup.TotalWorkflows,
                 cleanup.ScheduleCleanup.TotalSchedules);
             
@@ -616,7 +617,7 @@ public class ActivationService : IActivationService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error deactivating agent for activation {ActivationId}", activationId);
+            _logger.LogError(ex, "Error deactivating agent for activation {ActivationId}", LogSanitizer.Sanitize(activationId));
             return ServiceResult<AgentActivation>.InternalServerError(
                 "An error occurred while deactivating the agent");
         }
@@ -630,7 +631,7 @@ public class ActivationService : IActivationService
     {
         try
         {
-            _logger.LogInformation("Deleting activation {ActivationId}", activationId);
+            _logger.LogInformation("Deleting activation {ActivationId}", LogSanitizer.Sanitize(activationId));
 
             if (string.IsNullOrWhiteSpace(activationId))
             {
@@ -640,7 +641,7 @@ public class ActivationService : IActivationService
             var activation = await _activationRepository.GetByIdAsync(activationId);
             if (activation == null)
             {
-                _logger.LogWarning("Activation with ID {ActivationId} not found", activationId);
+                _logger.LogWarning("Activation with ID {ActivationId} not found", LogSanitizer.Sanitize(activationId));
                 return ServiceResult<bool>.NotFound($"Activation with ID '{activationId}' not found");
             }
 
@@ -648,23 +649,23 @@ public class ActivationService : IActivationService
             if (activation.WorkflowIds != null && activation.WorkflowIds.Count > 0)
             {
                 _logger.LogWarning("Attempting to delete activation {ActivationId} with {Count} workflows running.", 
-                    activationId, activation.WorkflowIds.Count);
+                    LogSanitizer.Sanitize(activationId), activation.WorkflowIds.Count);
                 return ServiceResult<bool>.Conflict("Cannot delete an activation with running workflows. Please deactivate it first.");
             }
 
             var deleted = await _activationRepository.DeleteAsync(activationId);
             if (!deleted)
             {
-                _logger.LogWarning("Failed to delete activation {ActivationId}", activationId);
+                _logger.LogWarning("Failed to delete activation {ActivationId}", LogSanitizer.Sanitize(activationId));
                 return ServiceResult<bool>.InternalServerError("Failed to delete the activation");
             }
 
-            _logger.LogInformation("Successfully deleted activation {ActivationId}", activationId);
+            _logger.LogInformation("Successfully deleted activation {ActivationId}", LogSanitizer.Sanitize(activationId));
             return ServiceResult<bool>.Success(true);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error deleting activation {ActivationId}", activationId);
+            _logger.LogError(ex, "Error deleting activation {ActivationId}", LogSanitizer.Sanitize(activationId));
             return ServiceResult<bool>.InternalServerError(
                 "An error occurred while deleting the activation");
         }

--- a/XiansAi.Server.Src/Shared/Services/ActivationValidationService.cs
+++ b/XiansAi.Server.Src/Shared/Services/ActivationValidationService.cs
@@ -1,5 +1,6 @@
 using Shared.Repositories;
 using Shared.Utils.Services;
+using Shared.Utils;
 
 namespace Shared.Services;
 
@@ -113,7 +114,7 @@ public class ActivationValidationService : IActivationValidationService
             var flowDefinitions = await _flowDefinitionRepository.GetByNameAsync(agentName, tenantId);
             if (flowDefinitions == null || flowDefinitions.Count == 0)
             {
-                _logger.LogWarning("No workflow definitions found for agent '{AgentName}' in tenant {TenantId}", agentName, tenantId);
+                _logger.LogWarning("No workflow definitions found for agent '{AgentName}' in tenant {TenantId}", LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(tenantId));
                 return ServiceResult.Failure(
                     $" No agent process registered for agent '{agentName}'. Unable to use this agent for this purpose.",
                     StatusCode.BadRequest);
@@ -134,7 +135,7 @@ public class ActivationValidationService : IActivationValidationService
                 var registeredList = registeredTypes.Count > 0 ? string.Join(", ", registeredTypes) : "none";
                 _logger.LogWarning(
                     "Workflow type '{WorkflowType}' is not registered for agent '{AgentName}'. Registered types: {Registered}",
-                    workflowType, agentName, registeredList);
+                    LogSanitizer.Sanitize(workflowType), LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(registeredList));
                 return ServiceResult.Failure(
                     $"Workflow type '{workflowType}' is not registered for agent '{agentName}'. Registered workflow types: {registeredList}.",
                     StatusCode.BadRequest);
@@ -146,7 +147,7 @@ public class ActivationValidationService : IActivationValidationService
         {
             _logger.LogError(ex,
                 "Error validating workflow type '{WorkflowType}' for agent '{AgentName}' in tenant {TenantId}",
-                workflowType, agentName, tenantId);
+                LogSanitizer.Sanitize(workflowType), LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(tenantId));
             return ServiceResult.InternalServerError(
                 "An error occurred while validating the workflow type");
         }
@@ -161,7 +162,7 @@ public class ActivationValidationService : IActivationValidationService
             {
                 _logger.LogWarning(
                     "Activation '{ActivationName}' not found for agent '{AgentName}' in tenant {TenantId}",
-                    activationName, agentName, tenantId);
+                    LogSanitizer.Sanitize(activationName), LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(tenantId));
                 return ServiceResult.Failure(
                     $"Activation '{activationName}' not found for agent '{agentName}'",
                     StatusCode.NotFound);
@@ -171,7 +172,7 @@ public class ActivationValidationService : IActivationValidationService
             {
                 _logger.LogWarning(
                     "Activation '{ActivationName}' for agent '{AgentName}' is deactivated",
-                    activationName, agentName);
+                    LogSanitizer.Sanitize(activationName), LogSanitizer.Sanitize(agentName));
                 return ServiceResult.Failure(
                     $"Activation '{activationName}' is deactivated",
                     StatusCode.Conflict);
@@ -183,7 +184,7 @@ public class ActivationValidationService : IActivationValidationService
         {
             _logger.LogError(ex,
                 "Error validating activation '{ActivationName}' for agent '{AgentName}' in tenant {TenantId}",
-                activationName, agentName, tenantId);
+                LogSanitizer.Sanitize(activationName), LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(tenantId));
             return ServiceResult.InternalServerError(
                 "An error occurred while validating the activation");
         }

--- a/XiansAi.Server.Src/Shared/Services/AdminAgentService.cs
+++ b/XiansAi.Server.Src/Shared/Services/AdminAgentService.cs
@@ -3,6 +3,7 @@ using Shared.Data.Models;
 using Shared.Repositories;
 using Shared.Services;
 using Shared.Utils.Services;
+using Shared.Utils;
 
 namespace Shared.Services;
 
@@ -71,7 +72,7 @@ public class AdminAgentService : IAdminAgentService
     {
         try
         {
-            _logger.LogInformation("Retrieving agent instances for tenant {TenantId}", tenantId);
+            _logger.LogInformation("Retrieving agent instances for tenant {TenantId}", LogSanitizer.Sanitize(tenantId));
 
             // Get tenant-scoped agents (instances) - SystemScoped = false
             var agents = await _agentRepository.GetAgentsWithPermissionAsync(
@@ -107,7 +108,7 @@ public class AdminAgentService : IAdminAgentService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error retrieving agent instances for tenant {TenantId}", tenantId);
+            _logger.LogError(ex, "Error retrieving agent instances for tenant {TenantId}", LogSanitizer.Sanitize(tenantId));
             return ServiceResult<AgentListResult>.InternalServerError(
                 "An error occurred while retrieving agent instances");
         }
@@ -120,7 +121,7 @@ public class AdminAgentService : IAdminAgentService
     {
         try
         {
-            _logger.LogInformation("Retrieving agent instance by name {AgentName} in tenant {TenantId}", agentName, tenantId);
+            _logger.LogInformation("Retrieving agent instance by name {AgentName} in tenant {TenantId}", LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(tenantId));
 
             if (string.IsNullOrWhiteSpace(agentName))
             {
@@ -135,14 +136,14 @@ public class AdminAgentService : IAdminAgentService
             var agent = await _agentRepository.GetByNameInternalAsync(agentName, tenantId);
             if (agent == null)
             {
-                _logger.LogWarning("Agent with name {AgentName} not found in tenant {TenantId}", agentName, tenantId);
+                _logger.LogWarning("Agent with name {AgentName} not found in tenant {TenantId}", LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(tenantId));
                 return ServiceResult<AgentWithDefinitions>.NotFound($"Agent with name '{agentName}' not found in tenant '{tenantId}'");
             }
 
             // Fetch workflow definitions for this agent
             var definitions = await _flowDefinitionRepository.GetByNameAsync(agentName, tenantId);
             
-            _logger.LogInformation("Found {Count} workflow definitions for agent {AgentName}", definitions?.Count ?? 0, agentName);
+            _logger.LogInformation("Found {Count} workflow definitions for agent {AgentName}", definitions?.Count ?? 0, LogSanitizer.Sanitize(agentName));
 
             var result = new AgentWithDefinitions
             {
@@ -154,7 +155,7 @@ public class AdminAgentService : IAdminAgentService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error retrieving agent instance by name {AgentName} in tenant {TenantId}", agentName, tenantId);
+            _logger.LogError(ex, "Error retrieving agent instance by name {AgentName} in tenant {TenantId}", LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(tenantId));
             return ServiceResult<AgentWithDefinitions>.InternalServerError(
                 "An error occurred while retrieving the agent instance");
         }
@@ -167,7 +168,7 @@ public class AdminAgentService : IAdminAgentService
     {
         try
         {
-            _logger.LogInformation("Updating agent instance {AgentName} in tenant {TenantId}", agentName, tenantId);
+            _logger.LogInformation("Updating agent instance {AgentName} in tenant {TenantId}", LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(tenantId));
 
             if (string.IsNullOrWhiteSpace(agentName))
             {
@@ -182,7 +183,7 @@ public class AdminAgentService : IAdminAgentService
             var agent = await _agentRepository.GetByNameInternalAsync(agentName, tenantId);
             if (agent == null)
             {
-                _logger.LogWarning("Agent with name {AgentName} not found in tenant {TenantId}", agentName, tenantId);
+                _logger.LogWarning("Agent with name {AgentName} not found in tenant {TenantId}", LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(tenantId));
                 return ServiceResult<Agent>.NotFound($"Agent with name '{agentName}' not found in tenant '{tenantId}'");
             }
 
@@ -193,7 +194,7 @@ public class AdminAgentService : IAdminAgentService
                 var existingAgent = await _agentRepository.GetByNameInternalAsync(request.Name, agent.Tenant);
                 if (existingAgent != null && existingAgent.Id != agent.Id)
                 {
-                    _logger.LogWarning("Agent with name {Name} already exists in tenant {TenantId}", request.Name, agent.Tenant);
+                    _logger.LogWarning("Agent with name {Name} already exists in tenant {TenantId}", LogSanitizer.Sanitize(request.Name), LogSanitizer.Sanitize(agent.Tenant));
                     return ServiceResult<Agent>.Conflict($"Agent with name '{request.Name}' already exists in tenant");
                 }
                 agent.Name = request.Name;
@@ -217,16 +218,16 @@ public class AdminAgentService : IAdminAgentService
             var updated = await _agentRepository.UpdateInternalAsync(agent.Id, agent);
             if (!updated)
             {
-                _logger.LogWarning("Failed to update agent {AgentName} in tenant {TenantId}", agentName, tenantId);
+                _logger.LogWarning("Failed to update agent {AgentName} in tenant {TenantId}", LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(tenantId));
                 return ServiceResult<Agent>.InternalServerError("Failed to update the agent");
             }
 
-            _logger.LogInformation("Successfully updated agent instance {AgentName} in tenant {TenantId}", agentName, tenantId);
+            _logger.LogInformation("Successfully updated agent instance {AgentName} in tenant {TenantId}", LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(tenantId));
             return ServiceResult<Agent>.Success(agent);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error updating agent instance {AgentName} in tenant {TenantId}", agentName, tenantId);
+            _logger.LogError(ex, "Error updating agent instance {AgentName} in tenant {TenantId}", LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(tenantId));
             return ServiceResult<Agent>.InternalServerError(
                 "An error occurred while updating the agent instance");
         }
@@ -239,7 +240,7 @@ public class AdminAgentService : IAdminAgentService
     {
         try
         {
-            _logger.LogInformation("Deleting agent instance {AgentName} in tenant {TenantId}", agentName, tenantId);
+            _logger.LogInformation("Deleting agent instance {AgentName} in tenant {TenantId}", LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(tenantId));
 
             if (string.IsNullOrWhiteSpace(agentName))
             {
@@ -254,7 +255,7 @@ public class AdminAgentService : IAdminAgentService
             var agent = await _agentRepository.GetByNameInternalAsync(agentName, tenantId);
             if (agent == null)
             {
-                _logger.LogWarning("Agent with name {AgentName} not found in tenant {TenantId}", agentName, tenantId);
+                _logger.LogWarning("Agent with name {AgentName} not found in tenant {TenantId}", LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(tenantId));
                 return ServiceResult<bool>.NotFound($"Agent with name '{agentName}' not found in tenant '{tenantId}'");
             }
 
@@ -262,7 +263,7 @@ public class AdminAgentService : IAdminAgentService
             var deletionResult = await _agentDeletionService.DeleteAgentAsync(agent.Name, agent.SystemScoped);
             if (!deletionResult.IsSuccess)
             {
-                _logger.LogWarning("Failed to delete agent {AgentName} in tenant {TenantId}: {Error}", agentName, tenantId, deletionResult.ErrorMessage);
+                _logger.LogWarning("Failed to delete agent {AgentName} in tenant {TenantId}: {Error}", LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(tenantId), LogSanitizer.Sanitize(deletionResult.ErrorMessage));
                 return deletionResult.StatusCode switch
                 {
                     StatusCode.BadRequest => ServiceResult<bool>.BadRequest(deletionResult.ErrorMessage ?? "Bad request"),
@@ -274,12 +275,12 @@ public class AdminAgentService : IAdminAgentService
                 };
             }
 
-            _logger.LogInformation("Successfully deleted agent instance {AgentName} in tenant {TenantId}", agentName, tenantId);
+            _logger.LogInformation("Successfully deleted agent instance {AgentName} in tenant {TenantId}", LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(tenantId));
             return ServiceResult<bool>.Success(true);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error deleting agent instance {AgentName} in tenant {TenantId}", agentName, tenantId);
+            _logger.LogError(ex, "Error deleting agent instance {AgentName} in tenant {TenantId}", LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(tenantId));
             return ServiceResult<bool>.InternalServerError(
                 "An error occurred while deleting the agent instance");
         }

--- a/XiansAi.Server.Src/Shared/Services/AdminDataService.cs
+++ b/XiansAi.Server.Src/Shared/Services/AdminDataService.cs
@@ -2,6 +2,7 @@ using Features.AgentApi.Repositories;
 using Shared.Utils.Services;
 using System.Text.Json;
 using MongoDB.Bson;
+using Shared.Utils;
 
 namespace Shared.Services;
 
@@ -194,13 +195,13 @@ public class AdminDataService : IAdminDataService
 
             _logger.LogInformation(
                 "Data schema retrieved successfully - AgentName: {AgentName}, Types: {TypeCount}",
-                request.AgentName, documentTypes.Count);
+                LogSanitizer.Sanitize(request.AgentName), documentTypes.Count);
 
             return ServiceResult<AdminDataSchemaResponse>.Success(response);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to retrieve data schema. Error: {ErrorMessage}", ex.Message);
+            _logger.LogError(ex, "Failed to retrieve data schema. Error: {ErrorMessage}", LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<AdminDataSchemaResponse>.InternalServerError("Failed to retrieve data schema");
         }
     }
@@ -271,7 +272,7 @@ public class AdminDataService : IAdminDataService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to retrieve data. Error: {ErrorMessage}", ex.Message);
+            _logger.LogError(ex, "Failed to retrieve data. Error: {ErrorMessage}", LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<AdminDataListResponse>.InternalServerError("Failed to retrieve data");
         }
     }
@@ -330,7 +331,7 @@ public class AdminDataService : IAdminDataService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to delete data. Error: {ErrorMessage}", ex.Message);
+            _logger.LogError(ex, "Failed to delete data. Error: {ErrorMessage}", LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<AdminDataDeleteResponse>.InternalServerError("Failed to delete data");
         }
     }
@@ -350,7 +351,7 @@ public class AdminDataService : IAdminDataService
         {
             _logger.LogInformation(
                 "Deleting record - TenantId: {TenantId}, RecordId: {RecordId}",
-                request.TenantId, request.RecordId);
+                LogSanitizer.Sanitize(request.TenantId), LogSanitizer.Sanitize(request.RecordId));
 
             // First, get the record to return it in the response (for confirmation)
             var existingRecord = await _documentRepository.GetByIdAsync(request.RecordId);
@@ -361,12 +362,12 @@ public class AdminDataService : IAdminDataService
                 if (existingRecord == null)
                 {
                     _logger.LogWarning("Record not found - RecordId: {RecordId}, TenantId: {TenantId}", 
-                        request.RecordId, request.TenantId);
+                        LogSanitizer.Sanitize(request.RecordId), LogSanitizer.Sanitize(request.TenantId));
                 }
                 else
                 {
                     _logger.LogWarning("Access denied - Record belongs to different tenant. RecordId: {RecordId}, RequestedTenant: {TenantId}, ActualTenant: {ActualTenantId}", 
-                        request.RecordId, request.TenantId, existingRecord.TenantId);
+                        LogSanitizer.Sanitize(request.RecordId), LogSanitizer.Sanitize(request.TenantId), LogSanitizer.Sanitize(existingRecord.TenantId));
                 }
 
                 // Return a not found response (the endpoint will handle the structured response)
@@ -387,13 +388,13 @@ public class AdminDataService : IAdminDataService
             {
                 _logger.LogInformation(
                     "Record deleted successfully - RecordId: {RecordId}, TenantId: {TenantId}, AgentName: {AgentName}, DataType: {DataType}",
-                    request.RecordId, request.TenantId, existingRecord.AgentId, existingRecord.Type);
+                    LogSanitizer.Sanitize(request.RecordId), LogSanitizer.Sanitize(request.TenantId), LogSanitizer.Sanitize(existingRecord.AgentId), LogSanitizer.Sanitize(existingRecord.Type));
             }
             else
             {
                 _logger.LogWarning(
                     "Record deletion failed - RecordId: {RecordId}, TenantId: {TenantId}",
-                    request.RecordId, request.TenantId);
+                    LogSanitizer.Sanitize(request.RecordId), LogSanitizer.Sanitize(request.TenantId));
             }
 
             return ServiceResult<AdminDataDeleteRecordResponse>.Success(response);
@@ -401,7 +402,7 @@ public class AdminDataService : IAdminDataService
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to delete record. RecordId: {RecordId}, Error: {ErrorMessage}", 
-                request.RecordId, ex.Message);
+                LogSanitizer.Sanitize(request.RecordId), LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<AdminDataDeleteRecordResponse>.InternalServerError("Failed to delete record");
         }
     }

--- a/XiansAi.Server.Src/Shared/Services/AdminLogsService.cs
+++ b/XiansAi.Server.Src/Shared/Services/AdminLogsService.cs
@@ -1,6 +1,7 @@
 using Features.WebApi.Models;
 using Features.WebApi.Repositories;
 using Shared.Utils.Services;
+using Shared.Utils;
 
 namespace Shared.Services;
 
@@ -125,9 +126,9 @@ public class AdminLogsService : IAdminLogsService
                 "Retrieving admin logs - TenantId: {TenantId}, AgentName: {AgentName}, ActivationName: {ActivationName}, " +
                 "ParticipantId: {ParticipantId}, WorkflowIds: {WorkflowIds}, WorkflowType: {WorkflowType}, " +
                 "LogLevels: {LogLevels}, StartDate: {StartDate}, EndDate: {EndDate}, Page: {Page}, PageSize: {PageSize}",
-                tenantId, agentName ?? "null", activationName ?? "null", participantId ?? "null",
+                LogSanitizer.Sanitize(tenantId), LogSanitizer.Sanitize(agentName ?? "null"), LogSanitizer.Sanitize(activationName ?? "null"), LogSanitizer.Sanitize(participantId ?? "null"),
                 workflowIds != null ? string.Join(",", workflowIds) : "null",
-                workflowType ?? "null",
+                LogSanitizer.Sanitize(workflowType ?? "null"),
                 logLevels != null ? string.Join(",", logLevels.Select(l => l.ToString())) : "null",
                 startDate?.ToString() ?? "null", endDate?.ToString() ?? "null", page, pageSize);
 
@@ -161,7 +162,7 @@ public class AdminLogsService : IAdminLogsService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to retrieve admin logs. Error: {ErrorMessage}", ex.Message);
+            _logger.LogError(ex, "Failed to retrieve admin logs. Error: {ErrorMessage}", LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<AdminLogsResponse>.InternalServerError("Failed to retrieve logs");
         }
     }
@@ -195,8 +196,8 @@ public class AdminLogsService : IAdminLogsService
                 "Retrieving admin log streams - TenantId: {TenantId}, AgentName: {AgentName}, ActivationName: {ActivationName}, " +
                 "ParticipantId: {ParticipantId}, WorkflowType: {WorkflowType}, LogLevels: {LogLevels}, " +
                 "StartDate: {StartDate}, EndDate: {EndDate}, Page: {Page}, PageSize: {PageSize}",
-                tenantId, agentName ?? "null", activationName ?? "null", participantId ?? "null",
-                workflowType ?? "null",
+                LogSanitizer.Sanitize(tenantId), LogSanitizer.Sanitize(agentName ?? "null"), LogSanitizer.Sanitize(activationName ?? "null"), LogSanitizer.Sanitize(participantId ?? "null"),
+                LogSanitizer.Sanitize(workflowType ?? "null"),
                 logLevels != null ? string.Join(",", logLevels.Select(l => l.ToString())) : "null",
                 startDate?.ToString() ?? "null", endDate?.ToString() ?? "null", page, pageSize);
 
@@ -229,7 +230,7 @@ public class AdminLogsService : IAdminLogsService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to retrieve admin log streams. Error: {ErrorMessage}", ex.Message);
+            _logger.LogError(ex, "Failed to retrieve admin log streams. Error: {ErrorMessage}", LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<AdminLogStreamsResponse>.InternalServerError("Failed to retrieve log streams");
         }
     }

--- a/XiansAi.Server.Src/Shared/Services/AdminMetricsService.cs
+++ b/XiansAi.Server.Src/Shared/Services/AdminMetricsService.cs
@@ -1,6 +1,7 @@
 using Shared.Data.Models.Usage;
 using Shared.Repositories;
 using Shared.Utils.Services;
+using Shared.Utils;
 
 namespace Shared.Services;
 
@@ -81,7 +82,7 @@ public class AdminMetricsService : IAdminMetricsService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to retrieve metrics stats. Error: {ErrorMessage}", ex.Message);
+            _logger.LogError(ex, "Failed to retrieve metrics stats. Error: {ErrorMessage}", LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<AdminMetricsStatsResponse>.InternalServerError("Failed to retrieve metrics statistics");
         }
     }
@@ -101,7 +102,7 @@ public class AdminMetricsService : IAdminMetricsService
         {
             _logger.LogInformation(
                 "Getting metrics timeseries - TenantId: {TenantId}, AgentName: {AgentName}, Category: {Category}, Type: {Type}, GroupBy: {GroupBy}",
-                request.TenantId, request.AgentName, request.Category, request.Type, request.GroupBy);
+                LogSanitizer.Sanitize(request.TenantId), LogSanitizer.Sanitize(request.AgentName), LogSanitizer.Sanitize(request.Category), LogSanitizer.Sanitize(request.Type), LogSanitizer.Sanitize(request.GroupBy));
 
             var response = await _repository.GetAdminMetricsTimeSeriesAsync(request, cancellationToken);
 
@@ -113,7 +114,7 @@ public class AdminMetricsService : IAdminMetricsService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to retrieve metrics timeseries. Error: {ErrorMessage}", ex.Message);
+            _logger.LogError(ex, "Failed to retrieve metrics timeseries. Error: {ErrorMessage}", LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<AdminMetricsTimeSeriesResponse>.InternalServerError("Failed to retrieve metrics timeseries");
         }
     }
@@ -133,7 +134,7 @@ public class AdminMetricsService : IAdminMetricsService
         {
             _logger.LogInformation(
                 "Getting metrics categories - TenantId: {TenantId}, AgentName: {AgentName}",
-                request.TenantId, request.AgentName ?? "all");
+                LogSanitizer.Sanitize(request.TenantId), LogSanitizer.Sanitize(request.AgentName ?? "all"));
 
             var response = await _repository.GetAdminMetricsCategoriesAsync(request, cancellationToken);
 
@@ -145,7 +146,7 @@ public class AdminMetricsService : IAdminMetricsService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to retrieve metrics categories. Error: {ErrorMessage}", ex.Message);
+            _logger.LogError(ex, "Failed to retrieve metrics categories. Error: {ErrorMessage}", LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<AdminMetricsCategoriesResponse>.InternalServerError("Failed to retrieve metrics categories");
         }
     }
@@ -233,14 +234,14 @@ public class AdminMetricsService : IAdminMetricsService
 
         if (!ValidGroupByValues.Contains(request.GroupBy.ToLower()))
         {
-            _logger.LogWarning("Invalid groupBy value: {GroupBy}", request.GroupBy);
+            _logger.LogWarning("Invalid groupBy value: {GroupBy}", LogSanitizer.Sanitize(request.GroupBy));
             return ServiceResult<AdminMetricsTimeSeriesResponse>.BadRequest(
                 $"GroupBy must be one of: {string.Join(", ", ValidGroupByValues)}");
         }
 
         if (!ValidAggregationValues.Contains(request.Aggregation.ToLower()))
         {
-            _logger.LogWarning("Invalid aggregation value: {Aggregation}", request.Aggregation);
+            _logger.LogWarning("Invalid aggregation value: {Aggregation}", LogSanitizer.Sanitize(request.Aggregation));
             return ServiceResult<AdminMetricsTimeSeriesResponse>.BadRequest(
                 $"Aggregation must be one of: {string.Join(", ", ValidAggregationValues)}");
         }

--- a/XiansAi.Server.Src/Shared/Services/AdminStatsService.cs
+++ b/XiansAi.Server.Src/Shared/Services/AdminStatsService.cs
@@ -1,5 +1,6 @@
 using Shared.Repositories;
 using Shared.Utils.Services;
+using Shared.Utils;
 
 namespace Shared.Services;
 
@@ -101,7 +102,7 @@ public class AdminStatsService : IAdminStatsService
             
             if (!taskStatsResult.IsSuccess)
             {
-                _logger.LogError("Failed to retrieve task statistics: {Error}", taskStatsResult.ErrorMessage);
+                _logger.LogError("Failed to retrieve task statistics: {Error}", LogSanitizer.Sanitize(taskStatsResult.ErrorMessage));
                 return ServiceResult<AdminStatsResponse>.InternalServerError("Failed to retrieve task statistics");
             }
 
@@ -130,7 +131,7 @@ public class AdminStatsService : IAdminStatsService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to retrieve admin stats. Error: {ErrorMessage}", ex.Message);
+            _logger.LogError(ex, "Failed to retrieve admin stats. Error: {ErrorMessage}", LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<AdminStatsResponse>.InternalServerError("Failed to retrieve admin statistics");
         }
     }
@@ -160,7 +161,7 @@ public class AdminStatsService : IAdminStatsService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to retrieve messaging statistics. Error: {ErrorMessage}", ex.Message);
+            _logger.LogError(ex, "Failed to retrieve messaging statistics. Error: {ErrorMessage}", LogSanitizer.Sanitize(ex.Message));
             
             // Return zero stats on error rather than failing the entire request
             return new MessagingStatsData

--- a/XiansAi.Server.Src/Shared/Services/AdminTaskService.cs
+++ b/XiansAi.Server.Src/Shared/Services/AdminTaskService.cs
@@ -108,7 +108,7 @@ public class AdminTaskService : IAdminTaskService
 
         try
         {
-            _logger.LogInformation("Retrieving task with workflow ID: {WorkflowId}", workflowId);
+            _logger.LogInformation("Retrieving task with workflow ID: {WorkflowId}", LogSanitizer.Sanitize(workflowId));
             var client = await _clientFactory.GetClientAsync();
 
             var workflowHandle = client.GetWorkflowHandle(workflowId);
@@ -185,13 +185,13 @@ public class AdminTaskService : IAdminTaskService
                 TenantId = tenantId
             };
 
-            _logger.LogInformation("Successfully retrieved task {WorkflowId}", workflowId);
+            _logger.LogInformation("Successfully retrieved task {WorkflowId}", LogSanitizer.Sanitize(workflowId));
             return ServiceResult<AdminTaskInfoResponse>.Success(response);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to retrieve task {WorkflowId}. Error: {ErrorMessage}",
-                workflowId, ex.Message);
+                LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<AdminTaskInfoResponse>.BadRequest($"Failed to retrieve task: {ex.Message}");
         }
     }
@@ -256,7 +256,7 @@ public class AdminTaskService : IAdminTaskService
             }
 
             var listQuery = string.Join(" and ", queryParts);
-            _logger.LogDebug("Executing paginated tasks query: {Query}", listQuery);
+            _logger.LogDebug("Executing paginated tasks query: {Query}", LogSanitizer.Sanitize(listQuery));
 
             // Get total count efficiently using CountWorkflow API if available
             int? totalCount = await GetWorkflowCountAsync(client, listQuery, agentName);
@@ -335,12 +335,12 @@ public class AdminTaskService : IAdminTaskService
             };
 
             _logger.LogInformation("Retrieved {Count} tasks for page (Total: {TotalCount})", 
-                allTasks.Count, totalCount?.ToString() ?? "unknown");
+                allTasks.Count, LogSanitizer.Sanitize(totalCount?.ToString() ?? "unknown"));
             return ServiceResult<AdminPaginatedTasksResponse>.Success(response);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to retrieve paginated tasks. Error: {ErrorMessage}", ex.Message);
+            _logger.LogError(ex, "Failed to retrieve paginated tasks. Error: {ErrorMessage}", LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<AdminPaginatedTasksResponse>.InternalServerError("Failed to retrieve tasks");
         }
     }
@@ -356,7 +356,7 @@ public class AdminTaskService : IAdminTaskService
             // Build count query - add Task Workflow filter when agentName is not specified
             var countQuery = listQuery;
 
-            _logger.LogDebug("Executing count query: {CountQuery}", countQuery);
+            _logger.LogDebug("Executing count query: {CountQuery}", LogSanitizer.Sanitize(countQuery));
 
             // Call CountWorkflowsAsync directly - available in Temporal Server v1.20+
             var countResponse = await client.CountWorkflowsAsync(countQuery);
@@ -365,7 +365,7 @@ public class AdminTaskService : IAdminTaskService
         }
         catch (NotSupportedException ex)
         {
-            _logger.LogDebug("CountWorkflow API not supported in this Temporal version: {Message}", ex.Message);
+            _logger.LogDebug("CountWorkflow API not supported in this Temporal version: {Message}", LogSanitizer.Sanitize(ex.Message));
             return null;
         }
         catch (Exception ex)
@@ -467,7 +467,7 @@ public class AdminTaskService : IAdminTaskService
             }
 
             var baseQuery = string.Join(" and ", baseQueryParts);
-            _logger.LogDebug("Base statistics query: {Query}", baseQuery);
+            _logger.LogDebug("Base statistics query: {Query}", LogSanitizer.Sanitize(baseQuery));
 
             // Try to use CountWorkflow API for efficient statistics
             var statistics = await GetTaskStatisticsUsingCountApi(client, baseQuery);
@@ -482,7 +482,7 @@ public class AdminTaskService : IAdminTaskService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to retrieve task statistics. Error: {ErrorMessage}", ex.Message);
+            _logger.LogError(ex, "Failed to retrieve task statistics. Error: {ErrorMessage}", LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<TaskStatisticsResponse>.InternalServerError("Failed to retrieve task statistics");
         }
     }
@@ -553,7 +553,7 @@ public class AdminTaskService : IAdminTaskService
         }
         catch (NotSupportedException ex)
         {
-            _logger.LogDebug("CountWorkflow API not supported in this Temporal version: {Message}", ex.Message);
+            _logger.LogDebug("CountWorkflow API not supported in this Temporal version: {Message}", LogSanitizer.Sanitize(ex.Message));
             return null;
         }
         catch (Exception ex)
@@ -671,7 +671,7 @@ public class AdminTaskService : IAdminTaskService
 
         try
         {
-            _logger.LogInformation("Updating draft for task {WorkflowId}", workflowId);
+            _logger.LogInformation("Updating draft for task {WorkflowId}", LogSanitizer.Sanitize(workflowId));
             var client = await _clientFactory.GetClientAsync();
 
             var workflowHandle = client.GetWorkflowHandle(workflowId);
@@ -679,13 +679,13 @@ public class AdminTaskService : IAdminTaskService
             // Send UpdateDraft signal
             await workflowHandle.SignalAsync("UpdateDraft", new object[] { updatedDraft });
 
-            _logger.LogInformation("Successfully updated draft for task {WorkflowId}", workflowId);
+            _logger.LogInformation("Successfully updated draft for task {WorkflowId}", LogSanitizer.Sanitize(workflowId));
             return ServiceResult<object>.Success(new { message = "Draft updated successfully" });
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to update draft for task {WorkflowId}. Error: {ErrorMessage}",
-                workflowId, ex.Message);
+                LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<object>.BadRequest($"Failed to update draft: {ex.Message}");
         }
     }
@@ -703,14 +703,14 @@ public class AdminTaskService : IAdminTaskService
 
         if (string.IsNullOrWhiteSpace(action))
         {
-            _logger.LogWarning("Attempt to perform action with empty action for task {WorkflowId}", workflowId);
+            _logger.LogWarning("Attempt to perform action with empty action for task {WorkflowId}", LogSanitizer.Sanitize(workflowId));
             return ServiceResult<object>.BadRequest("Action cannot be empty");
         }
 
         try
         {
             _logger.LogInformation("Performing action '{Action}' on task {WorkflowId} with comment: {Comment}", 
-                action, workflowId, comment ?? "(none)");
+                LogSanitizer.Sanitize(action), LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(comment ?? "(none)"));
             var client = await _clientFactory.GetClientAsync();
 
             var workflowHandle = client.GetWorkflowHandle(workflowId);
@@ -719,13 +719,13 @@ public class AdminTaskService : IAdminTaskService
             var actionRequest = new { Action = action, Comment = comment };
             await workflowHandle.SignalAsync("PerformAction", new object[] { actionRequest });
 
-            _logger.LogInformation("Successfully performed action '{Action}' on task {WorkflowId}", action, workflowId);
+            _logger.LogInformation("Successfully performed action '{Action}' on task {WorkflowId}", LogSanitizer.Sanitize(action), LogSanitizer.Sanitize(workflowId));
             return ServiceResult<object>.Success(new { message = $"Action '{action}' performed successfully" });
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to perform action '{Action}' on task {WorkflowId}. Error: {ErrorMessage}",
-                action, workflowId, ex.Message);
+                LogSanitizer.Sanitize(action), LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<object>.BadRequest($"Failed to perform action: {ex.Message}");
         }
     }

--- a/XiansAi.Server.Src/Shared/Services/AgentService.cs
+++ b/XiansAi.Server.Src/Shared/Services/AgentService.cs
@@ -7,6 +7,7 @@ using Shared.Repositories;
 using Shared.Utils.Services;
 using Features.WebApi.Services;
 using System.Text.RegularExpressions;
+using Shared.Utils;
 
 namespace Shared.Services;
 
@@ -118,7 +119,7 @@ public class AgentDeletionService : IAgentDeletionService
                 var activations = await _activationRepository.GetByAgentNameAsync(agentName, tenantId);
                 if (activations != null && activations.Count > 0)
                 {
-                    _logger.LogWarning("Cannot delete agent {AgentName} - {Count} activation(s) exist", agentName, activations.Count);
+                    _logger.LogWarning("Cannot delete agent {AgentName} - {Count} activation(s) exist", LogSanitizer.Sanitize(agentName), activations.Count);
                     return ServiceResult<AgentDeletionResult>.Conflict(
                         $"Cannot delete agent '{agentName}' because it has {activations.Count} activation(s). Please delete all activations first.");
                 }
@@ -136,7 +137,7 @@ public class AgentDeletionService : IAgentDeletionService
                 }
                 else
                 {
-                    _logger.LogWarning("Failed deleting schedules for agent {Agent}: {Error}", agentName, scheduleResult.ErrorMessage);
+                    _logger.LogWarning("Failed deleting schedules for agent {Agent}: {Error}", LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(scheduleResult.ErrorMessage));
                 }
             }
 
@@ -159,7 +160,7 @@ public class AgentDeletionService : IAgentDeletionService
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Failed to delete knowledge for agent {Agent}", agentName);
+                _logger.LogWarning(ex, "Failed to delete knowledge for agent {Agent}", LogSanitizer.Sanitize(agentName));
             }
 
             // Delete flow definitions
@@ -190,7 +191,7 @@ public class AgentDeletionService : IAgentDeletionService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Unexpected error deleting agent {AgentName}", agentName);
+            _logger.LogError(ex, "Unexpected error deleting agent {AgentName}", LogSanitizer.Sanitize(agentName));
             return ServiceResult<AgentDeletionResult>.InternalServerError("An error occurred while deleting the agent");
         }
     }

--- a/XiansAi.Server.Src/Shared/Services/ApiKeyService.cs
+++ b/XiansAi.Server.Src/Shared/Services/ApiKeyService.cs
@@ -5,6 +5,7 @@ using Shared.Data.Models;
 using Microsoft.Extensions.Caching.Memory;
 using System.Security.Cryptography;
 using System.Text;
+using Shared.Utils;
 namespace Shared.Services
 {
     public interface IApiKeyService
@@ -42,7 +43,7 @@ namespace Shared.Services
 
         public async Task<ServiceResult<(string apiKey, ApiKey meta)>> CreateApiKeyAsync(string tenantId, string name, string createdBy, string? agentName = null, string? activationName = null, string? type = null, string? workflowName = null, string? participantId = null, int? timeoutInSeconds = null, string? webhookName = null)
         {
-            _logger.LogInformation("Creating API key for tenant {TenantId} by {CreatedBy}", tenantId, createdBy);
+            _logger.LogInformation("Creating API key for tenant {TenantId} by {CreatedBy}", LogSanitizer.Sanitize(tenantId), LogSanitizer.Sanitize(createdBy));
             try
             {
                 var result = await _apiKeyRepository.CreateAsync(tenantId, name, createdBy, agentName, activationName, type, workflowName, participantId, timeoutInSeconds, webhookName);
@@ -50,19 +51,19 @@ namespace Shared.Services
             }
             catch (MongoWriteException ex) when (ex.WriteError?.Category == ServerErrorCategory.DuplicateKey)
             {
-                _logger.LogWarning("Duplicate API key name '{Name}' for tenant {TenantId}", name, tenantId);
+                _logger.LogWarning("Duplicate API key name '{Name}' for tenant {TenantId}", LogSanitizer.Sanitize(name), LogSanitizer.Sanitize(tenantId));
                 return ServiceResult<(string, ApiKey)>.Conflict($"API key name '{name}' was previously created for this tenant, use another name.");
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error creating API key for tenant {TenantId}", tenantId);
+                _logger.LogError(ex, "Error creating API key for tenant {TenantId}", LogSanitizer.Sanitize(tenantId));
                 return ServiceResult<(string, ApiKey)>.InternalServerError("An error occurred while creating the API key");
             }
         }
 
         public async Task<ServiceResult<bool>> RevokeApiKeyAsync(string id, string tenantId)
         {
-            _logger.LogInformation("Revoking API key {ApiKeyId} for tenant {TenantId}", id, tenantId);
+            _logger.LogInformation("Revoking API key {ApiKeyId} for tenant {TenantId}", LogSanitizer.Sanitize(id), LogSanitizer.Sanitize(tenantId));
             try
             {
                 // Get the API key first to invalidate its cache entry
@@ -77,21 +78,21 @@ namespace Shared.Services
                 {
                     var cacheKey = $"{CacheKeyPrefix}{tenantId}:{existingKey.HashedKey}";
                     _cache.Remove(cacheKey);
-                    _logger.LogDebug("Invalidated cache for revoked API key {ApiKeyId} in tenant {TenantId}", id, tenantId);
+                    _logger.LogDebug("Invalidated cache for revoked API key {ApiKeyId} in tenant {TenantId}", LogSanitizer.Sanitize(id), LogSanitizer.Sanitize(tenantId));
                 }
                 
                 return ServiceResult<bool>.Success(true);
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error revoking API key {ApiKeyId} for tenant {TenantId}", id, tenantId);
+                _logger.LogError(ex, "Error revoking API key {ApiKeyId} for tenant {TenantId}", LogSanitizer.Sanitize(id), LogSanitizer.Sanitize(tenantId));
                 return ServiceResult<bool>.InternalServerError("An error occurred while revoking the API key");
             }
         }
 
         public async Task<ServiceResult<List<ApiKey>>> GetApiKeysAsync(string tenantId)
         {
-            _logger.LogInformation("Getting API keys for tenant {TenantId}", tenantId);
+            _logger.LogInformation("Getting API keys for tenant {TenantId}", LogSanitizer.Sanitize(tenantId));
             try
             {
                 var keys = await _apiKeyRepository.GetByTenantAsync(tenantId);
@@ -99,14 +100,14 @@ namespace Shared.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error getting API keys for tenant {TenantId}", tenantId);
+                _logger.LogError(ex, "Error getting API keys for tenant {TenantId}", LogSanitizer.Sanitize(tenantId));
                 return ServiceResult<List<ApiKey>>.InternalServerError("An error occurred while retrieving API keys");
             }
         }
 
         public async Task<ServiceResult<(string apiKey, ApiKey meta)?>> RotateApiKeyAsync(string id, string tenantId)
         {
-            _logger.LogInformation("Rotating API key {ApiKeyId} for tenant {TenantId}", id, tenantId);
+            _logger.LogInformation("Rotating API key {ApiKeyId} for tenant {TenantId}", LogSanitizer.Sanitize(id), LogSanitizer.Sanitize(tenantId));
             try
             {
                 // Get the existing API key to invalidate its cache entry
@@ -121,7 +122,7 @@ namespace Shared.Services
                 {
                     var oldCacheKey = $"{CacheKeyPrefix}{tenantId}:{existingKey.HashedKey}";
                     _cache.Remove(oldCacheKey);
-                    _logger.LogDebug("Invalidated old cache for rotated API key {ApiKeyId} in tenant {TenantId}", id, tenantId);
+                    _logger.LogDebug("Invalidated old cache for rotated API key {ApiKeyId} in tenant {TenantId}", LogSanitizer.Sanitize(id), LogSanitizer.Sanitize(tenantId));
                 }
                 
                 // The new key will be cached on first use by GetApiKeyByRawKeyAsync
@@ -130,7 +131,7 @@ namespace Shared.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error rotating API key {ApiKeyId} for tenant {TenantId}", id, tenantId);
+                _logger.LogError(ex, "Error rotating API key {ApiKeyId} for tenant {TenantId}", LogSanitizer.Sanitize(id), LogSanitizer.Sanitize(tenantId));
                 return ServiceResult<(string, ApiKey)?>.InternalServerError("An error occurred while rotating the API key");
             }
         }
@@ -146,7 +147,7 @@ namespace Shared.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error getting API key by id {ApiKeyId} for tenant {TenantId}", id, tenantId);
+                _logger.LogError(ex, "Error getting API key by id {ApiKeyId} for tenant {TenantId}", LogSanitizer.Sanitize(id), LogSanitizer.Sanitize(tenantId));
                 return ServiceResult<ApiKey?>.InternalServerError("An error occurred while retrieving the API key");
             }
         }
@@ -159,7 +160,7 @@ namespace Shared.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error getting API key by id {ApiKeyId}", id);
+                _logger.LogError(ex, "Error getting API key by id {ApiKeyId}", LogSanitizer.Sanitize(id));
                 return null;
             }
         }
@@ -172,7 +173,7 @@ namespace Shared.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error getting webhook API keys for tenant {TenantId}", tenantId);
+                _logger.LogError(ex, "Error getting webhook API keys for tenant {TenantId}", LogSanitizer.Sanitize(tenantId));
                 return new List<ApiKey>();
             }
         }
@@ -189,12 +190,12 @@ namespace Shared.Services
                 // Try to get from cache first
                 if (_cache.TryGetValue(cacheKey, out ApiKey? cachedApiKey))
                 {
-                    _logger.LogDebug("Retrieved API key for tenant {TenantId} from cache", tenantId);
+                    _logger.LogDebug("Retrieved API key for tenant {TenantId} from cache", LogSanitizer.Sanitize(tenantId));
                     return cachedApiKey;
                 }
                 
                 // Cache miss - fetch from database
-                _logger.LogDebug("Cache miss for tenant {TenantId} API key, fetching from database", tenantId);
+                _logger.LogDebug("Cache miss for tenant {TenantId} API key, fetching from database", LogSanitizer.Sanitize(tenantId));
                 var apiKey = await _apiKeyRepository.GetByRawKeyAsync(rawKey, tenantId);
                 
                 // Cache the result (including null results to prevent repeated DB hits for invalid keys)
@@ -214,14 +215,14 @@ namespace Shared.Services
                         .SetAbsoluteExpiration(TimeSpan.FromMinutes(2))
                         .SetSize(1);
                     _cache.Set(cacheKey, (ApiKey?)null, cacheOptions);
-                    _logger.LogDebug("Cached null API key result for tenant {TenantId}", tenantId);
+                    _logger.LogDebug("Cached null API key result for tenant {TenantId}", LogSanitizer.Sanitize(tenantId));
                 }
                 
                 return apiKey;
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error getting API key by raw key for tenant {TenantId}", tenantId);
+                _logger.LogError(ex, "Error getting API key by raw key for tenant {TenantId}", LogSanitizer.Sanitize(tenantId));
                 throw;
             }
         }

--- a/XiansAi.Server.Src/Shared/Services/EmailService.cs
+++ b/XiansAi.Server.Src/Shared/Services/EmailService.cs
@@ -1,4 +1,5 @@
 using Shared.Providers;
+using Shared.Utils;
 
 namespace Shared.Services;
 
@@ -43,7 +44,7 @@ public class EmailService : IEmailService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error sending email to {Recipient} with subject '{Subject}'", to, subject);
+            _logger.LogError(ex, "Error sending email to {Recipient} with subject '{Subject}'", LogSanitizer.RedactEmail(to), LogSanitizer.Sanitize(subject));
             throw new Exception("Error sending email", ex);
         }
     }
@@ -68,7 +69,7 @@ public class EmailService : IEmailService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error sending email to {RecipientCount} recipients with subject '{Subject}'", to.Count(), subject);
+            _logger.LogError(ex, "Error sending email to {RecipientCount} recipients with subject '{Subject}'", to.Count(), LogSanitizer.Sanitize(subject));
             throw new Exception("Error sending email", ex);
         }
     }

--- a/XiansAi.Server.Src/Shared/Services/FeedbackService.cs
+++ b/XiansAi.Server.Src/Shared/Services/FeedbackService.cs
@@ -165,19 +165,19 @@ public class FeedbackService : IFeedbackService
         try
         {
             var id = await _feedbackRepository.SaveFeedbackAsync(doc);
-            _logger.LogInformation("Saved message feedback {FeedbackId} for message {MessageId}", id, request.MessageId);
+            _logger.LogInformation("Saved message feedback {FeedbackId} for message {MessageId}", LogSanitizer.Sanitize(id), LogSanitizer.Sanitize(request.MessageId));
             return ServiceResult<string>.Success(id, StatusCode.Created);
         }
         catch (MongoWriteException ex) when (
             ex.WriteError?.Code == 11000
             || ex.WriteError?.Category == ServerErrorCategory.DuplicateKey)
         {
-            _logger.LogDebug(ex, "Duplicate feedback insert for message {MessageId} (tenant unique index)", request.MessageId);
+            _logger.LogDebug(ex, "Duplicate feedback insert for message {MessageId} (tenant unique index)", LogSanitizer.Sanitize(request.MessageId));
             return ServiceResult<string>.Conflict("Feedback has already been submitted for this message.");
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to save feedback for message {MessageId}", request.MessageId);
+            _logger.LogError(ex, "Failed to save feedback for message {MessageId}", LogSanitizer.Sanitize(request.MessageId));
             return ServiceResult<string>.InternalServerError("Failed to save feedback.");
         }
     }

--- a/XiansAi.Server.Src/Shared/Services/KnowledgeService.cs
+++ b/XiansAi.Server.Src/Shared/Services/KnowledgeService.cs
@@ -150,7 +150,7 @@ public class KnowledgeService : IKnowledgeService
         if (knowledge.TenantId != null && knowledge.TenantId != _tenantContext.TenantId)
         {
             _logger.LogWarning("Unauthorized access attempt to knowledge {Id} from tenant {TenantId}",
-                knowledge.Id, _tenantContext.TenantId);
+                LogSanitizer.Sanitize(knowledge.Id), LogSanitizer.Sanitize(_tenantContext.TenantId));
             throw new SecurityException("Access denied: Knowledge does not belong to this tenant");
         }
     }
@@ -221,7 +221,7 @@ public class KnowledgeService : IKnowledgeService
             if (!_tenantContext.UserRoles.Contains(SystemRoles.SysAdmin))
             {
                 _logger.LogWarning("Unauthorized access attempt to delete system-scoped knowledge by user {UserId}",
-                    _tenantContext.LoggedInUser);
+                    LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
                 return Results.Json(
                     new { error = "Forbidden", message = "Only system administrators can delete system-scoped knowledge" },
                     statusCode: StatusCodes.Status403Forbidden);
@@ -237,7 +237,7 @@ public class KnowledgeService : IKnowledgeService
                 if (!agentNames.Contains(knowledge.Agent, StringComparer.OrdinalIgnoreCase))
                 {
                     _logger.LogWarning("Unauthorized access attempt to delete knowledge for agent {Agent} by user {UserId}",
-                        knowledge.Agent, _tenantContext.LoggedInUser);
+                        LogSanitizer.Sanitize(knowledge.Agent), LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
                     return Results.Json(
                         new { error = "Forbidden", message = "You do not have permission to delete this knowledge" },
                         statusCode: StatusCodes.Status403Forbidden);
@@ -286,7 +286,7 @@ public class KnowledgeService : IKnowledgeService
             if (!_tenantContext.UserRoles.Contains(SystemRoles.SysAdmin))
             {
                 _logger.LogWarning("Unauthorized access attempt to delete system-scoped knowledge by user {UserId}",
-                    _tenantContext.LoggedInUser);
+                    LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
                 return Results.Json(
                     new { error = "Forbidden", message = "Only system administrators can delete system-scoped knowledge" },
                     statusCode: StatusCodes.Status403Forbidden);
@@ -302,7 +302,7 @@ public class KnowledgeService : IKnowledgeService
                 if (!agentNames.Contains(request.Agent, StringComparer.OrdinalIgnoreCase))
                 {
                     _logger.LogWarning("Unauthorized access attempt to delete knowledge for agent {Agent} by user {UserId}",
-                        request.Agent, _tenantContext.LoggedInUser);
+                        LogSanitizer.Sanitize(request.Agent), LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
                     return Results.Json(
                         new { error = "Forbidden", message = "You do not have permission to delete knowledge for this agent" },
                         statusCode: StatusCodes.Status403Forbidden);
@@ -333,7 +333,7 @@ public class KnowledgeService : IKnowledgeService
             if (!agentNames.Contains(agent, StringComparer.OrdinalIgnoreCase))
             {
                 _logger.LogWarning("Unauthorized access attempt to get knowledge for agent {Agent} by user {UserId}",
-                    agent, _tenantContext.LoggedInUser);
+                    LogSanitizer.Sanitize(agent), LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
                 return Results.Json(
                     new { error = "Forbidden", message = "You do not have permission to access knowledge for this agent" },
                     statusCode: StatusCodes.Status403Forbidden);
@@ -403,7 +403,7 @@ public class KnowledgeService : IKnowledgeService
             groups.Add(group);
         }
 
-        _logger.LogInformation("Found {Count} knowledge groups for agent {Agent}", groups.Count, agent);
+        _logger.LogInformation("Found {Count} knowledge groups for agent {Agent}", groups.Count, LogSanitizer.Sanitize(agent));
 
         var response = new GroupedKnowledgeResponse { Groups = groups };
         return Results.Ok(response);
@@ -438,7 +438,7 @@ public class KnowledgeService : IKnowledgeService
         }
 
         _logger.LogDebug("GetLatestByNameForTenantAsync: name={Name}, agent={Agent}, activationName={ActivationName}, tenantId={TenantId}",
-            name, agent, activationName ?? "(null)", tenantId ?? "(null)");
+            LogSanitizer.Sanitize(name), LogSanitizer.Sanitize(agent), LogSanitizer.Sanitize(activationName ?? "(null)"), LogSanitizer.Sanitize(tenantId ?? "(null)"));
 
         // Priority 1: If activationName is provided, try knowledge with matching tenant + agent + activationName
         if (!string.IsNullOrEmpty(activationName) && !string.IsNullOrEmpty(tenantId))
@@ -449,7 +449,7 @@ public class KnowledgeService : IKnowledgeService
             if (knowledge != null)
             {
                 _logger.LogInformation("Found knowledge (priority 1: matching activation_name) - tenantId={TenantId}, activationName={ActivationName}",
-                    knowledge.TenantId, knowledge.ActivationName);
+                    LogSanitizer.Sanitize(knowledge.TenantId), LogSanitizer.Sanitize(knowledge.ActivationName));
                 return ServiceResult<Knowledge>.Success(knowledge);
             }
         }
@@ -466,7 +466,7 @@ public class KnowledgeService : IKnowledgeService
             if (knowledge != null)
             {
                 _logger.LogInformation("Found knowledge (priority 2: tenant-default match, activation_name=null) - tenantId={TenantId}",
-                    knowledge.TenantId);
+                    LogSanitizer.Sanitize(knowledge.TenantId));
                 return ServiceResult<Knowledge>.Success(knowledge);
             }
         }
@@ -498,7 +498,7 @@ public class KnowledgeService : IKnowledgeService
         if (!request.SystemScoped && string.IsNullOrWhiteSpace(_tenantContext.TenantId))
         {
             _logger.LogError("Cannot create non-system knowledge without a tenant ID. User: {UserId}", 
-                _tenantContext.LoggedInUser);
+                LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
             return Results.Json(
                 new { error = "BadRequest", message = "Non-system knowledge must be associated with a tenant" },
                 statusCode: StatusCodes.Status400BadRequest);
@@ -508,7 +508,7 @@ public class KnowledgeService : IKnowledgeService
         if (request.SystemScoped && !_tenantContext.UserRoles.Contains(SystemRoles.SysAdmin))
         {
             _logger.LogWarning("Unauthorized access attempt to create system-scoped knowledge by user {UserId}",
-                _tenantContext.LoggedInUser);
+                LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
             return Results.Json(
                 new { error = "Forbidden", message = "Only system administrators can create system-scoped knowledge" },
                 statusCode: StatusCodes.Status403Forbidden);
@@ -522,7 +522,7 @@ public class KnowledgeService : IKnowledgeService
             if (!agentNames.Contains(request.Agent, StringComparer.OrdinalIgnoreCase))
             {
                 _logger.LogWarning("Unauthorized access attempt to create knowledge for agent {Agent} by user {UserId}",
-                    request.Agent, _tenantContext.LoggedInUser);
+                    LogSanitizer.Sanitize(request.Agent), LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
                 return Results.Json(
                     new { error = "Forbidden", message = "You do not have permission to create knowledge for this agent" },
                     statusCode: StatusCodes.Status403Forbidden);
@@ -545,7 +545,7 @@ public class KnowledgeService : IKnowledgeService
             latest.SystemScoped == request.SystemScoped &&
             latest.ActivationName == request.ActivationName)
         {
-            _logger.LogInformation("Knowledge {Name} already exists with the same content hash, scope, and activation", request.Name);
+            _logger.LogInformation("Knowledge {Name} already exists with the same content hash, scope, and activation", LogSanitizer.Sanitize(request.Name));
             return Results.Ok(latest);
         }
 
@@ -576,13 +576,13 @@ public class KnowledgeService : IKnowledgeService
         catch (MongoWriteException ex) when (ex.WriteError?.Category == ServerErrorCategory.DuplicateKey)
         {
             // Handle race condition where knowledge was created between our check and insert
-            _logger.LogWarning(ex, "Duplicate key error creating knowledge {Name}. Retrieving existing knowledge.", request.Name);
+            _logger.LogWarning(ex, "Duplicate key error creating knowledge {Name}. Retrieving existing knowledge.", LogSanitizer.Sanitize(request.Name));
             
             // Try to get the existing knowledge again
             var existingKnowledge = await GetLatestByNameAsync(request.Name, request.Agent);
             if (existingKnowledge.IsSuccess && existingKnowledge.Data != null)
             {
-                _logger.LogInformation("Returning existing knowledge {Name} after duplicate key error", request.Name);
+                _logger.LogInformation("Returning existing knowledge {Name} after duplicate key error", LogSanitizer.Sanitize(request.Name));
                 return Results.Ok(existingKnowledge.Data);
             }
             
@@ -603,7 +603,7 @@ public class KnowledgeService : IKnowledgeService
             if (!agentNames.Contains(agent, StringComparer.OrdinalIgnoreCase))
             {
                 _logger.LogWarning("Unauthorized access attempt to list knowledge for agent {Agent} by user {UserId}",
-                    agent, _tenantContext.LoggedInUser);
+                    LogSanitizer.Sanitize(agent), LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
                 return Results.Json(
                     new { error = "Forbidden", message = "You do not have permission to list knowledge for this agent" },
                     statusCode: StatusCodes.Status403Forbidden);
@@ -612,7 +612,7 @@ public class KnowledgeService : IKnowledgeService
 
         var knowledge = await _knowledgeRepository.GetUniqueLatestAsync<Knowledge>(_tenantContext.TenantId, new List<string> { agent });
 
-        _logger.LogInformation("Found {Count} knowledge items for agent {Agent}", knowledge.Count, agent);
+        _logger.LogInformation("Found {Count} knowledge items for agent {Agent}", knowledge.Count, LogSanitizer.Sanitize(agent));
         
         foreach (var item in knowledge)
         {

--- a/XiansAi.Server.Src/Shared/Services/MessageService.cs
+++ b/XiansAi.Server.Src/Shared/Services/MessageService.cs
@@ -147,7 +147,7 @@ public class MessageService : IMessageService
 
     public async Task<ServiceResult<string>> ProcessHandoff(HandoffRequest request)
     {
-        _logger.LogInformation("Processing handover for thread {ThreadId}", request.ThreadId);
+        _logger.LogInformation("Processing handover for thread {ThreadId}", LogSanitizer.Sanitize(request.ThreadId));
 
         try
         {
@@ -235,7 +235,7 @@ public class MessageService : IMessageService
 
             if (string.IsNullOrEmpty(workflowId) || string.IsNullOrEmpty(participantId))
             {
-                _logger.LogWarning("Invalid request: missing required fields workflowId {WorkflowId}, participant {ParticipantId}", workflowId, participantId);
+                _logger.LogWarning("Invalid request: missing required fields workflowId {WorkflowId}, participant {ParticipantId}", LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(participantId));
                 return ServiceResult<List<ConversationMessageDto>>.BadRequest("WorkflowId and ParticipantId are required");
             }
 
@@ -248,14 +248,14 @@ public class MessageService : IMessageService
             // Get messages directly by workflow and participant IDs
             var messages = await _conversationRepository.GetMessagesByWorkflowAndParticipantAsync(workflowId, participantId, page, pageSize, scope, sortOrder);
 
-            _logger.LogInformation("Found {Count} messages for workflowId {WorkflowId}, participant {ParticipantId}", messages.Count, workflowId, participantId);
+            _logger.LogInformation("Found {Count} messages for workflowId {WorkflowId}, participant {ParticipantId}", messages.Count, LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(participantId));
 
             var withFeedback = await _feedbackService.BuildMessagesWithFeedbackAsync(messages, _tenantContext.TenantId);
             return ServiceResult<List<ConversationMessageDto>>.Success(withFeedback);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error getting message history for workflowId {WorkflowId}, participant {ParticipantId}", workflowId, participantId);
+            _logger.LogError(ex, "Error getting message history for workflowId {WorkflowId}, participant {ParticipantId}", LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(participantId));
             throw;
         }
     }
@@ -263,7 +263,7 @@ public class MessageService : IMessageService
     public async Task<ServiceResult<string>> ProcessOutgoingMessage(ChatOrDataRequest request, MessageType messageType)
     {
         _logger.LogInformation("Processing outbound message from workflow {WorkflowId} to participant {ParticipantId}",
-             request.WorkflowId, request.ParticipantId);
+             LogSanitizer.Sanitize(request.WorkflowId), LogSanitizer.Sanitize(request.ParticipantId));
 
         try
         {
@@ -290,14 +290,14 @@ public class MessageService : IMessageService
                 if (string.IsNullOrEmpty(request.Origin) && !string.IsNullOrEmpty(lastOrigin))
                 {
                     request.Origin = lastOrigin;
-                    _logger.LogInformation("Auto-populated origin from last incoming message in scope {Scope}: {Origin}", replyScope ?? "default", lastOrigin);
+                    _logger.LogInformation("Auto-populated origin from last incoming message in scope {Scope}: {Origin}", LogSanitizer.Sanitize(replyScope ?? "default"), LogSanitizer.Sanitize(lastOrigin));
                 }
 
                 // Auto-populate platform-specific metadata (e.g., Slack channel, Teams conversation) if not provided
                 if (request.Data == null && !string.IsNullOrEmpty(request.Origin) && request.Origin.StartsWith("app:") && lastData != null)
                 {
                     request.Data = lastData;
-                    _logger.LogInformation("Auto-populated platform metadata from last incoming message in scope {Scope}", replyScope ?? "default");
+                    _logger.LogInformation("Auto-populated platform metadata from last incoming message in scope {Scope}", LogSanitizer.Sanitize(replyScope ?? "default"));
                 }
             }
 
@@ -355,7 +355,7 @@ public class MessageService : IMessageService
         }
 
         _logger.LogInformation("Processing inbound message for WorkflowId `{WorkflowId}` from participant {ParticipantId}",
-            request.WorkflowId, request.ParticipantId);
+            LogSanitizer.Sanitize(request.WorkflowId), LogSanitizer.Sanitize(request.ParticipantId));
         
         // Critical Operation: If the threadId is not provided, we need to create a new thread
         var threadId = await CreateOrGetThread(request);
@@ -480,7 +480,7 @@ public class MessageService : IMessageService
 
         // Save the message with transaction support
         message.Id = await _conversationRepository.SaveMessageAsync(message);
-        _logger.LogInformation("Created conversation message {MessageId} in thread {ThreadId}", message.Id, message.ThreadId);
+        _logger.LogInformation("Created conversation message {MessageId} in thread {ThreadId}", LogSanitizer.Sanitize(message.Id), LogSanitizer.Sanitize(message.ThreadId));
 
         return message;
     }
@@ -490,12 +490,12 @@ public class MessageService : IMessageService
         try
         {
             _logger.LogInformation("Attempting to delete thread for workflowId {WorkflowId}, participant {ParticipantId}", 
-                workflowId, participantId);
+                LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(participantId));
 
             if (string.IsNullOrEmpty(workflowId) || string.IsNullOrEmpty(participantId))
             {
                 _logger.LogWarning("Invalid request: missing required fields workflowId {WorkflowId}, participant {ParticipantId}", 
-                    workflowId, participantId);
+                    LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(participantId));
                 return ServiceResult<bool>.BadRequest("WorkflowId and ParticipantId are required");
             }
 
@@ -508,13 +508,13 @@ public class MessageService : IMessageService
             catch (KeyNotFoundException)
             {
                 _logger.LogWarning("Thread not found for workflowId {WorkflowId}, participant {ParticipantId}, tenant {TenantId}", 
-                    workflowId, participantId, _tenantContext.TenantId);
+                    LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(participantId), LogSanitizer.Sanitize(_tenantContext.TenantId));
                 return ServiceResult<bool>.NotFound("Thread not found");
             }
 
             // Delete all messages in the thread first
             await _conversationRepository.DeleteMessagesByThreadIdAsync(threadId);
-            _logger.LogInformation("Deleted messages for thread {ThreadId}", threadId);
+            _logger.LogInformation("Deleted messages for thread {ThreadId}", LogSanitizer.Sanitize(threadId));
 
             // Delete the thread
             var result = await _conversationRepository.DeleteThreadAsync(threadId, _tenantContext.TenantId);
@@ -522,18 +522,18 @@ public class MessageService : IMessageService
             if (!result)
             {
                 _logger.LogWarning("Failed to delete thread {ThreadId} for workflowId {WorkflowId}, participant {ParticipantId}", 
-                    threadId, workflowId, participantId);
+                    LogSanitizer.Sanitize(threadId), LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(participantId));
                 return ServiceResult<bool>.InternalServerError("Failed to delete thread");
             }
 
             _logger.LogInformation("Successfully deleted thread {ThreadId} for workflowId {WorkflowId}, participant {ParticipantId}", 
-                threadId, workflowId, participantId);
+                LogSanitizer.Sanitize(threadId), LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(participantId));
             return ServiceResult<bool>.Success(true);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error deleting thread for workflowId {WorkflowId}, participant {ParticipantId}", 
-                workflowId, participantId);
+                LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(participantId));
             return ServiceResult<bool>.InternalServerError("An error occurred while deleting the thread");
         }
     }
@@ -543,12 +543,12 @@ public class MessageService : IMessageService
         try
         {
             _logger.LogInformation("Attempting to delete messages for workflowId {WorkflowId}, participant {ParticipantId}, topic {Topic}", 
-                workflowId, participantId, topic ?? "null");
+                LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(participantId), LogSanitizer.Sanitize(topic ?? "null"));
 
             if (string.IsNullOrEmpty(workflowId) || string.IsNullOrEmpty(participantId))
             {
                 _logger.LogWarning("Invalid request: missing required fields workflowId {WorkflowId}, participant {ParticipantId}", 
-                    workflowId, participantId);
+                    LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(participantId));
                 return ServiceResult<bool>.BadRequest("WorkflowId and ParticipantId are required");
             }
 
@@ -559,18 +559,18 @@ public class MessageService : IMessageService
             if (!result)
             {
                 _logger.LogWarning("Failed to delete messages for workflowId {WorkflowId}, participant {ParticipantId}, topic {Topic}", 
-                    workflowId, participantId, topic ?? "null");
+                    LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(participantId), LogSanitizer.Sanitize(topic ?? "null"));
                 return ServiceResult<bool>.InternalServerError("Failed to delete messages");
             }
 
             _logger.LogInformation("Successfully deleted messages for workflowId {WorkflowId}, participant {ParticipantId}, topic {Topic}", 
-                workflowId, participantId, topic ?? "null");
+                LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(participantId), LogSanitizer.Sanitize(topic ?? "null"));
             return ServiceResult<bool>.Success(true);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error deleting messages for workflowId {WorkflowId}, participant {ParticipantId}, topic {Topic}", 
-                workflowId, participantId, topic ?? "null");
+                LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(participantId), LogSanitizer.Sanitize(topic ?? "null"));
             return ServiceResult<bool>.InternalServerError("An error occurred while deleting messages");
         }
     }
@@ -580,12 +580,12 @@ public class MessageService : IMessageService
         try
         {
             _logger.LogInformation("Getting last task id for workflowId {WorkflowId}, participant {ParticipantId}, scope {Scope}",
-                workflowId, participantId, scope ?? "null");
+                LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(participantId), LogSanitizer.Sanitize(scope ?? "null"));
 
             if (string.IsNullOrEmpty(workflowId) || string.IsNullOrEmpty(participantId))
             {
                 _logger.LogWarning("Invalid request: missing required fields workflowId {WorkflowId}, participant {ParticipantId}",
-                    workflowId, participantId);
+                    LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(participantId));
                 return ServiceResult<string?>.BadRequest("WorkflowId and ParticipantId are required");
             }
 
@@ -594,12 +594,12 @@ public class MessageService : IMessageService
             if (taskId == null)
             {
                 _logger.LogInformation("No task id found for workflowId {WorkflowId}, participant {ParticipantId}, scope {Scope}",
-                    workflowId, participantId, scope ?? "null");
+                    LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(participantId), LogSanitizer.Sanitize(scope ?? "null"));
             }
             else
             {
                 _logger.LogInformation("Found task id for workflowId {WorkflowId}, participant {ParticipantId}, scope {Scope}",
-                    workflowId, participantId, scope ?? "null");
+                    LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(participantId), LogSanitizer.Sanitize(scope ?? "null"));
             }
 
             return ServiceResult<string?>.Success(taskId);
@@ -607,7 +607,7 @@ public class MessageService : IMessageService
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error getting last task id for workflowId {WorkflowId}, participant {ParticipantId}",
-                workflowId, participantId);
+                LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(participantId));
             return ServiceResult<string?>.InternalServerError("An error occurred while getting the last task id");
         }
     }
@@ -622,7 +622,7 @@ public class MessageService : IMessageService
             if (string.IsNullOrEmpty(workflowId) || string.IsNullOrEmpty(participantId))
             {
                 _logger.LogWarning("Invalid request: missing required fields workflowId {WorkflowId}, participant {ParticipantId}", 
-                    workflowId, participantId);
+                    LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(participantId));
                 return ServiceResult<TopicsResult>.BadRequest("WorkflowId and ParticipantId are required");
             }
 
@@ -641,7 +641,7 @@ public class MessageService : IMessageService
             catch (KeyNotFoundException)
             {
                 _logger.LogInformation("Thread not found for workflowId {WorkflowId}, participant {ParticipantId}, tenant {TenantId}. Returning empty topics list.", 
-                    workflowId, participantId, _tenantContext.TenantId);
+                    LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(participantId), LogSanitizer.Sanitize(_tenantContext.TenantId));
                 
                 // Return empty result when thread doesn't exist
                 return ServiceResult<TopicsResult>.Success(new TopicsResult
@@ -669,14 +669,14 @@ public class MessageService : IMessageService
             var topicsResult = await _conversationRepository.GetTopicsByThreadIdAsync(_tenantContext.TenantId, threadId, page, pageSize);
 
             _logger.LogInformation("Found {Count} topics for workflowId {WorkflowId}, participant {ParticipantId}", 
-                topicsResult.Topics.Count, workflowId, participantId);
+                topicsResult.Topics.Count, LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(participantId));
 
             return ServiceResult<TopicsResult>.Success(topicsResult);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error getting topics for workflowId {WorkflowId}, participant {ParticipantId}", 
-                workflowId, participantId);
+                LogSanitizer.Sanitize(workflowId), LogSanitizer.Sanitize(participantId));
             return ServiceResult<TopicsResult>.InternalServerError("An error occurred while retrieving topics");
         }
     }

--- a/XiansAi.Server.Src/Shared/Services/PendingRequestService.cs
+++ b/XiansAi.Server.Src/Shared/Services/PendingRequestService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using Shared.Repositories;
+using Shared.Utils;
 
 namespace Shared.Services;
 
@@ -38,7 +39,7 @@ public class PendingRequestService : IPendingRequestService, IDisposable
         
         if (!_pendingRequests.TryAdd(requestId, pendingRequest))
         {
-            _logger.LogWarning("Request with ID {RequestId} already exists", requestId);
+            _logger.LogWarning("Request with ID {RequestId} already exists", LogSanitizer.Sanitize(requestId));
             return default(T);
         }
 
@@ -56,7 +57,7 @@ public class PendingRequestService : IPendingRequestService, IDisposable
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            _logger.LogDebug("Request {RequestId} was cancelled by caller", requestId);
+            _logger.LogDebug("Request {RequestId} was cancelled by caller", LogSanitizer.Sanitize(requestId));
             throw;
         }
         catch (OperationCanceledException)
@@ -93,18 +94,18 @@ public class PendingRequestService : IPendingRequestService, IDisposable
                     return;
                 }
 
-                _logger.LogDebug("Completing request {RequestId} with {MessageType} response", requestId, messageType?.ToString() ?? "unspecified");
+                _logger.LogDebug("Completing request {RequestId} with {MessageType} response", LogSanitizer.Sanitize(requestId), LogSanitizer.Sanitize(messageType?.ToString() ?? "unspecified"));
                 typedRequest.TaskCompletionSource.SetResult(response);
             }
             else
             {
                 _logger.LogWarning("Type mismatch when completing request {RequestId}. Expected {ExpectedType}, got {ActualType}", 
-                    requestId, typeof(T).Name, pendingRequest.GetType().GetGenericArguments().FirstOrDefault()?.Name ?? "unknown");
+                    LogSanitizer.Sanitize(requestId), typeof(T).Name, LogSanitizer.Sanitize(pendingRequest.GetType().GetGenericArguments().FirstOrDefault()?.Name ?? "unknown"));
             }
         }
         else
         {
-            _logger.LogDebug("No pending request found for RequestId {RequestId} - may have already completed or timed out", requestId);
+            _logger.LogDebug("No pending request found for RequestId {RequestId} - may have already completed or timed out", LogSanitizer.Sanitize(requestId));
         }
     }
 
@@ -118,12 +119,12 @@ public class PendingRequestService : IPendingRequestService, IDisposable
 
         if (_pendingRequests.TryRemove(requestId, out var pendingRequest))
         {
-            _logger.LogDebug("Completing request {RequestId} with error: {Error}", requestId, exception.Message);
+            _logger.LogDebug("Completing request {RequestId} with error: {Error}", LogSanitizer.Sanitize(requestId), LogSanitizer.Sanitize(exception.Message));
             pendingRequest.SetException(exception);
         }
         else
         {
-            _logger.LogDebug("No pending request found for RequestId {RequestId} when setting error", requestId);
+            _logger.LogDebug("No pending request found for RequestId {RequestId} when setting error", LogSanitizer.Sanitize(requestId));
         }
     }
 
@@ -137,7 +138,7 @@ public class PendingRequestService : IPendingRequestService, IDisposable
 
         if (_pendingRequests.TryRemove(requestId, out var pendingRequest))
         {
-            _logger.LogDebug("Cancelling request {RequestId}", requestId);
+            _logger.LogDebug("Cancelling request {RequestId}", LogSanitizer.Sanitize(requestId));
             pendingRequest.SetCanceled();
         }
     }
@@ -164,7 +165,7 @@ public class PendingRequestService : IPendingRequestService, IDisposable
         {
             if (_pendingRequests.TryRemove(requestId, out var pendingRequest))
             {
-                _logger.LogDebug("Cleaning up expired request {RequestId}", requestId);
+                _logger.LogDebug("Cleaning up expired request {RequestId}", LogSanitizer.Sanitize(requestId));
                 pendingRequest.SetException(new TimeoutException($"Request {requestId} expired"));
             }
         }

--- a/XiansAi.Server.Src/Shared/Services/PermissionsService.cs
+++ b/XiansAi.Server.Src/Shared/Services/PermissionsService.cs
@@ -3,6 +3,7 @@ using Shared.Data;
 using Shared.Auth;
 using Shared.Utils.Services;
 using Shared.Repositories;
+using Shared.Utils;
 
 namespace Shared.Services;
 
@@ -60,12 +61,12 @@ public class PermissionsService : IPermissionsService
             return ServiceResult<PermissionDto>.BadRequest("Agent name is required");
         }
 
-        _logger.LogInformation("Getting permissions for agent: {AgentName}", agentName);
+        _logger.LogInformation("Getting permissions for agent: {AgentName}", LogSanitizer.Sanitize(agentName));
         
         var permissions = await _permissionRepository.GetAgentPermissionsAsync(agentName);
         if (permissions == null)
         {
-            _logger.LogWarning("No permissions found for agent: {AgentName}", agentName);
+            _logger.LogWarning("No permissions found for agent: {AgentName}", LogSanitizer.Sanitize(agentName));
             return ServiceResult<PermissionDto>.NotFound("No permissions found for this agent");
         }
         
@@ -97,14 +98,14 @@ public class PermissionsService : IPermissionsService
             return ServiceResult<bool>.BadRequest("Permissions object must contain ownerAccess, readAccess, and writeAccess arrays");
         }
 
-        _logger.LogInformation("Updating permissions for agent: {AgentName}", agentName);
+        _logger.LogInformation("Updating permissions for agent: {AgentName}", LogSanitizer.Sanitize(agentName));
         
         var hasPermission = await CheckPermissions(agentName, PermissionLevel.Owner);
 
         if (!hasPermission)
         {
             _logger.LogWarning("User {UserId} attempted to update permissions for agent {AgentName} without owner permission",
-                _tenantContext.LoggedInUser, agentName);
+                LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(agentName));
             return ServiceResult<bool>.Forbidden("You must have owner permission to update permissions");
         }
 
@@ -140,21 +141,21 @@ public class PermissionsService : IPermissionsService
         }
 
         _logger.LogInformation("Adding user {UserId} to agent {AgentName} with permission level {PermissionLevel}", 
-            userId, agentName, permissionLevel);
+            LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(permissionLevel));
         
         var hasPermission = await CheckPermissions(agentName, PermissionLevel.Owner);
 
         if (!hasPermission)
         {
             _logger.LogWarning("User {UserId} attempted to add user to agent {AgentName} without owner permission", 
-                _tenantContext.LoggedInUser, agentName);
+                LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(agentName));
             return ServiceResult<bool>.Forbidden("You must have owner permission to add users");
         }
 
         var level = NormalizePermissionLevel(permissionLevel);
         if (level == null)
         {
-            _logger.LogWarning("Invalid permission level: {PermissionLevel}", permissionLevel);
+            _logger.LogWarning("Invalid permission level: {PermissionLevel}", LogSanitizer.Sanitize(permissionLevel));
             return ServiceResult<bool>.BadRequest("Invalid permission level. Must be one of: Owner, Write, Read");
         }
 
@@ -176,14 +177,14 @@ public class PermissionsService : IPermissionsService
             return ServiceResult<bool>.BadRequest("User ID is required");
         }
 
-        _logger.LogInformation("Removing user {UserId} from agent {AgentName}", userId, agentName);
+        _logger.LogInformation("Removing user {UserId} from agent {AgentName}", LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(agentName));
         
         var hasPermission = await CheckPermissions(agentName, PermissionLevel.Owner);
 
         if (!hasPermission)
         {
             _logger.LogWarning("User {UserId} attempted to remove user from agent {AgentName} without owner permission", 
-                _tenantContext.LoggedInUser, agentName);
+                LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(agentName));
             return ServiceResult<bool>.Forbidden("You must have owner permission to remove users");
         }
 
@@ -212,21 +213,21 @@ public class PermissionsService : IPermissionsService
         }
 
         _logger.LogInformation("Updating permission for user {UserId} in agent {AgentName} to {PermissionLevel}", 
-            userId, agentName, newPermissionLevel);
+            LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(newPermissionLevel));
         
         var hasPermission = await CheckPermissions(agentName, PermissionLevel.Owner);
 
         if (!hasPermission)
         {
             _logger.LogWarning("User {UserId} attempted to update user permission for agent {AgentName} without owner permission", 
-                _tenantContext.LoggedInUser, agentName);
+                LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(agentName));
             return ServiceResult<bool>.Forbidden("You must have owner permission to update user permissions");
         }
 
         var level = NormalizePermissionLevel(newPermissionLevel);
         if (level == null)
         {
-            _logger.LogWarning("Invalid permission level: {PermissionLevel}", newPermissionLevel);
+            _logger.LogWarning("Invalid permission level: {PermissionLevel}", LogSanitizer.Sanitize(newPermissionLevel));
             return ServiceResult<bool>.BadRequest("Invalid permission level. Must be one of: Owner, Write, Read");
         }
 
@@ -242,12 +243,12 @@ public class PermissionsService : IPermissionsService
             return ServiceResult<bool>.BadRequest("Agent name is required");
         }
 
-        _logger.LogInformation("Checking read permission for agent: {AgentName}", agentName);
+        _logger.LogInformation("Checking read permission for agent: {AgentName}", LogSanitizer.Sanitize(agentName));
         
         var permissions = await _permissionRepository.GetAgentPermissionsAsync(agentName);
         if (permissions == null)
         {
-            _logger.LogWarning("No permissions found for agent: {AgentName}", agentName);
+            _logger.LogWarning("No permissions found for agent: {AgentName}", LogSanitizer.Sanitize(agentName));
             return ServiceResult<bool>.NotFound("Agent not found");
         }
 
@@ -263,12 +264,12 @@ public class PermissionsService : IPermissionsService
             return ServiceResult<bool>.BadRequest("Agent name is required");
         }
 
-        _logger.LogInformation("Checking write permission for agent: {AgentName}", agentName);
+        _logger.LogInformation("Checking write permission for agent: {AgentName}", LogSanitizer.Sanitize(agentName));
         
         var permissions = await _permissionRepository.GetAgentPermissionsAsync(agentName);
         if (permissions == null)
         {
-            _logger.LogWarning("No permissions found for agent: {AgentName}", agentName);
+            _logger.LogWarning("No permissions found for agent: {AgentName}", LogSanitizer.Sanitize(agentName));
             return ServiceResult<bool>.NotFound("Agent not found");
         }
 
@@ -284,12 +285,12 @@ public class PermissionsService : IPermissionsService
             return ServiceResult<bool>.BadRequest("Agent name is required");
         }
 
-        _logger.LogInformation("Checking owner permission for agent: {AgentName}", agentName);
+        _logger.LogInformation("Checking owner permission for agent: {AgentName}", LogSanitizer.Sanitize(agentName));
         
         var permissions = await _permissionRepository.GetAgentPermissionsAsync(agentName);
         if (permissions == null)
         {
-            _logger.LogWarning("No permissions found for agent: {AgentName}", agentName);
+            _logger.LogWarning("No permissions found for agent: {AgentName}", LogSanitizer.Sanitize(agentName));
             return ServiceResult<bool>.NotFound("Agent not found");
         }
 

--- a/XiansAi.Server.Src/Shared/Services/SecretVaultService.cs
+++ b/XiansAi.Server.Src/Shared/Services/SecretVaultService.cs
@@ -3,6 +3,7 @@ using System.Text.RegularExpressions;
 using Shared.Data.Models;
 using Shared.Providers;
 using Shared.Repositories;
+using Shared.Utils;
 using Shared.Utils.Services;
 
 namespace Shared.Services;
@@ -156,7 +157,7 @@ public class SecretVaultService : ISecretVaultService
 
             _logger.LogInformation(
                 "Secret vault entry created. id={SecretId} key={Key} tenant={TenantId} actor={Actor} provider={Provider}",
-                id, input.Key, entity.TenantId ?? "*", actorUserId, _secretStore.Name);
+                LogSanitizer.Sanitize(id), LogSanitizer.Sanitize(input.Key), entity.TenantId ?? "*", LogSanitizer.Sanitize(actorUserId), LogSanitizer.Sanitize(_secretStore.Name));
 
             return ServiceResult<SecretVaultGetResponse>.Success(ToGetResponse(entity, input.Value), StatusCode.Ok);
         }
@@ -176,7 +177,7 @@ public class SecretVaultService : ISecretVaultService
                 {
                     _logger.LogError(cleanupEx,
                         "Failed to clean up orphaned secret value for id {SecretId} after metadata insert failure",
-                        id);
+                        LogSanitizer.Sanitize(id));
                 }
             }
 
@@ -200,7 +201,7 @@ public class SecretVaultService : ISecretVaultService
             {
                 _logger.LogError(
                     "Secret value missing in store for id {SecretId} (provider={Provider})",
-                    entity.Id, _secretStore.Name);
+                    LogSanitizer.Sanitize(entity.Id), LogSanitizer.Sanitize(_secretStore.Name));
                 return ServiceResult<SecretVaultGetResponse?>.Conflict("Secret value missing in store");
             }
 
@@ -208,7 +209,7 @@ public class SecretVaultService : ISecretVaultService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error getting secret vault id {Id}", id);
+            _logger.LogError(ex, "Error getting secret vault id {Id}", LogSanitizer.Sanitize(id));
             return ServiceResult<SecretVaultGetResponse?>.InternalServerError("Failed to get secret");
         }
     }
@@ -271,7 +272,7 @@ public class SecretVaultService : ISecretVaultService
 
             _logger.LogInformation(
                 "Secret vault entry updated. id={SecretId} key={Key} tenant={TenantId} actor={Actor} valueChanged={ValueChanged} provider={Provider}",
-                entity.Id, entity.Key, entity.TenantId ?? "*", actorUserId, updatedValue != null, _secretStore.Name);
+                LogSanitizer.Sanitize(entity.Id), LogSanitizer.Sanitize(entity.Key), entity.TenantId ?? "*", LogSanitizer.Sanitize(actorUserId), updatedValue != null, LogSanitizer.Sanitize(_secretStore.Name));
 
             // For the response value: prefer the just-set value to avoid an extra round-trip to the store.
             var responseValue = updatedValue ?? await _secretStore.GetAsync(entity.Id) ?? string.Empty;
@@ -279,7 +280,7 @@ public class SecretVaultService : ISecretVaultService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error updating secret vault id {Id}", id);
+            _logger.LogError(ex, "Error updating secret vault id {Id}", LogSanitizer.Sanitize(id));
             return ServiceResult<SecretVaultGetResponse>.InternalServerError("Failed to update secret");
         }
     }
@@ -304,15 +305,15 @@ public class SecretVaultService : ISecretVaultService
                 // Metadata is already gone; log the orphan but do not fail the caller.
                 _logger.LogError(storeEx,
                     "Metadata for secret {SecretId} was deleted but store {Provider} delete failed; value may need manual cleanup",
-                    id, _secretStore.Name);
+                    LogSanitizer.Sanitize(id), LogSanitizer.Sanitize(_secretStore.Name));
             }
 
-            _logger.LogInformation("Secret vault entry deleted. id={SecretId} provider={Provider}", id, _secretStore.Name);
+            _logger.LogInformation("Secret vault entry deleted. id={SecretId} provider={Provider}", LogSanitizer.Sanitize(id), LogSanitizer.Sanitize(_secretStore.Name));
             return ServiceResult<bool>.Success(true);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error deleting secret vault id {Id}", id);
+            _logger.LogError(ex, "Error deleting secret vault id {Id}", LogSanitizer.Sanitize(id));
             return ServiceResult<bool>.InternalServerError("Failed to delete secret");
         }
     }
@@ -333,7 +334,7 @@ public class SecretVaultService : ISecretVaultService
             {
                 _logger.LogError(
                     "Secret value missing in store for key {Key} id {SecretId} (provider={Provider})",
-                    key, entity.Id, _secretStore.Name);
+                    LogSanitizer.Sanitize(key), LogSanitizer.Sanitize(entity.Id), LogSanitizer.Sanitize(_secretStore.Name));
                 return ServiceResult<SecretVaultFetchResponse?>.Conflict("Secret value missing in store");
             }
 
@@ -342,7 +343,7 @@ public class SecretVaultService : ISecretVaultService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error fetching secret vault key {Key}", key);
+            _logger.LogError(ex, "Error fetching secret vault key {Key}", LogSanitizer.Sanitize(key));
             return ServiceResult<SecretVaultFetchResponse?>.InternalServerError("Failed to fetch secret");
         }
     }
@@ -362,7 +363,7 @@ public class SecretVaultService : ISecretVaultService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error getting secret vault metadata for id {Id}", id);
+            _logger.LogError(ex, "Error getting secret vault metadata for id {Id}", LogSanitizer.Sanitize(id));
             return ServiceResult<SecretVaultMetadataResponse?>.InternalServerError("Failed to get secret metadata");
         }
     }
@@ -382,7 +383,7 @@ public class SecretVaultService : ISecretVaultService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error finding secret vault metadata for key {Key}", key);
+            _logger.LogError(ex, "Error finding secret vault metadata for key {Key}", LogSanitizer.Sanitize(key));
             return ServiceResult<SecretVaultMetadataResponse?>.InternalServerError("Failed to find secret metadata");
         }
     }

--- a/XiansAi.Server.Src/Shared/Services/TemplateService.cs
+++ b/XiansAi.Server.Src/Shared/Services/TemplateService.cs
@@ -3,6 +3,7 @@ using Shared.Auth;
 using Shared.Data.Models;
 using Shared.Repositories;
 using Shared.Utils.Services;
+using Shared.Utils;
 
 namespace Shared.Services;
 
@@ -61,21 +62,21 @@ public class TemplateService : ITemplateService
         try
         {
             _logger.LogInformation("Retrieving system-scoped agent definitions for user {UserId} in tenant {TenantId} (no permission checks)", 
-                _tenantContext.LoggedInUser, _tenantContext.TenantId);
+                LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(_tenantContext.TenantId));
 
             // Get system-scoped agents without permission checks
             // System-scoped agents are available to any logged-in user with a valid tenant
             var systemScopedAgents = await _agentRepository.GetSystemScopedAgentsWithDefinitionsAsync(basicDataOnly);
 
             _logger.LogInformation("Found {Count} system-scoped agents for user {UserId}", 
-                systemScopedAgents.Count, _tenantContext.LoggedInUser);
+                systemScopedAgents.Count, LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
 
             return ServiceResult<List<AgentWithDefinitions>>.Success(systemScopedAgents);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error retrieving system-scoped agent definitions for user {UserId} in tenant {TenantId}", 
-                _tenantContext.LoggedInUser, _tenantContext.TenantId);
+                LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(_tenantContext.TenantId));
             return ServiceResult<List<AgentWithDefinitions>>.InternalServerError(
                 "An error occurred while retrieving system-scoped agent definitions");
         }
@@ -143,7 +144,7 @@ public class TemplateService : ITemplateService
         try
         {
             _logger.LogInformation("Attempting to delete system-scoped agent {AgentName} by user {UserId}", 
-                agentName, _tenantContext.LoggedInUser);
+                LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
 
             // Validate input
             if (string.IsNullOrWhiteSpace(agentName))
@@ -156,14 +157,14 @@ public class TemplateService : ITemplateService
             
             if (agent == null)
             {
-                _logger.LogWarning("Agent {AgentName} not found", agentName);
+                _logger.LogWarning("Agent {AgentName} not found", LogSanitizer.Sanitize(agentName));
                 return ServiceResult<bool>.NotFound($"Agent '{agentName}' not found");
             }
 
             // Verify that the agent is system-scoped
             if (!agent.SystemScoped)
             {
-                _logger.LogWarning("Agent {AgentName} is not system-scoped", agentName);
+                _logger.LogWarning("Agent {AgentName} is not system-scoped", LogSanitizer.Sanitize(agentName));
                 return ServiceResult<bool>.BadRequest($"Agent '{agentName}' is not a system-scoped agent. Only system-scoped agents can be deleted through this endpoint.");
             }
 
@@ -182,7 +183,7 @@ public class TemplateService : ITemplateService
             
             if (!success)
             {
-                _logger.LogWarning("Failed to delete system-scoped agent {AgentName}", agentName);
+                _logger.LogWarning("Failed to delete system-scoped agent {AgentName}", LogSanitizer.Sanitize(agentName));
                 return ServiceResult<bool>.InternalServerError($"Failed to delete system-scoped agent '{agentName}'");
             }
 
@@ -193,7 +194,7 @@ public class TemplateService : ITemplateService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error deleting system-scoped agent {AgentName}", agentName);
+            _logger.LogError(ex, "Error deleting system-scoped agent {AgentName}", LogSanitizer.Sanitize(agentName));
             return ServiceResult<bool>.InternalServerError(
                 "An error occurred while deleting the system-scoped agent");
         }
@@ -214,7 +215,7 @@ public class TemplateService : ITemplateService
         try
         {
             _logger.LogInformation("Deploying template agent {AgentName} to tenant {TenantId} by user {CreatedBy}", 
-                agentName, tenantId, createdBy);
+                LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(tenantId), LogSanitizer.Sanitize(createdBy));
 
             // Validate input
             if (string.IsNullOrWhiteSpace(agentName))
@@ -238,7 +239,7 @@ public class TemplateService : ITemplateService
 
             if (templateAgent == null)
             {
-                _logger.LogWarning("System-scoped agent {AgentName} not found", agentName);
+                _logger.LogWarning("System-scoped agent {AgentName} not found", LogSanitizer.Sanitize(agentName));
                 return ServiceResult<Agent>.NotFound($"System-scoped agent '{agentName}' not found");
             }
 
@@ -246,7 +247,7 @@ public class TemplateService : ITemplateService
             var existingAgent = await _agentRepository.GetByNameInternalAsync(agentName, tenantId);
             if (existingAgent != null)
             {
-                _logger.LogWarning("Agent {AgentName} already exists in tenant {TenantId}", agentName, tenantId);
+                _logger.LogWarning("Agent {AgentName} already exists in tenant {TenantId}", LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(tenantId));
                 return ServiceResult<Agent>.Conflict($"Agent '{agentName}' already exists in tenant '{tenantId}'. Delete it first if you want to redeploy.");
             }
 
@@ -277,7 +278,7 @@ public class TemplateService : ITemplateService
             // Create the agent
             await _agentRepository.CreateAsync(newAgent);
             _logger.LogInformation("Created agent replica {AgentName} with ID {AgentId} for tenant {TenantId} by user {CreatedBy}", 
-                agentName, newAgent.Id, tenantId, createdBy);
+                LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(newAgent.Id), LogSanitizer.Sanitize(tenantId), LogSanitizer.Sanitize(createdBy));
 
             // Clone all flow definitions from the template
             var clonedDefinitionsCount = 0;
@@ -305,7 +306,7 @@ public class TemplateService : ITemplateService
                 clonedDefinitionsCount++;
                 
                 _logger.LogDebug("Cloned flow definition {WorkflowType} for agent {AgentName}", 
-                    templateDefinition.WorkflowType, agentName);
+                    LogSanitizer.Sanitize(templateDefinition.WorkflowType), LogSanitizer.Sanitize(agentName));
             }
 
             _logger.LogInformation("Successfully deployed template agent {AgentName} to tenant {TenantId} with {DefinitionsCount} flow definitions by user {CreatedBy}", 
@@ -316,7 +317,7 @@ public class TemplateService : ITemplateService
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error deploying template agent {AgentName} to tenant {TenantId} by user {CreatedBy}", 
-                agentName, tenantId, createdBy);
+                LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(tenantId), LogSanitizer.Sanitize(createdBy));
             return ServiceResult<Agent>.InternalServerError(
                 "An error occurred while deploying the template to tenant");
         }
@@ -331,7 +332,7 @@ public class TemplateService : ITemplateService
     {
         try
         {
-            _logger.LogInformation("Retrieving system-scoped agent template by ID {TemplateObjectId}", templateObjectId);
+            _logger.LogInformation("Retrieving system-scoped agent template by ID {TemplateObjectId}", LogSanitizer.Sanitize(templateObjectId));
 
             if (string.IsNullOrWhiteSpace(templateObjectId))
             {
@@ -341,13 +342,13 @@ public class TemplateService : ITemplateService
             var template = await _agentRepository.GetByIdInternalAsync(templateObjectId);
             if (template == null)
             {
-                _logger.LogWarning("Template with ID {TemplateObjectId} not found", templateObjectId);
+                _logger.LogWarning("Template with ID {TemplateObjectId} not found", LogSanitizer.Sanitize(templateObjectId));
                 return ServiceResult<Agent>.NotFound($"Agent template with ID '{templateObjectId}' not found");
             }
 
             if (!template.SystemScoped)
             {
-                _logger.LogWarning("Agent with ID {TemplateObjectId} is not system-scoped", templateObjectId);
+                _logger.LogWarning("Agent with ID {TemplateObjectId} is not system-scoped", LogSanitizer.Sanitize(templateObjectId));
                 return ServiceResult<Agent>.BadRequest($"Agent with ID '{templateObjectId}' is not a system-scoped template");
             }
 
@@ -355,7 +356,7 @@ public class TemplateService : ITemplateService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error retrieving system-scoped agent template by ID {TemplateObjectId}", templateObjectId);
+            _logger.LogError(ex, "Error retrieving system-scoped agent template by ID {TemplateObjectId}", LogSanitizer.Sanitize(templateObjectId));
             return ServiceResult<Agent>.InternalServerError(
                 "An error occurred while retrieving the template");
         }
@@ -376,7 +377,7 @@ public class TemplateService : ITemplateService
     {
         try
         {
-            _logger.LogInformation("Updating system-scoped agent template by ID {TemplateObjectId}", templateObjectId);
+            _logger.LogInformation("Updating system-scoped agent template by ID {TemplateObjectId}", LogSanitizer.Sanitize(templateObjectId));
 
             if (string.IsNullOrWhiteSpace(templateObjectId))
             {
@@ -386,13 +387,13 @@ public class TemplateService : ITemplateService
             var template = await _agentRepository.GetByIdInternalAsync(templateObjectId);
             if (template == null)
             {
-                _logger.LogWarning("Template with ID {TemplateObjectId} not found", templateObjectId);
+                _logger.LogWarning("Template with ID {TemplateObjectId} not found", LogSanitizer.Sanitize(templateObjectId));
                 return ServiceResult<Agent>.NotFound($"Agent template with ID '{templateObjectId}' not found");
             }
 
             if (!template.SystemScoped)
             {
-                _logger.LogWarning("Agent with ID {TemplateObjectId} is not system-scoped", templateObjectId);
+                _logger.LogWarning("Agent with ID {TemplateObjectId} is not system-scoped", LogSanitizer.Sanitize(templateObjectId));
                 return ServiceResult<Agent>.BadRequest($"Agent with ID '{templateObjectId}' is not a system-scoped template");
             }
 
@@ -430,16 +431,16 @@ public class TemplateService : ITemplateService
             var updated = await _agentRepository.UpdateInternalAsync(template.Id, template);
             if (!updated)
             {
-                _logger.LogWarning("Failed to update template with ID {TemplateObjectId}", templateObjectId);
+                _logger.LogWarning("Failed to update template with ID {TemplateObjectId}", LogSanitizer.Sanitize(templateObjectId));
                 return ServiceResult<Agent>.InternalServerError("Failed to update the template");
             }
 
-            _logger.LogInformation("Successfully updated system-scoped agent template {TemplateObjectId}", templateObjectId);
+            _logger.LogInformation("Successfully updated system-scoped agent template {TemplateObjectId}", LogSanitizer.Sanitize(templateObjectId));
             return ServiceResult<Agent>.Success(template);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error updating system-scoped agent template by ID {TemplateObjectId}", templateObjectId);
+            _logger.LogError(ex, "Error updating system-scoped agent template by ID {TemplateObjectId}", LogSanitizer.Sanitize(templateObjectId));
             return ServiceResult<Agent>.InternalServerError(
                 "An error occurred while updating the template");
         }

--- a/XiansAi.Server.Src/Shared/Services/TenantOidcConfigService.cs
+++ b/XiansAi.Server.Src/Shared/Services/TenantOidcConfigService.cs
@@ -87,7 +87,7 @@ public class TenantOidcConfigService : ITenantOidcConfigService
             
             if (cachedRules != null)
             {
-                _logger.LogDebug("Retrieved OIDC config for tenant {TenantId} from cache", tenantId);
+                _logger.LogDebug("Retrieved OIDC config for tenant {TenantId} from cache", LogSanitizer.Sanitize(tenantId));
                 return ServiceResult<TenantOidcRules?>.Success(cachedRules);
             }
 
@@ -96,12 +96,12 @@ public class TenantOidcConfigService : ITenantOidcConfigService
             var hasNullResult = await _cache.GetAsync<bool?>(nullCacheKey);
             if (hasNullResult == true)
             {
-                _logger.LogDebug("Retrieved null OIDC config for tenant {TenantId} from cache", tenantId);
+                _logger.LogDebug("Retrieved null OIDC config for tenant {TenantId} from cache", LogSanitizer.Sanitize(tenantId));
                 return ServiceResult<TenantOidcRules?>.Success(null);
             }
 
             // Cache miss - fetch from database
-            _logger.LogDebug("Cache miss for tenant {TenantId} OIDC config, fetching from database", tenantId);
+            _logger.LogDebug("Cache miss for tenant {TenantId} OIDC config, fetching from database", LogSanitizer.Sanitize(tenantId));
             var result = await GetForTenantFromDatabaseAsync(tenantId);
             
             // Cache the result based on success/failure
@@ -127,7 +127,7 @@ public class TenantOidcConfigService : ITenantOidcConfigService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error getting cached OIDC config for tenant {TenantId}", tenantId);
+            _logger.LogError(ex, "Error getting cached OIDC config for tenant {TenantId}", LogSanitizer.Sanitize(tenantId));
             // Fallback to database on cache errors
             return await GetForTenantFromDatabaseAsync(tenantId);
         }
@@ -152,13 +152,13 @@ public class TenantOidcConfigService : ITenantOidcConfigService
             }
             catch (AuthenticationTagMismatchException ex)
             {
-                _logger.LogWarning(ex, "Decryption failed due to tag mismatch for tenant {TenantId}", tenantId);
+                _logger.LogWarning(ex, "Decryption failed due to tag mismatch for tenant {TenantId}", LogSanitizer.Sanitize(tenantId));
                 return ServiceResult<TenantOidcRules?>.Conflict("The encryption keys may have changed. Please reconfigure the tenant OIDC settings.");
             }
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error getting OIDC config for tenant {TenantId}", tenantId);
+            _logger.LogError(ex, "Error getting OIDC config for tenant {TenantId}", LogSanitizer.Sanitize(tenantId));
             return ServiceResult<TenantOidcRules?>.InternalServerError("Failed to load OIDC configuration");
         }
     }
@@ -224,13 +224,13 @@ public class TenantOidcConfigService : ITenantOidcConfigService
             
             // Invalidate cache after successful update
             await InvalidateCacheAsync(tenantId);
-            _logger.LogDebug("Invalidated cache for tenant {TenantId} after upsert", tenantId);
+            _logger.LogDebug("Invalidated cache for tenant {TenantId} after upsert", LogSanitizer.Sanitize(tenantId));
             
             return ServiceResult<bool>.Success(true);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error upserting OIDC config for tenant {TenantId}", tenantId);
+            _logger.LogError(ex, "Error upserting OIDC config for tenant {TenantId}", LogSanitizer.Sanitize(tenantId));
             return ServiceResult<bool>.InternalServerError("Failed to save OIDC configuration");
         }
     }
@@ -248,14 +248,14 @@ public class TenantOidcConfigService : ITenantOidcConfigService
             {
                 // Invalidate cache after successful deletion
                 await InvalidateCacheAsync(tenantId);
-                _logger.LogDebug("Invalidated cache for tenant {TenantId} after deletion", tenantId);
+                _logger.LogDebug("Invalidated cache for tenant {TenantId} after deletion", LogSanitizer.Sanitize(tenantId));
             }
             
             return removed ? ServiceResult<bool>.Success(true) : ServiceResult<bool>.NotFound("No configuration found");
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error deleting OIDC config for tenant {TenantId}", tenantId);
+            _logger.LogError(ex, "Error deleting OIDC config for tenant {TenantId}", LogSanitizer.Sanitize(tenantId));
             return ServiceResult<bool>.InternalServerError("Failed to delete OIDC configuration");
         }
     }
@@ -276,7 +276,7 @@ public class TenantOidcConfigService : ITenantOidcConfigService
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Failed to decrypt/deserialize OIDC config for tenant {TenantId}", item.TenantId);
+                    _logger.LogError(ex, "Failed to decrypt/deserialize OIDC config for tenant {TenantId}", LogSanitizer.Sanitize(item.TenantId));
                     list.Add((item.TenantId, null));
                 }
             }
@@ -329,7 +329,7 @@ public class TenantOidcConfigService : ITenantOidcConfigService
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to invalidate cache for tenant {TenantId}", tenantId);
+            _logger.LogWarning(ex, "Failed to invalidate cache for tenant {TenantId}", LogSanitizer.Sanitize(tenantId));
             // Don't throw - cache invalidation failure shouldn't break the main operation
         }
     }

--- a/XiansAi.Server.Src/Shared/Services/TenantService.cs
+++ b/XiansAi.Server.Src/Shared/Services/TenantService.cs
@@ -1,5 +1,6 @@
 using MongoDB.Bson;
 using Shared.Auth;
+using Shared.Utils;
 using Shared.Utils.Services;
 using Shared.Data.Models;
 using System.ComponentModel.DataAnnotations;
@@ -83,7 +84,7 @@ public class TenantService : ITenantService
         }
         catch (ValidationException ex)
         {
-            _logger.LogWarning("Validation failed while ensuring tenant access: {Message}", ex.Message);
+            _logger.LogWarning("Validation failed while ensuring tenant access: {Message}", LogSanitizer.Sanitize(ex.Message));
             throw;
         }
 
@@ -101,7 +102,7 @@ public class TenantService : ITenantService
         }
 
         // Otherwise, forbidden
-        _logger.LogWarning("Attempted to access tenant `{Id}` but is restricted to SysAdmins and of tenant `{TenantId}`", tenantId, _tenantContext.TenantId);
+        _logger.LogWarning("Attempted to access tenant `{Id}` but is restricted to SysAdmins and of tenant `{TenantId}`", LogSanitizer.Sanitize(tenantId), LogSanitizer.Sanitize(_tenantContext.TenantId));
         throw new UnauthorizedAccessException("Access denied: insufficient permissions");
     }
 
@@ -113,7 +114,7 @@ public class TenantService : ITenantService
         }
         catch (ValidationException ex)
         {
-            _logger.LogWarning("Validation failed while sanitizing and validating ID: {Message}", ex.Message);
+            _logger.LogWarning("Validation failed while sanitizing and validating ID: {Message}", LogSanitizer.Sanitize(ex.Message));
             throw;
         }
     }
@@ -126,14 +127,14 @@ public class TenantService : ITenantService
             var accessibleTenantId = _tenantContext.AuthorizedTenantIds?.FirstOrDefault(t => t == id);
             if (accessibleTenantId == null)
             {
-                _logger.LogWarning("Unauthorized access attempt to tenant with ID {Id}", id);
+                _logger.LogWarning("Unauthorized access attempt to tenant with ID {Id}", LogSanitizer.Sanitize(id));
                 return ServiceResult<Tenant>.Forbidden("Access denied: insufficient permissions");
             }
 
             var tenant = await _tenantRepository.GetByIdAsync(id);
             if (tenant == null)
             {
-                _logger.LogWarning("Tenant with ID {Id} not found", id);
+                _logger.LogWarning("Tenant with ID {Id} not found", LogSanitizer.Sanitize(id));
                 return ServiceResult<Tenant>.NotFound("Tenant not found");
             }
 
@@ -141,12 +142,12 @@ public class TenantService : ITenantService
         }
         catch (ValidationException ex)
         {
-            _logger.LogWarning("Validation failed while retrieving tenant by ID: {Message}", ex.Message);
+            _logger.LogWarning("Validation failed while retrieving tenant by ID: {Message}", LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<Tenant>.BadRequest($"Validation failed: {ex.Message}");
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error retrieving tenant with ID {Id}", id);
+            _logger.LogError(ex, "Error retrieving tenant with ID {Id}", LogSanitizer.Sanitize(id));
             return ServiceResult<Tenant>.InternalServerError("An error occurred while retrieving the tenant.");
         }
     }
@@ -160,7 +161,7 @@ public class TenantService : ITenantService
             var tenant = await _tenantRepository.GetByDomainAsync(domain);
             if (tenant == null)
             {
-                _logger.LogWarning("Tenant with domain {Domain} not found", domain);
+                _logger.LogWarning("Tenant with domain {Domain} not found", LogSanitizer.Sanitize(domain));
                 return ServiceResult<Tenant>.NotFound("Tenant not found");
             }
 
@@ -168,12 +169,12 @@ public class TenantService : ITenantService
         }
         catch (ValidationException ex)
         {
-            _logger.LogWarning("Validation failed while retrieving tenant by domain: {Message}", ex.Message);
+            _logger.LogWarning("Validation failed while retrieving tenant by domain: {Message}", LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<Tenant>.BadRequest($"Validation failed: {ex.Message}");
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error retrieving tenant with domain {Domain}", domain);
+            _logger.LogError(ex, "Error retrieving tenant with domain {Domain}", LogSanitizer.Sanitize(domain));
             return ServiceResult<Tenant>.InternalServerError("An error occurred while retrieving the tenant.");
         }
     }
@@ -186,14 +187,14 @@ public class TenantService : ITenantService
             var accessibleTenantId = _tenantContext.AuthorizedTenantIds?.FirstOrDefault(t => t == tenantId);
             if (accessibleTenantId == null)
             {
-                _logger.LogWarning("Unauthorized access attempt to tenant with tenant ID {TenantId}", tenantId);
+                _logger.LogWarning("Unauthorized access attempt to tenant with tenant ID {TenantId}", LogSanitizer.Sanitize(tenantId));
                 return ServiceResult<Tenant>.Forbidden("Access denied: insufficient permissions");
             }
 
             var tenant = await _tenantCacheService.GetByTenantIdAsync(tenantId, cancellationToken);
             if (tenant == null)
             {
-                _logger.LogWarning("Tenant with tenant ID {TenantId} not found", tenantId);
+                _logger.LogWarning("Tenant with tenant ID {TenantId} not found", LogSanitizer.Sanitize(tenantId));
                 return ServiceResult<Tenant>.NotFound("Tenant not found");
             }
 
@@ -201,12 +202,12 @@ public class TenantService : ITenantService
         }
         catch (ValidationException ex)
         {
-            _logger.LogWarning("Validation failed while retrieving tenant by tenant ID: {Message}", ex.Message);
+            _logger.LogWarning("Validation failed while retrieving tenant by tenant ID: {Message}", LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<Tenant>.BadRequest($"Validation failed: {ex.Message}");
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error retrieving tenant with tenant ID {TenantId}", tenantId);
+            _logger.LogError(ex, "Error retrieving tenant with tenant ID {TenantId}", LogSanitizer.Sanitize(tenantId));
             return ServiceResult<Tenant>.InternalServerError("An error occurred while retrieving the tenant.");
         }
     }
@@ -226,14 +227,14 @@ public class TenantService : ITenantService
             var accessibleTenantId = _tenantContext.AuthorizedTenantIds?.FirstOrDefault(t => t == tenantId);
             if (accessibleTenantId == null)
             {
-                _logger.LogWarning("Unauthorized access attempt to tenant with tenant ID {TenantId}", tenantId);
+                _logger.LogWarning("Unauthorized access attempt to tenant with tenant ID {TenantId}", LogSanitizer.Sanitize(tenantId));
                 return ServiceResult<Tenant>.Forbidden("Access denied: insufficient permissions");
             }
 
             var tenant = await _tenantCacheService.GetByTenantIdAsync(tenantId, cancellationToken);
             if (tenant == null)
             {
-                _logger.LogWarning("Tenant with tenant ID {TenantId} not found", tenantId);
+                _logger.LogWarning("Tenant with tenant ID {TenantId} not found", LogSanitizer.Sanitize(tenantId));
                 return ServiceResult<Tenant>.NotFound("Tenant not found");
             }
 
@@ -241,7 +242,7 @@ public class TenantService : ITenantService
         }
         catch (ValidationException ex)
         {
-            _logger.LogWarning("Validation failed while retrieving current tenant info: {Message}", ex.Message);
+            _logger.LogWarning("Validation failed while retrieving current tenant info: {Message}", LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<Tenant>.BadRequest($"Validation failed: {ex.Message}");
         }
         catch (Exception ex)
@@ -258,7 +259,7 @@ public class TenantService : ITenantService
             // Only SysAdmin can get all tenants
             if (!_tenantContext.UserRoles.Contains(SystemRoles.SysAdmin))
             {
-                _logger.LogWarning("Unauthorized attempt to get all tenants by user {UserId}", _tenantContext.LoggedInUser);
+                _logger.LogWarning("Unauthorized attempt to get all tenants by user {UserId}", LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
                 return ServiceResult<List<Tenant>>.Forbidden("Access denied: Only system administrators can retrieve all tenants");
             }
 
@@ -279,7 +280,7 @@ public class TenantService : ITenantService
             // Only SysAdmin can get tenant list
             if (!_tenantContext.UserRoles.Contains(SystemRoles.SysAdmin))
             {
-                _logger.LogWarning("Unauthorized attempt to get tenant list by user {UserId}", _tenantContext.LoggedInUser);
+                _logger.LogWarning("Unauthorized attempt to get tenant list by user {UserId}", LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
                 return ServiceResult<List<string>>.Forbidden("Access denied: Only system administrators can retrieve tenant list");
             }
 
@@ -298,10 +299,10 @@ public class TenantService : ITenantService
         try
         {
             _logger.LogInformation("CreateTenant request received - CreatedBy: {RequestCreatedBy}, Method param CreatedBy: {MethodCreatedBy}, LoggedInUser: {LoggedInUser}", 
-                request.CreatedBy, createdBy, _tenantContext.LoggedInUser);
+                LogSanitizer.Sanitize(request.CreatedBy), LogSanitizer.Sanitize(createdBy), LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
 
             var finalCreatedBy = request.CreatedBy ?? createdBy ?? _tenantContext.LoggedInUser ?? throw new InvalidOperationException("Logged in user is not set");
-            _logger.LogInformation("Final CreatedBy value determined: {FinalCreatedBy}", finalCreatedBy);
+            _logger.LogInformation("Final CreatedBy value determined: {FinalCreatedBy}", LogSanitizer.Sanitize(finalCreatedBy));
 
             var tenant = new Tenant
             {
@@ -318,14 +319,14 @@ public class TenantService : ITenantService
                 CreatedAt = DateTime.UtcNow,
                 UpdatedAt = DateTime.UtcNow
             };
-            _logger.LogInformation("Tenant object created with CreatedBy: {CreatedBy}", tenant.CreatedBy);
+            _logger.LogInformation("Tenant object created with CreatedBy: {CreatedBy}", LogSanitizer.Sanitize(tenant.CreatedBy));
             
             var validatedTenant = tenant.SanitizeAndValidate();
-            _logger.LogInformation("After sanitization, CreatedBy: {CreatedBy}", validatedTenant.CreatedBy);
+            _logger.LogInformation("After sanitization, CreatedBy: {CreatedBy}", LogSanitizer.Sanitize(validatedTenant.CreatedBy));
 
 
             await _tenantRepository.CreateAsync(validatedTenant);
-            _logger.LogInformation("Created new tenant with ID {Id} and CreatedBy: {CreatedBy}", validatedTenant.Id, validatedTenant.CreatedBy);
+            _logger.LogInformation("Created new tenant with ID {Id} and CreatedBy: {CreatedBy}", LogSanitizer.Sanitize(validatedTenant.Id), LogSanitizer.Sanitize(validatedTenant.CreatedBy));
 
             var result = new TenantCreatedResult
             {
@@ -336,12 +337,12 @@ public class TenantService : ITenantService
         }
         catch (ValidationException ex)
         {
-            _logger.LogWarning("Validation failed while creating tenant: {Message}", ex.Message);
+            _logger.LogWarning("Validation failed while creating tenant: {Message}", LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<TenantCreatedResult>.BadRequest($"Validation failed: {ex.Message}");
         }
         catch (MongoWriteException ex) when (ex.WriteError?.Code == 11000) // Duplicate key error
         {
-            _logger.LogWarning("Duplicate tenant ID or domain: {TenantId}", request.TenantId);
+            _logger.LogWarning("Duplicate tenant ID or domain: {TenantId}", LogSanitizer.Sanitize(request.TenantId));
             return ServiceResult<TenantCreatedResult>.BadRequest("A tenant with this ID or domain already exists.");
         }
         catch (Exception ex)
@@ -360,7 +361,7 @@ public class TenantService : ITenantService
             var existingTenant = await _tenantRepository.GetByIdAsync(id);
             if (existingTenant == null)
             {
-                _logger.LogWarning("Tenant with ID {Id} not found for update", id);
+                _logger.LogWarning("Tenant with ID {Id} not found for update", LogSanitizer.Sanitize(id));
                 return ServiceResult<Tenant>.NotFound("Tenant not found");
             }
 
@@ -397,29 +398,29 @@ public class TenantService : ITenantService
                 if (!string.IsNullOrEmpty(existingTenant.TenantId))
                     _tenantCacheService.InvalidateTenant(existingTenant.TenantId);
                 else
-                    _logger.LogWarning("Skipping tenant cache invalidation: Tenant {Id} has null or empty TenantId", id);
-                _logger.LogInformation("Updated tenant with ID {Id}", id);
+                    _logger.LogWarning("Skipping tenant cache invalidation: Tenant {Id} has null or empty TenantId", LogSanitizer.Sanitize(id));
+                _logger.LogInformation("Updated tenant with ID {Id}", LogSanitizer.Sanitize(id));
                 return ServiceResult<Tenant>.Success(validatedTenant);
             }
             else
             {
-                _logger.LogError("Failed to update tenant with ID {Id}", id);
+                _logger.LogError("Failed to update tenant with ID {Id}", LogSanitizer.Sanitize(id));
                 return ServiceResult<Tenant>.BadRequest("Failed to update tenant.");
             }
         }
         catch (ValidationException ex)
         {
-            _logger.LogWarning("Validation failed while updating tenant: {Message}", ex.Message);
+            _logger.LogWarning("Validation failed while updating tenant: {Message}", LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<Tenant>.BadRequest($"Validation failed: {ex.Message}");
         }
         catch (UnauthorizedAccessException ex)
         {
-            _logger.LogWarning("Access denied: {Message}", ex.Message);
+            _logger.LogWarning("Access denied: {Message}", LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<Tenant>.Forbidden("Access denied: insufficient permissions");
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error updating tenant with ID {Id}", id);
+            _logger.LogError(ex, "Error updating tenant with ID {Id}", LogSanitizer.Sanitize(id));
             return ServiceResult<Tenant>.InternalServerError("An error occurred while updating the tenant.");
         }
     }
@@ -432,7 +433,7 @@ public class TenantService : ITenantService
             var existingTenant = await _tenantRepository.GetByIdAsync(id);
             if (existingTenant == null)
             {
-                _logger.LogWarning("Tenant with ID {Id} not found for deletion", id);
+                _logger.LogWarning("Tenant with ID {Id} not found for deletion", LogSanitizer.Sanitize(id));
                 return ServiceResult<bool>.NotFound("Tenant not found");
             }
             EnsureTenantAccessOrThrow(existingTenant.TenantId);
@@ -443,29 +444,29 @@ public class TenantService : ITenantService
                 if (!string.IsNullOrEmpty(existingTenant.TenantId))
                     _tenantCacheService.InvalidateTenant(existingTenant.TenantId);
                 else
-                    _logger.LogWarning("Skipping tenant cache invalidation: Tenant {Id} has null or empty TenantId", id);
-                _logger.LogInformation("Deleted tenant with ID {Id}", id);
+                    _logger.LogWarning("Skipping tenant cache invalidation: Tenant {Id} has null or empty TenantId", LogSanitizer.Sanitize(id));
+                _logger.LogInformation("Deleted tenant with ID {Id}", LogSanitizer.Sanitize(id));
                 return ServiceResult<bool>.Success(true);
             }
             else
             {
-                _logger.LogWarning("Tenant with ID {Id} not found for deletion", id);
+                _logger.LogWarning("Tenant with ID {Id} not found for deletion", LogSanitizer.Sanitize(id));
                 return ServiceResult<bool>.NotFound("Tenant not found");
             }
         }
         catch (ValidationException ex)
         {
-            _logger.LogWarning("Validation failed while deleting tenant: {Message}", ex.Message);
+            _logger.LogWarning("Validation failed while deleting tenant: {Message}", LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<bool>.BadRequest($"Validation failed: {ex.Message}");
         }
         catch (UnauthorizedAccessException ex)
         {
-            _logger.LogWarning("Access denied: {Message}", ex.Message);
+            _logger.LogWarning("Access denied: {Message}", LogSanitizer.Sanitize(ex.Message));
             return ServiceResult<bool>.Forbidden("Access denied: insufficient permissions");
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error deleting tenant with ID {Id}", id);
+            _logger.LogError(ex, "Error deleting tenant with ID {Id}", LogSanitizer.Sanitize(id));
             return ServiceResult<bool>.InternalServerError("An error occurred while deleting the tenant.");
         }
     }

--- a/XiansAi.Server.Src/Shared/Services/UsageEventService.cs
+++ b/XiansAi.Server.Src/Shared/Services/UsageEventService.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using Shared.Configuration;
 using Shared.Data.Models.Usage;
 using Shared.Repositories;
+using Shared.Utils;
 
 namespace Shared.Services;
 
@@ -72,10 +73,10 @@ public class UsageEventService : IUsageEventService
 
         _logger.LogInformation(
             "Recording flattened usage metrics: tenant={TenantId}, participant={ParticipantId}, agent={AgentName}, activation={ActivationName}, metricsCount={MetricsCount}",
-            tenantId,
-            participantId,
-            request.AgentName,
-            request.ActivationName,
+            LogSanitizer.Sanitize(tenantId),
+            LogSanitizer.Sanitize(participantId),
+            LogSanitizer.Sanitize(request.AgentName),
+            LogSanitizer.Sanitize(request.ActivationName),
             request.Metrics.Count);
 
         // Use agent name from request if provided, otherwise extract from workflow_id
@@ -152,7 +153,7 @@ public class UsageEventService : IUsageEventService
 
         _logger.LogInformation(
             "Retrieved statistics: category={Category}, type={MetricType}, totalValue={TotalValue}, requests={RequestCount}, users={UserCount}",
-            stats.Category, stats.MetricType, stats.TotalValue, stats.TotalMetrics.RequestCount, stats.UserBreakdown.Count);
+            LogSanitizer.Sanitize(stats.Category), LogSanitizer.Sanitize(stats.MetricType), stats.TotalValue, stats.TotalMetrics.RequestCount, stats.UserBreakdown.Count);
 
         return stats;
     }
@@ -166,7 +167,7 @@ public class UsageEventService : IUsageEventService
             throw new ArgumentException("Tenant ID is required", nameof(tenantId));
         }
 
-        _logger.LogInformation("Retrieving users with usage for tenant={TenantId}", tenantId);
+        _logger.LogInformation("Retrieving users with usage for tenant={TenantId}", LogSanitizer.Sanitize(tenantId));
 
         var users = await _repository.GetUsersWithUsageAsync(tenantId, cancellationToken);
 
@@ -184,7 +185,7 @@ public class UsageEventService : IUsageEventService
             throw new ArgumentException("Tenant ID is required", nameof(tenantId));
         }
 
-        _logger.LogInformation("Retrieving available metrics for tenant={TenantId}", tenantId);
+        _logger.LogInformation("Retrieving available metrics for tenant={TenantId}", LogSanitizer.Sanitize(tenantId));
 
         var metrics = await _repository.GetAvailableMetricsAsync(tenantId, cancellationToken);
 

--- a/XiansAi.Server.Src/Shared/Services/UserManagementService.cs
+++ b/XiansAi.Server.Src/Shared/Services/UserManagementService.cs
@@ -181,12 +181,12 @@ public class UserManagementService : IUserManagementService
 
             // Invalidate all cached tokens for this user to ensure locked users cannot access the system
             await _tokenCache.InvalidateUserTokens(userId);
-            _logger.LogInformation("User {UserId} locked by {AdminUserId} and tokens invalidated", userId, _tenantContext.LoggedInUser);
+            _logger.LogInformation("User {UserId} locked by {AdminUserId} and tokens invalidated", LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
             return ServiceResult<bool>.Success(true);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error locking user {UserId}", userId);
+            _logger.LogError(ex, "Error locking user {UserId}", LogSanitizer.Sanitize(userId));
             return ServiceResult<bool>.InternalServerError("An error occurred while locking the user");
         }
     }
@@ -209,12 +209,12 @@ public class UserManagementService : IUserManagementService
 
             // Invalidate cached tokens so user needs to re-authenticate with fresh token
             await _tokenCache.InvalidateUserTokens(userId);
-            _logger.LogInformation("User {UserId} unlocked by {AdminUserId} and tokens invalidated", userId, _tenantContext.LoggedInUser);
+            _logger.LogInformation("User {UserId} unlocked by {AdminUserId} and tokens invalidated", LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
             return ServiceResult<bool>.Success(true);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error unlocking user {UserId}", userId);
+            _logger.LogError(ex, "Error unlocking user {UserId}", LogSanitizer.Sanitize(userId));
             return ServiceResult<bool>.InternalServerError("An error occurred while unlocking the user");
         }
     }
@@ -228,7 +228,7 @@ public class UserManagementService : IUserManagementService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error checking lock status for user {UserId}", userId);
+            _logger.LogError(ex, "Error checking lock status for user {UserId}", LogSanitizer.Sanitize(userId));
             return ServiceResult<bool>.InternalServerError("An error occurred while checking user lock status");
         }
     }
@@ -252,7 +252,7 @@ public class UserManagementService : IUserManagementService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error retrieving user {UserId}", userId);
+            _logger.LogError(ex, "Error retrieving user {UserId}", LogSanitizer.Sanitize(userId));
             return ServiceResult<User>.InternalServerError("An error occurred while retrieving the user");
         }
     }
@@ -290,23 +290,23 @@ public class UserManagementService : IUserManagementService
                     existingUser = await _userRepository.GetByUserIdAsync(userDto.UserId);
                     if (existingUser != null)
                     {
-                        _logger.LogInformation("User {UserId} already exists, creation was redundant", userDto.UserId);
+                        _logger.LogInformation("User {UserId} already exists, creation was redundant", LogSanitizer.Sanitize(userDto.UserId));
                         return ServiceResult<bool>.Conflict("User already exists");
                     }
                     return ServiceResult<bool>.InternalServerError("Failed to create new user");
                 }
-                _logger.LogInformation("New user created: {UserId}", userDto.UserId);
+                _logger.LogInformation("New user created: {UserId}", LogSanitizer.Sanitize(userDto.UserId));
                 return ServiceResult<bool>.Success(true);
             }
             catch (Exception createEx)
             {
-                _logger.LogWarning(createEx, "User creation failed for {UserId}, checking if user already exists", userDto.UserId);
+                _logger.LogWarning(createEx, "User creation failed for {UserId}, checking if user already exists", LogSanitizer.Sanitize(userDto.UserId));
 
                 // Check if user was created by another process
                 existingUser = await _userRepository.GetByUserIdAsync(userDto.UserId);
                 if (existingUser != null)
                 {
-                    _logger.LogInformation("User {UserId} already exists after creation failure", userDto.UserId);
+                    _logger.LogInformation("User {UserId} already exists after creation failure", LogSanitizer.Sanitize(userDto.UserId));
                     return ServiceResult<bool>.Conflict("User already exists");
                 }
 
@@ -315,7 +315,7 @@ public class UserManagementService : IUserManagementService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error creating new user {UserId}", userDto.UserId);
+            _logger.LogError(ex, "Error creating new user {UserId}", LogSanitizer.Sanitize(userDto.UserId));
             return ServiceResult<bool>.InternalServerError("An error occurred while creating the new user");
         }
     }
@@ -334,7 +334,7 @@ public class UserManagementService : IUserManagementService
             var belongsToTenant = existingUser.TenantRoles.Any(tr => tr.Tenant == _tenantContext.TenantId);
             if (!belongsToTenant && !existingUser.IsSysAdmin)
             {
-                _logger.LogWarning("User {UserId} does not belong to tenant {TenantId}. IDOR attempt detected.", user.UserId, _tenantContext.TenantId);
+                _logger.LogWarning("User {UserId} does not belong to tenant {TenantId}. IDOR attempt detected.", LogSanitizer.Sanitize(user.UserId), LogSanitizer.Sanitize(_tenantContext.TenantId));
                 return ServiceResult<bool>.Forbidden("User does not belong to the current tenant");
             }
         }
@@ -364,7 +364,7 @@ public class UserManagementService : IUserManagementService
 
         // Invalidate all cached tokens for this user to ensure permission changes take effect immediately
         await _tokenCache.InvalidateUserTokens(user.UserId);
-        _logger.LogInformation("Invalidated cached tokens for user {UserId} after update", user.UserId);
+        _logger.LogInformation("Invalidated cached tokens for user {UserId} after update", LogSanitizer.Sanitize(user.UserId));
 
         return ServiceResult<bool>.Success(true);
     }
@@ -379,7 +379,7 @@ public class UserManagementService : IUserManagementService
                 if (!_tenantContext.UserRoles.Contains(SystemRoles.TenantAdmin))
                 {
                     _logger.LogWarning("User {UserId} attempted to invite user without admin permissions", 
-                        _tenantContext.LoggedInUser);
+                        LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
                     return ServiceResult<string>.Forbidden("Only admins can invite users");
                 }
                 
@@ -387,7 +387,7 @@ public class UserManagementService : IUserManagementService
                 if (invite.TenantId != _tenantContext.TenantId)
                 {
                     _logger.LogWarning("Tenant admin {UserId} attempted to invite user to different tenant. Current: {CurrentTenant}, Invite: {InviteTenant}", 
-                        _tenantContext.LoggedInUser, _tenantContext.TenantId, invite.TenantId);
+                        LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(_tenantContext.TenantId), LogSanitizer.Sanitize(invite.TenantId));
                     return ServiceResult<string>.Forbidden("Cannot invite users to other tenants");
                 }
             }
@@ -409,12 +409,12 @@ public class UserManagementService : IUserManagementService
             await _emailService.SendEmailAsync(invite.Email, EMAIL_SUBJECT, GetEmailBody(invitation.ExpiresAt.ToString("f")), false);
 
             _logger.LogInformation("Invitation created for {Email} (tenant: {TenantId}) by user {UserId}", 
-                invite.Email, invite.TenantId, _tenantContext.LoggedInUser);
+                LogSanitizer.Sanitize(invite.Email), LogSanitizer.Sanitize(invite.TenantId), LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
             return ServiceResult<string>.Success(token);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error inviting user {Email}", invite.Email);
+            _logger.LogError(ex, "Error inviting user {Email}", LogSanitizer.Sanitize(invite.Email));
             return ServiceResult<string>.InternalServerError("An error occurred while inviting the user");
         }
     }
@@ -429,7 +429,7 @@ public class UserManagementService : IUserManagementService
                 if (!_tenantContext.UserRoles.Contains(SystemRoles.TenantAdmin))
                 {
                     _logger.LogWarning("User {UserId} attempted to get invitations without admin permissions", 
-                        _tenantContext.LoggedInUser);
+                        LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
                     return ServiceResult<List<InviteDto>>.Forbidden("Only admins can view invitations");
                 }
                 
@@ -437,7 +437,7 @@ public class UserManagementService : IUserManagementService
                 if (tenantId != _tenantContext.TenantId)
                 {
                     _logger.LogWarning("Tenant admin {UserId} attempted to get invitations for different tenant. Current: {CurrentTenant}, Requested: {RequestedTenant}", 
-                        _tenantContext.LoggedInUser, _tenantContext.TenantId, tenantId);
+                        LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(_tenantContext.TenantId), LogSanitizer.Sanitize(tenantId));
                     return ServiceResult<List<InviteDto>>.Forbidden("Cannot view invitations from other tenants");
                 }
             }
@@ -451,7 +451,7 @@ public class UserManagementService : IUserManagementService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error getting invitations for tenant {TenantId}", tenantId);
+            _logger.LogError(ex, "Error getting invitations for tenant {TenantId}", LogSanitizer.Sanitize(tenantId));
             return ServiceResult<List<InviteDto>>.InternalServerError("An error occurred while retrieving invitations");
         }
     }
@@ -479,7 +479,7 @@ public class UserManagementService : IUserManagementService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error retrieving invitation for user {userId}", _tenantContext.LoggedInUser);
+            _logger.LogError(ex, "Error retrieving invitation for user {userId}", LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
             return ServiceResult<InviteDto?>.InternalServerError("An error occurred while retrieving the invitation");
         }
     }
@@ -508,7 +508,7 @@ public class UserManagementService : IUserManagementService
             if (!string.Equals(invitation.Email, existingUser.Email, StringComparison.OrdinalIgnoreCase))
             {
                 _logger.LogWarning("User {UserId} ({Email}) attempted to accept invitation for different email {InvitationEmail}", 
-                    _tenantContext.LoggedInUser, existingUser.Email, invitation.Email);
+                    LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.RedactEmail(existingUser.Email), LogSanitizer.RedactEmail(invitation.Email));
                 return ServiceResult<bool>.Forbidden("This invitation is for a different email address");
             }
             
@@ -516,7 +516,7 @@ public class UserManagementService : IUserManagementService
             if (existingUser.TenantRoles.Any(tr => tr.Tenant == invitation.TenantId))
             {
                 _logger.LogWarning("User {UserId} already has access to tenant {TenantId}", 
-                    _tenantContext.LoggedInUser, invitation.TenantId);
+                    LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(invitation.TenantId));
                 return ServiceResult<bool>.Conflict("You already have access to this tenant");
             }
 
@@ -534,12 +534,12 @@ public class UserManagementService : IUserManagementService
 
             await _invitationRepository.MarkAsAcceptedAsync(invitationToken);
 
-            _logger.LogInformation("User {UserId} accepted invitation for tenant {TenantId}", _tenantContext.LoggedInUser, invitation.TenantId);
+            _logger.LogInformation("User {UserId} accepted invitation for tenant {TenantId}", LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(invitation.TenantId));
             return ServiceResult<bool>.Success(true);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error accepting invitation for user {UserId}", _tenantContext.LoggedInUser);
+            _logger.LogError(ex, "Error accepting invitation for user {UserId}", LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
             return ServiceResult<bool>.InternalServerError("An error occurred while accepting the invitation");
         }
     }
@@ -559,7 +559,7 @@ public class UserManagementService : IUserManagementService
         
         // Invalidate all cached tokens for the deleted user
         await _tokenCache.InvalidateUserTokens(userId);
-        _logger.LogInformation("User {UserId} deleted and tokens invalidated", userId);
+        _logger.LogInformation("User {UserId} deleted and tokens invalidated", LogSanitizer.Sanitize(userId));
         
         return ServiceResult<bool>.Success(deleted);
     }
@@ -598,7 +598,7 @@ public class UserManagementService : IUserManagementService
                 if (!_tenantContext.UserRoles.Contains(SystemRoles.TenantAdmin))
                 {
                     _logger.LogWarning("User {UserId} attempted to delete invitation without admin permissions", 
-                        _tenantContext.LoggedInUser);
+                        LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
                     return ServiceResult<bool>.Forbidden("Only admins can delete invitations");
                 }
                 
@@ -606,7 +606,7 @@ public class UserManagementService : IUserManagementService
                 if (invitation.TenantId != _tenantContext.TenantId)
                 {
                     _logger.LogWarning("Tenant admin {UserId} attempted to delete invitation for different tenant. Current: {CurrentTenant}, Invitation: {InvitationTenant}", 
-                        _tenantContext.LoggedInUser, _tenantContext.TenantId, invitation.TenantId);
+                        LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(_tenantContext.TenantId), LogSanitizer.Sanitize(invitation.TenantId));
                     return ServiceResult<bool>.Forbidden("Cannot delete invitations from other tenants");
                 }
             }
@@ -617,12 +617,12 @@ public class UserManagementService : IUserManagementService
                 return ServiceResult<bool>.InternalServerError("Failed to delete invitation");
             }
             
-            _logger.LogInformation("Invitation {Token} deleted by user {UserId}", token, _tenantContext.LoggedInUser);
+            _logger.LogInformation("Invitation {Token} deleted by user {UserId}", LogSanitizer.Sanitize(token), LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
             return ServiceResult<bool>.Success(true);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error deleting invitation {Token}", token);
+            _logger.LogError(ex, "Error deleting invitation {Token}", LogSanitizer.Sanitize(token));
             return ServiceResult<bool>.InternalServerError("An error occurred while deleting the invitation");
         }
     }
@@ -639,17 +639,17 @@ public class UserManagementService : IUserManagementService
             if (!jwtResult.IsValid)
             {
                 _logger.LogWarning("JWT token validation failed in getUserEmailfromToken: {Error}", 
-                    jwtResult.ErrorMessage);
+                    LogSanitizer.Sanitize(jwtResult.ErrorMessage));
                 throw new ArgumentException(jwtResult.ErrorMessage ?? "Invalid or expired token", nameof(token));
             }
             
             if (string.IsNullOrWhiteSpace(jwtResult.Email))
             {
-                _logger.LogWarning("Email claim not found in validated token for user: {UserId}", jwtResult.UserId);
+                _logger.LogWarning("Email claim not found in validated token for user: {UserId}", LogSanitizer.Sanitize(jwtResult.UserId));
                 throw new ArgumentException("Email not found in token", nameof(token));
             }
 
-            _logger.LogDebug("Successfully extracted email from validated token for user: {UserId}", jwtResult.UserId);
+            _logger.LogDebug("Successfully extracted email from validated token for user: {UserId}", LogSanitizer.Sanitize(jwtResult.UserId));
             return jwtResult.Email;
         }
         catch (ArgumentException)

--- a/XiansAi.Server.Src/Shared/Services/UserTenantService.cs
+++ b/XiansAi.Server.Src/Shared/Services/UserTenantService.cs
@@ -103,10 +103,10 @@ public class UserTenantService : IUserTenantService
             var userDto = await createUserFromToken(token);
             if (userDto == null)
             {
-                _logger.LogError("Failed to create user from token {Token}", token);
+                _logger.LogError("Failed to create user from token {Token}", LogSanitizer.Sanitize(token));
                 return ServiceResult<List<TenantInfoDto>>.InternalServerError("Failed to create user from token");
             }
-            _logger.LogInformation("User {UserId} created from token", userDto.UserId);
+            _logger.LogInformation("User {UserId} created from token", LogSanitizer.Sanitize(userDto.UserId));
         }
 
         // Optional: Azure AD group-based SysAdmin promotion
@@ -172,7 +172,7 @@ public class UserTenantService : IUserTenantService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error getting tenants for user {UserId}", userId);
+            _logger.LogError(ex, "Error getting tenants for user {UserId}", LogSanitizer.Sanitize(userId));
             return ServiceResult<List<TenantInfoDto>>.InternalServerError("Error getting tenants for user");
         }
     }
@@ -210,7 +210,7 @@ public class UserTenantService : IUserTenantService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error adding tenant {TenantId} to user {UserId}", tenantId, userId);
+            _logger.LogError(ex, "Error adding tenant {TenantId} to user {UserId}", LogSanitizer.Sanitize(tenantId), LogSanitizer.Sanitize(userId));
             return ServiceResult<bool>.InternalServerError("Error adding tenant to user");
         }
     }
@@ -251,7 +251,7 @@ public class UserTenantService : IUserTenantService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error adding user with email user {email} to tenant {TenantId}", _tenantContext.TenantId, email);
+            _logger.LogError(ex, "Error adding user with email user {email} to tenant {TenantId}", LogSanitizer.Sanitize(_tenantContext.TenantId), LogSanitizer.RedactEmail(email));
             return ServiceResult<bool>.InternalServerError("Error adding tenant to user with email {email}, email");
         }
     }
@@ -276,7 +276,7 @@ public class UserTenantService : IUserTenantService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error removing tenant {TenantId} from user {UserId}", tenantId, userId);
+            _logger.LogError(ex, "Error removing tenant {TenantId} from user {UserId}", LogSanitizer.Sanitize(tenantId), LogSanitizer.Sanitize(userId));
             return ServiceResult<bool>.InternalServerError("Error removing tenant from user");
         }
     }
@@ -305,7 +305,7 @@ public class UserTenantService : IUserTenantService
             else
             {
                 _logger.LogWarning("User {UserId} attempted to get unapproved users without proper permissions",
-                    _tenantContext.LoggedInUser);
+                    LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
                 return ServiceResult<List<User>>.Forbidden("Insufficient permissions to view unapproved users");
             }
             
@@ -334,7 +334,7 @@ public class UserTenantService : IUserTenantService
             {
                 if (user.TenantRoles.FirstOrDefault(tr => tr.Tenant == tenantId)?.IsApproved == true)
                 {
-                    _logger.LogWarning("User {UserId} already approved for tenant {TenantId}", userId, tenantId);
+                    _logger.LogWarning("User {UserId} already approved for tenant {TenantId}", LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(tenantId));
                     return ServiceResult<bool>.Conflict("User already approved for this tenant");
                 }
 
@@ -366,7 +366,7 @@ public class UserTenantService : IUserTenantService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error approving user {UserId} for tenant {TenantId}", userId, tenantId);
+            _logger.LogError(ex, "Error approving user {UserId} for tenant {TenantId}", LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(tenantId));
             return ServiceResult<bool>.InternalServerError("Error approving user");
         }
     }
@@ -385,7 +385,7 @@ public class UserTenantService : IUserTenantService
             if (!_tenantContext.TenantId.Equals(tenantId, StringComparison.OrdinalIgnoreCase))
             {
                 _logger.LogWarning("Tenant admin {UserId} attempted to {Operation} in different tenant {TenantId}",
-                    _tenantContext.LoggedInUser, operation, tenantId);
+                    LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(operation), LogSanitizer.Sanitize(tenantId));
                 return ServiceResult.Failure("Tenant admins can only access their own tenant", StatusCode.Forbidden);
             }
             return ServiceResult.Success();
@@ -393,7 +393,7 @@ public class UserTenantService : IUserTenantService
 
         // Regular users need to be at least tenant admin
         _logger.LogWarning("User {UserId} attempted to {Operation} without proper permissions",
-            _tenantContext.LoggedInUser, operation);
+            LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(operation));
         return ServiceResult.Failure("Insufficient permissions to manage roles", StatusCode.Forbidden);
     }
 
@@ -406,7 +406,7 @@ public class UserTenantService : IUserTenantService
                 return ServiceResult<bool>.NotFound("User not found");
             if (user.TenantRoles.Any(tr => tr.Tenant == tenantId))
             {
-                _logger.LogWarning("User {UserId} in tenant {TenantId}", _tenantContext.LoggedInUser, tenantId);
+                _logger.LogWarning("User {UserId} in tenant {TenantId}", LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(tenantId));
                 return ServiceResult<bool>.Conflict("User already in this tenant");
             }
             var tenantEntry = new TenantRole
@@ -423,7 +423,7 @@ public class UserTenantService : IUserTenantService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error approving user {UserId} for tenant {TenantId}", _tenantContext.LoggedInUser, tenantId);
+            _logger.LogError(ex, "Error approving user {UserId} for tenant {TenantId}", LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(tenantId));
             return ServiceResult<bool>.InternalServerError("Error approving user");
         }
     }
@@ -456,7 +456,7 @@ public class UserTenantService : IUserTenantService
         if (user.IsSysAdmin != existingUser.IsSysAdmin)
         {
             _logger.LogWarning("Attempt to modify system admin status for user {UserId} via tenant endpoint by {LoggedInUser}", 
-                user.UserId, _tenantContext.LoggedInUser);
+                LogSanitizer.Sanitize(user.UserId), LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
             return ServiceResult<bool>.Forbidden("Cannot modify system admin status via this endpoint");
         }
 
@@ -465,7 +465,7 @@ public class UserTenantService : IUserTenantService
         if (rolesForOtherTenants.Any())
         {
             _logger.LogWarning("Attempt to modify roles for other tenants by user {LoggedInUser} in tenant {TenantId}", 
-                _tenantContext.LoggedInUser, _tenantContext.TenantId);
+                LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(_tenantContext.TenantId));
             return ServiceResult<bool>.Forbidden("Can only modify roles for the current tenant");
         }
 
@@ -488,7 +488,7 @@ public class UserTenantService : IUserTenantService
             if (hasSystemRoles && !_tenantContext.UserRoles.Contains(SystemRoles.SysAdmin))
             {
                 _logger.LogWarning("Attempt to assign system-wide roles by non-sysadmin user {LoggedInUser} in tenant {TenantId}",
-                    _tenantContext.LoggedInUser, _tenantContext.TenantId);
+                    LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(_tenantContext.TenantId));
                 return ServiceResult<bool>.Forbidden("Cannot assign system-wide roles");
             }
 
@@ -511,7 +511,7 @@ public class UserTenantService : IUserTenantService
         await _userRepository.UpdateAsync(existingUser.UserId, existingUser);
 
         _logger.LogInformation("User {UserId} updated by {LoggedInUser} in tenant {TenantId}", 
-            user.UserId, _tenantContext.LoggedInUser, _tenantContext.TenantId);
+            LogSanitizer.Sanitize(user.UserId), LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(_tenantContext.TenantId));
 
         return ServiceResult<bool>.Success(true);
     }
@@ -574,18 +574,18 @@ public class UserTenantService : IUserTenantService
             var created = await _userRepository.CreateAsync(newUser);
             if (!created)
             {
-                _logger.LogError("Failed to create user {Email} in database", dto.Email);
+                _logger.LogError("Failed to create user {Email} in database", LogSanitizer.RedactEmail(dto.Email));
                 return ServiceResult<User>.InternalServerError("Failed to create user");
             }
 
             _logger.LogInformation("User {UserId} ({Email}) created by {CreatedBy} in tenant {TenantId}",
-                userId, dto.Email, _tenantContext.LoggedInUser, tenantId);
+                LogSanitizer.Sanitize(userId), LogSanitizer.RedactEmail(dto.Email), LogSanitizer.Sanitize(_tenantContext.LoggedInUser), LogSanitizer.Sanitize(tenantId));
 
             // Retrieve the created user to return complete data
             var createdUser = await _userRepository.GetByUserIdAsync(userId);
             if (createdUser == null)
             {
-                _logger.LogError("Created user {UserId} but failed to retrieve it", userId);
+                _logger.LogError("Created user {UserId} but failed to retrieve it", LogSanitizer.Sanitize(userId));
                 return ServiceResult<User>.InternalServerError("User created but failed to retrieve");
             }
 
@@ -593,7 +593,7 @@ public class UserTenantService : IUserTenantService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error creating new user in tenant {TenantId}", tenantId);
+            _logger.LogError(ex, "Error creating new user in tenant {TenantId}", LogSanitizer.Sanitize(tenantId));
             return ServiceResult<User>.InternalServerError("An error occurred while creating the new user");
         }
     }
@@ -627,7 +627,7 @@ public class UserTenantService : IUserTenantService
         if (!jwtResult.IsValid || string.IsNullOrEmpty(jwtResult.UserId))
         {
             _logger.LogWarning("JWT token validation failed in createUserFromToken: {Error}", 
-                jwtResult.ErrorMessage);
+                LogSanitizer.Sanitize(jwtResult.ErrorMessage));
             throw new ArgumentException(jwtResult.ErrorMessage ?? "Invalid or expired token", nameof(token));
         }
 
@@ -642,7 +642,7 @@ public class UserTenantService : IUserTenantService
 
         if (!createdUser.IsSuccess && createdUser.StatusCode == StatusCode.Conflict)
         {
-            _logger.LogInformation("User {UserId} already exists, returning existing user", jwtResult.UserId);
+            _logger.LogInformation("User {UserId} already exists, returning existing user", LogSanitizer.Sanitize(jwtResult.UserId));
             return newUser;
         }
 

--- a/XiansAi.Server.Src/Shared/Services/WorkflowSignalService.cs
+++ b/XiansAi.Server.Src/Shared/Services/WorkflowSignalService.cs
@@ -152,14 +152,14 @@ public class WorkflowSignalService : IWorkflowSignalService
             options.SignalWithStart(request.SignalName, signalPayload);
 
             _logger.LogInformation("Starting/invoking workflow `{WorkflowId}` with signal `{SignalName}`",
-                request.TargetWorkflowId, request.SignalName);
+                LogSanitizer.Sanitize(request.TargetWorkflowId), LogSanitizer.Sanitize(request.SignalName));
 
             await client.StartWorkflowAsync(request.TargetWorkflowType, new List<object>().AsReadOnly(), options);
 
             activity?.SetStatus(ActivityStatusCode.Ok);
 
             _logger.LogInformation("Successfully invoked workflow type {WorkflowType} with signal {SignalName}",
-                request.TargetWorkflowType, request.SignalName);
+                LogSanitizer.Sanitize(request.TargetWorkflowType), LogSanitizer.Sanitize(request.SignalName));
 
             return Results.Ok(new {
                 message = "Signal with start sent successfully",
@@ -171,7 +171,7 @@ public class WorkflowSignalService : IWorkflowSignalService
         {
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             activity?.AddException(ex);
-            _logger.LogWarning(ex, "Workflow reference not found for type: {WorkflowType}", request.TargetWorkflowType);
+            _logger.LogWarning(ex, "Workflow reference not found for type: {WorkflowType}", LogSanitizer.Sanitize(request.TargetWorkflowType));
             return Results.NotFound(new {
                 message = $"Workflow type '{request.TargetWorkflowType}' could not be started or referenced",
                 workflowType = request.TargetWorkflowType
@@ -182,7 +182,7 @@ public class WorkflowSignalService : IWorkflowSignalService
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             activity?.AddException(ex);
             _logger.LogError(ex, "Error sending signal {SignalName} to workflow {WorkflowType}",
-                request.SignalName, request.TargetWorkflowType);
+                LogSanitizer.Sanitize(request.SignalName), LogSanitizer.Sanitize(request.TargetWorkflowType));
 
             throw;
         }

--- a/XiansAi.Server.Src/Shared/Utils/JwtClaimsExtractor.cs
+++ b/XiansAi.Server.Src/Shared/Utils/JwtClaimsExtractor.cs
@@ -191,7 +191,7 @@ public class JwtClaimsExtractor : IJwtClaimsExtractor
             var claimValue = jsonToken.Claims.FirstOrDefault(c => c.Type == claimType)?.Value;
             if (!string.IsNullOrEmpty(claimValue))
             {
-                _logger.LogDebug("Found claim '{ClaimType}': {Value}", claimType, claimValue);
+                _logger.LogDebug("Found claim '{ClaimType}'", claimType);
                 return claimValue;
             }
 
@@ -201,8 +201,8 @@ public class JwtClaimsExtractor : IJwtClaimsExtractor
                 claimValue = jsonToken.Claims.FirstOrDefault(c => c.Type == fallbackType)?.Value;
                 if (!string.IsNullOrEmpty(claimValue))
                 {
-                    _logger.LogDebug("Found claim '{FallbackType}' (fallback for '{ClaimType}'): {Value}", 
-                        fallbackType, claimType, claimValue);
+                    _logger.LogDebug("Found claim '{FallbackType}' (fallback for '{ClaimType}')", 
+                        fallbackType, claimType);
                     return claimValue;
                 }
             }

--- a/XiansAi.Server.Src/Shared/Utils/LogSanitizer.cs
+++ b/XiansAi.Server.Src/Shared/Utils/LogSanitizer.cs
@@ -1,0 +1,43 @@
+namespace Shared.Utils;
+
+/// <summary>
+/// Sanitizes user-supplied strings before they are written to log entries,
+/// preventing log-forging / log-injection attacks (CWE-117 / cs/log-forging).
+/// Newline and carriage-return characters are replaced with a space so that an
+/// attacker cannot inject fake log lines by embedding line-breaks in input.
+/// </summary>
+public static class LogSanitizer
+{
+    /// <summary>
+    /// Returns a sanitized copy of <paramref name="value"/> safe for logging,
+    /// or <c>null</c> when the input is <c>null</c>.
+    /// </summary>
+    public static string? Sanitize(string? value)
+    {
+        if (value is null)
+            return null;
+
+        return value
+            .Replace('\r', ' ')
+            .Replace('\n', ' ');
+    }
+
+    /// <summary>
+    /// Redacts an email address for logging to minimize PII retention
+    /// (CWE-359 / cs/exposure-of-sensitive-information). The local part is
+    /// masked while the domain is preserved for troubleshooting, producing
+    /// the form "***@domain". Returns a placeholder for empty or malformed
+    /// values so the original address is never written to a log entry.
+    /// </summary>
+    public static string RedactEmail(string? email)
+    {
+        if (string.IsNullOrEmpty(email))
+            return "[empty]";
+
+        var atIndex = email.IndexOf('@');
+        if (atIndex < 0)
+            return "***@[no-domain]";
+
+        return "***@" + email[(atIndex + 1)..];
+    }
+}

--- a/XiansAi.Server.Src/Shared/Utils/MongoRetryHelper.cs
+++ b/XiansAi.Server.Src/Shared/Utils/MongoRetryHelper.cs
@@ -1,5 +1,6 @@
 using MongoDB.Driver;
 using System.Net.Sockets;
+using Shared.Utils;
 
 namespace Shared.Utils;
 

--- a/XiansAi.Server.Src/Shared/Utils/ObjectCache.cs
+++ b/XiansAi.Server.Src/Shared/Utils/ObjectCache.cs
@@ -1,4 +1,5 @@
 using Shared.Providers;
+using Shared.Utils;
 
 namespace Shared.Utils;
 
@@ -39,7 +40,7 @@ public class ObjectCache
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error retrieving value from cache for key: {Key}", key);
+            _logger.LogError(ex, "Error retrieving value from cache for key: {Key}", LogSanitizer.Sanitize(key));
             return default;
         }
     }
@@ -62,7 +63,7 @@ public class ObjectCache
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error setting value in cache for key: {Key}", key);
+            _logger.LogError(ex, "Error setting value in cache for key: {Key}", LogSanitizer.Sanitize(key));
             return false;
         }
     }
@@ -80,7 +81,7 @@ public class ObjectCache
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error removing value from cache for key: {Key}", key);
+            _logger.LogError(ex, "Error removing value from cache for key: {Key}", LogSanitizer.Sanitize(key));
             return false;
         }
     }

--- a/XiansAi.Server.Src/XiansAi.Server.csproj
+++ b/XiansAi.Server.Src/XiansAi.Server.csproj
@@ -31,6 +31,11 @@
     <PackageReference Include="Microsoft.Identity.Web" Version="3.13.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.4.0" />
     <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="3.0.0" />
+    <!-- Pin patched versions to override vulnerable transitive dependencies from MongoDB.Driver -->
+    <!-- SharpCompress 0.49.1 fixes GHSA-6c8g-7p36-r338 (CVE-2026-44788) -->
+    <PackageReference Include="SharpCompress" Version="0.49.1" />
+    <!-- Snappier 1.3.1 fixes GHSA-pggp-6c3x-2xmx (CVE-2026-44302) -->
+    <PackageReference Include="Snappier" Version="1.3.1" />
     <PackageReference Include="OpenAI" Version="2.1.0" />
     <PackageReference Include="Pipelines.Sockets.Unofficial" Version="2.2.8" />
     <PackageReference Include="Polly" Version="8.5.2" />


### PR DESCRIPTION
## Summary
- Add `LogSanitizer` utility (`Shared/Utils/LogSanitizer.cs`) that strips CR/LF characters from user-supplied values before they are written to logs, preventing log-forging / log-injection (CWE-117), and redacts email local parts (`***@domain`) to limit PII exposure in logs (CWE-359).
- Apply sanitization/redaction across endpoints, services, repositories, and auth handlers (~90 files); also drop logging of sensitive raw claim values in `JwtClaimsExtractor`.
- Pin patched transitive dependencies in `XiansAi.Server.csproj` to override vulnerable versions pulled in via `MongoDB.Driver`:
  - `SharpCompress` 0.49.1 (GHSA-6c8g-7p36-r338 / CVE-2026-44788)
  - `Snappier` 1.3.1 (GHSA-pggp-6c3x-2xmx / CVE-2026-44302)

## Test plan
- [x] `dotnet build` succeeds with 0 warnings / 0 errors
- [ ] Verify log output no longer contains raw newline-injectable user input
- [ ] Confirm restored package graph no longer flags the vulnerable transitive versions

Made with [Cursor](https://cursor.com)