### PR TITLE
Support Cache-Control: no-cache on admin get-tenant-by-id endpoint

### DIFF
--- a/XiansAi.Server.Src/Features/AdminApi/Endpoints/AdminTenantEndpoints.cs
+++ b/XiansAi.Server.Src/Features/AdminApi/Endpoints/AdminTenantEndpoints.cs
@@ -72,7 +72,10 @@ public static class AdminTenantEndpoints
                     new { message = "Access denied: Only system administrators can retrieve tenant details by ID" },
                     statusCode: StatusCodes.Status403Forbidden);
             }
-            var result = await tenantService.GetTenantByTenantId(tenantId, httpContext.RequestAborted);
+            // Honor the standard "Cache-Control: no-cache" request header: when present, read the
+            // tenant directly from the database (bypassing, then refreshing, the tenant cache).
+            var bypassCache = httpContext.Request.IsNoCacheRequested();
+            var result = await tenantService.GetTenantByTenantId(tenantId, httpContext.RequestAborted, bypassCache);
             if (result.IsSuccess)
             {
                 TenantLogoHelper.ApplyLogoUrl(result.Data, httpContext, linkGenerator);

--- a/XiansAi.Server.Src/Shared/Services/TenantCacheService.cs
+++ b/XiansAi.Server.Src/Shared/Services/TenantCacheService.cs
@@ -18,8 +18,10 @@ public interface ITenantCacheService
     /// Gets a tenant by ID from cache or database.
     /// Null results are cached with a shorter TTL to mitigate brute-force enumeration.
     /// Returns a shallow copy so callers cannot mutate the cached original.
+    /// When <paramref name="bypassCache"/> is true, the cache is not read; the tenant is fetched
+    /// directly from the database and the cache entry is refreshed with the fresh value.
     /// </summary>
-    Task<Tenant?> GetByTenantIdAsync(string tenantId, CancellationToken cancellationToken = default);
+    Task<Tenant?> GetByTenantIdAsync(string tenantId, CancellationToken cancellationToken = default, bool bypassCache = false);
 
     /// <summary>
     /// Invalidates the cached tenant when it is updated or deleted.
@@ -60,7 +62,7 @@ public class TenantCacheService : ITenantCacheService
         _nullResultCacheExpiration = TimeSpan.FromMinutes(Math.Max(1, nullResultExpirationMinutes));
     }
 
-    public async Task<Tenant?> GetByTenantIdAsync(string tenantId, CancellationToken cancellationToken = default)
+    public async Task<Tenant?> GetByTenantIdAsync(string tenantId, CancellationToken cancellationToken = default, bool bypassCache = false)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -77,10 +79,11 @@ public class TenantCacheService : ITenantCacheService
             await semaphore.WaitAsync(cancellationToken);
             acquired = true;
 
-            if (_cache.TryGetValue(cacheKey, out TenantCacheHolder? cachedHolder))
+            if (!bypassCache && _cache.TryGetValue(cacheKey, out TenantCacheHolder? cachedHolder))
                 return cachedHolder?.Tenant?.ShallowCopy();
 
-            _logger.LogDebug("Cache miss for tenant {TenantId}, fetching from database", tenantId);
+            _logger.LogDebug("Fetching tenant {TenantId} from database (bypassCache: {BypassCache})", tenantId, bypassCache);
+
             using var scope = _scopeFactory.CreateScope();
             var repo = scope.ServiceProvider.GetRequiredService<ITenantRepository>();
             var tenant = await repo.GetByTenantIdAsync(tenantId, cancellationToken);

--- a/XiansAi.Server.Src/Shared/Services/TenantService.cs
+++ b/XiansAi.Server.Src/Shared/Services/TenantService.cs
@@ -49,7 +49,7 @@ public interface ITenantService
 {
     Task<ServiceResult<Tenant>> GetTenantById(string id);
     Task<ServiceResult<Tenant>> GetTenantByDomain(string domain);
-    Task<ServiceResult<Tenant>> GetTenantByTenantId(string tenantId, CancellationToken cancellationToken = default);
+    Task<ServiceResult<Tenant>> GetTenantByTenantId(string tenantId, CancellationToken cancellationToken = default, bool bypassCache = false);
     Task<ServiceResult<Tenant>> GetCurrentTenantInfo(CancellationToken cancellationToken = default);
     Task<ServiceResult<List<Tenant>>> GetAllTenants();
     Task<ServiceResult<List<string>>> GetTenantIdList();
@@ -186,7 +186,7 @@ public class TenantService : ITenantService
         }
     }
 
-    public async Task<ServiceResult<Tenant>> GetTenantByTenantId(string tenantId, CancellationToken cancellationToken = default)
+    public async Task<ServiceResult<Tenant>> GetTenantByTenantId(string tenantId, CancellationToken cancellationToken = default, bool bypassCache = false)
     {
         try
         {
@@ -198,7 +198,7 @@ public class TenantService : ITenantService
                 return ServiceResult<Tenant>.Forbidden("Access denied: insufficient permissions");
             }
 
-            var tenant = await _tenantCacheService.GetByTenantIdAsync(tenantId, cancellationToken);
+            var tenant = await _tenantCacheService.GetByTenantIdAsync(tenantId, cancellationToken, bypassCache);
             if (tenant == null)
             {
                 _logger.LogWarning("Tenant with tenant ID {TenantId} not found", LogSanitizer.Sanitize(tenantId));

--- a/XiansAi.Server.Src/Shared/Utils/HttpRequestExtensions.cs
+++ b/XiansAi.Server.Src/Shared/Utils/HttpRequestExtensions.cs
@@ -1,0 +1,18 @@
+namespace Shared.Utils;
+
+/// <summary>
+/// Extension methods for reading standard HTTP semantics from an incoming request.
+/// </summary>
+public static class HttpRequestExtensions
+{
+    /// <summary>
+    /// Returns <c>true</c> when the request carries the standard <c>Cache-Control: no-cache</c>
+    /// directive, signalling that the caller wants a fresh response that bypasses any server-side cache.
+    /// Parsing is delegated to ASP.NET's typed-header support, so casing and multiple values are handled.
+    /// </summary>
+    public static bool IsNoCacheRequested(this HttpRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return request.GetTypedHeaders().CacheControl?.NoCache ?? false;
+    }
+}


### PR DESCRIPTION
Fixes an issue where retrieving a tenant immediately after creating it via
the Xians Server Admin API's "Get Tenant by ID" endpoint
(GET /admin/tenants/{tenantId}) could fail because of the cache. Tenant
lookups are served from an in-memory cache (TTL ~5 min, and null/not-found
results are cached too), so a freshly created tenant could return stale or
not-found data until the cached entry expired, with no way for the caller to
force a fresh read.

Honor the standard "Cache-Control: no-cache" request header: when present,
bypass the tenant cache and read directly from the database, then refresh
the cache with the fresh value (standard no-cache semantics).

- Add IsNoCacheRequested() HttpRequest extension to parse the header via
  ASP.NET typed-header support
- Thread an optional bypassCache flag through ITenantService.GetTenantByTenantId
  and ITenantCacheService.GetByTenantIdAsync (defaults to false, placed after