### PR TITLE
refactor(tests): clean up ActivityHistoryTests and InstructionsEndpoi…

### DIFF
--- a/XiansAi.Server.Tests/IntegrationTests/AdminApi/AdminAgentEndpointsTests.cs
+++ b/XiansAi.Server.Tests/IntegrationTests/AdminApi/AdminAgentEndpointsTests.cs
@@ -22,7 +22,7 @@ public class AdminAgentEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         var agent1 = await CreateTestAgentAsync($"agent-1-{Guid.NewGuid()}", tenantId);
         var agent2 = await CreateTestAgentAsync($"agent-2-{Guid.NewGuid()}", tenantId);
 
@@ -31,12 +31,12 @@ public class AdminAgentEndpointsTests : AdminApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var result = await ReadAsJsonAsync<AgentListResult>(response);
         Assert.NotNull(result);
         Assert.NotNull(result.Agents);
         Assert.True(result.Agents.Count >= 2);
-        
+
         var agentNames = result.Agents.Select(a => a.Name).ToList();
         Assert.Contains(agent1.Name, agentNames);
         Assert.Contains(agent2.Name, agentNames);
@@ -49,7 +49,7 @@ public class AdminAgentEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         // Create multiple agents
         for (int i = 0; i < 5; i++)
         {
@@ -61,7 +61,7 @@ public class AdminAgentEndpointsTests : AdminApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var result = await ReadAsJsonAsync<AgentListResult>(response);
         Assert.NotNull(result);
         Assert.NotNull(result.Pagination);
@@ -75,7 +75,7 @@ public class AdminAgentEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         var agent = await CreateTestAgentAsync($"test-agent-{Guid.NewGuid()}", tenantId);
 
         // Act
@@ -98,7 +98,7 @@ public class AdminAgentEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         var invalidId = ObjectId.GenerateNewId().ToString();
 
         // Act
@@ -115,9 +115,9 @@ public class AdminAgentEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         var agent = await CreateTestAgentAsync($"test-agent-{Guid.NewGuid()}", tenantId);
-        
+
         var updateRequest = new UpdateAgentRequest
         {
             Name = $"updated-agent-{Guid.NewGuid()}",
@@ -130,7 +130,7 @@ public class AdminAgentEndpointsTests : AdminApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var result = await ReadAsJsonAsync<Agent>(response);
         Assert.NotNull(result);
         Assert.Equal(updateRequest.Name, result.Name);
@@ -144,7 +144,7 @@ public class AdminAgentEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         var invalidId = ObjectId.GenerateNewId().ToString();
         var updateRequest = new UpdateAgentRequest
         {
@@ -165,7 +165,7 @@ public class AdminAgentEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         var agent = await CreateTestAgentAsync($"test-agent-{Guid.NewGuid()}", tenantId);
 
         // Act
@@ -173,7 +173,7 @@ public class AdminAgentEndpointsTests : AdminApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         // Verify deletion
         var getResponse = await GetAsync($"/api/v1/admin/tenants/{tenantId}/agentDeployments/{agent.Name}");
         Assert.Equal(HttpStatusCode.NotFound, getResponse.StatusCode);
@@ -186,7 +186,7 @@ public class AdminAgentEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         var invalidId = ObjectId.GenerateNewId().ToString();
 
         // Act
@@ -218,9 +218,9 @@ public class AdminAgentEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         var agent = await CreateTestAgentAsync($"test-agent-{Guid.NewGuid()}", tenantId);
-        
+
         // Create an activation for the agent
         var activation = await CreateTestActivationAsync(agent.Name, tenantId);
 
@@ -229,16 +229,14 @@ public class AdminAgentEndpointsTests : AdminApiIntegrationTestBase
 
         // Assert - Should fail with Conflict
         Assert.Equal(HttpStatusCode.Conflict, deleteResponse.StatusCode);
-        
+
         var errorContent = await deleteResponse.Content.ReadAsStringAsync();
         Assert.Contains("activation", errorContent, StringComparison.OrdinalIgnoreCase);
-        
+
         // Cleanup - Delete the activation first, then the agent should be deletable
         await DeleteTestActivationAsync(activation.Id);
-        
+
         var deleteAfterCleanup = await DeleteAsync($"/api/v1/admin/tenants/{tenantId}/agentDeployments/{agent.Name}");
         Assert.Equal(HttpStatusCode.OK, deleteAfterCleanup.StatusCode);
     }
 }
-
-

--- a/XiansAi.Server.Tests/IntegrationTests/AdminApi/AdminApiIntegrationTestBase.cs
+++ b/XiansAi.Server.Tests/IntegrationTests/AdminApi/AdminApiIntegrationTestBase.cs
@@ -76,7 +76,7 @@ public abstract class AdminApiIntegrationTestBase : WebApiIntegrationTestBase
 
         // Create API key - the repository automatically generates keys with sk-Xnai- prefix
         var (apiKey, apiKeyMeta) = await apiKeyRepository.CreateAsync(tenantId, $"test-admin-key-{Guid.NewGuid()}", userId);
-        
+
         // Ensure the user has the required role
         await CreateTestUserWithRoleAsync(userId, tenantId, role);
 
@@ -333,5 +333,3 @@ public abstract class AdminApiIntegrationTestBase : WebApiIntegrationTestBase
         await activationRepository.DeleteAsync(activationId);
     }
 }
-
-

--- a/XiansAi.Server.Tests/IntegrationTests/AdminApi/AdminKnowledgeEndpointsTests.cs
+++ b/XiansAi.Server.Tests/IntegrationTests/AdminApi/AdminKnowledgeEndpointsTests.cs
@@ -19,7 +19,7 @@ public class AdminKnowledgeEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         var agent = await CreateTestAgentAsync($"test-agent-{Guid.NewGuid()}", tenantId);
         await CreateTestKnowledgeAsync("knowledge-1", agent.Name, "Content 1", tenantId);
         await CreateTestKnowledgeAsync("knowledge-2", agent.Name, "Content 2", tenantId);
@@ -29,7 +29,7 @@ public class AdminKnowledgeEndpointsTests : AdminApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var content = await response.Content.ReadAsStringAsync();
         Assert.NotNull(content);
         Assert.Contains("knowledge-1", content);
@@ -43,7 +43,7 @@ public class AdminKnowledgeEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         var agent = await CreateTestAgentAsync($"test-agent-{Guid.NewGuid()}", tenantId);
         var knowledge = await CreateTestKnowledgeAsync("test-knowledge", agent.Name, "Test content", tenantId);
 
@@ -52,7 +52,7 @@ public class AdminKnowledgeEndpointsTests : AdminApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var result = await ReadAsJsonAsync<Knowledge>(response);
         Assert.NotNull(result);
         Assert.Equal(knowledge.Id, result.Id);
@@ -66,7 +66,7 @@ public class AdminKnowledgeEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         var agent = await CreateTestAgentAsync($"test-agent-{Guid.NewGuid()}", tenantId);
         var invalidId = ObjectId.GenerateNewId().ToString();
 
@@ -84,9 +84,9 @@ public class AdminKnowledgeEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         var agent = await CreateTestAgentAsync($"test-agent-{Guid.NewGuid()}", tenantId);
-        
+
         var request = new
         {
             name = "new-knowledge",
@@ -99,7 +99,7 @@ public class AdminKnowledgeEndpointsTests : AdminApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        
+
         var result = await ReadAsJsonAsync<Knowledge>(response);
         Assert.NotNull(result);
         Assert.Equal("new-knowledge", result.Name);
@@ -113,10 +113,10 @@ public class AdminKnowledgeEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         var agent = await CreateTestAgentAsync($"test-agent-{Guid.NewGuid()}", tenantId);
         var knowledge = await CreateTestKnowledgeAsync("test-knowledge", agent.Name, "Original content", tenantId);
-        
+
         var request = new
         {
             content = "Updated content",
@@ -128,7 +128,7 @@ public class AdminKnowledgeEndpointsTests : AdminApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var result = await ReadAsJsonAsync<Knowledge>(response);
         Assert.NotNull(result);
         Assert.Equal("Updated content", result.Content);
@@ -141,7 +141,7 @@ public class AdminKnowledgeEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         var agent = await CreateTestAgentAsync($"test-agent-{Guid.NewGuid()}", tenantId);
         var knowledge = await CreateTestKnowledgeAsync("test-knowledge", agent.Name, "Test content", tenantId);
 
@@ -150,7 +150,7 @@ public class AdminKnowledgeEndpointsTests : AdminApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         // Verify deletion
         var getResponse = await GetAsync($"/api/v1/admin/tenants/{tenantId}/knowledge/{knowledge.Id}");
         Assert.Equal(HttpStatusCode.NotFound, getResponse.StatusCode);
@@ -163,7 +163,7 @@ public class AdminKnowledgeEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         var agent = await CreateTestAgentAsync($"test-agent-{Guid.NewGuid()}", tenantId);
         await CreateTestKnowledgeAsync("test-knowledge", agent.Name, "Version 1", tenantId, createdAt: DateTime.UtcNow.AddHours(-2));
         await CreateTestKnowledgeAsync("test-knowledge", agent.Name, "Version 2", tenantId, createdAt: DateTime.UtcNow.AddHours(-1));
@@ -174,7 +174,7 @@ public class AdminKnowledgeEndpointsTests : AdminApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var content = await response.Content.ReadAsStringAsync();
         Assert.NotNull(content);
         Assert.Contains("test-knowledge", content);
@@ -187,7 +187,7 @@ public class AdminKnowledgeEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         var agent = await CreateTestAgentAsync($"test-agent-{Guid.NewGuid()}", tenantId);
         var knowledge1 = await CreateTestKnowledgeAsync("test-knowledge", agent.Name, "Version 1", tenantId);
         var knowledge2 = await CreateTestKnowledgeAsync("test-knowledge", agent.Name, "Version 2", tenantId);
@@ -199,5 +199,3 @@ public class AdminKnowledgeEndpointsTests : AdminApiIntegrationTestBase
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 }
-
-

--- a/XiansAi.Server.Tests/IntegrationTests/AdminApi/AdminMessagingEndpointsTests.cs
+++ b/XiansAi.Server.Tests/IntegrationTests/AdminApi/AdminMessagingEndpointsTests.cs
@@ -18,7 +18,7 @@ public class AdminMessagingEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         var request = new
         {
             threadId = $"thread-{Guid.NewGuid()}",
@@ -42,7 +42,7 @@ public class AdminMessagingEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         var request = new
         {
             threadId = $"thread-{Guid.NewGuid()}",
@@ -59,5 +59,3 @@ public class AdminMessagingEndpointsTests : AdminApiIntegrationTestBase
         Assert.NotEqual(HttpStatusCode.Forbidden, response.StatusCode);
     }
 }
-
-

--- a/XiansAi.Server.Tests/IntegrationTests/AdminApi/AdminOwnershipEndpointsTests.cs
+++ b/XiansAi.Server.Tests/IntegrationTests/AdminApi/AdminOwnershipEndpointsTests.cs
@@ -17,7 +17,7 @@ public class AdminOwnershipEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         var agent = await CreateTestAgentAsync($"test-agent-{Guid.NewGuid()}", tenantId);
 
         // Act
@@ -25,7 +25,7 @@ public class AdminOwnershipEndpointsTests : AdminApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var content = await response.Content.ReadAsStringAsync();
         Assert.NotNull(content);
         Assert.Contains("ownerAccess", content);
@@ -40,7 +40,7 @@ public class AdminOwnershipEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         var invalidId = MongoDB.Bson.ObjectId.GenerateNewId().ToString();
 
         // Act
@@ -57,11 +57,11 @@ public class AdminOwnershipEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         var agent = await CreateTestAgentAsync($"test-agent-{Guid.NewGuid()}", tenantId);
         var newAdminUserId = $"new-admin-{Guid.NewGuid()}";
         await CreateTestUserWithRoleAsync(newAdminUserId, tenantId, SystemRoles.TenantAdmin);
-        
+
         var request = new
         {
             newAdminId = newAdminUserId
@@ -72,7 +72,7 @@ public class AdminOwnershipEndpointsTests : AdminApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var content = await response.Content.ReadAsStringAsync();
         Assert.NotNull(content);
         Assert.Contains(newAdminUserId, content);
@@ -85,9 +85,9 @@ public class AdminOwnershipEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         var agent = await CreateTestAgentAsync($"test-agent-{Guid.NewGuid()}", tenantId);
-        
+
         var request = new
         {
             newAdminId = "non-existent-user"
@@ -100,5 +100,3 @@ public class AdminOwnershipEndpointsTests : AdminApiIntegrationTestBase
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 }
-
-

--- a/XiansAi.Server.Tests/IntegrationTests/AdminApi/AdminTemplateEndpointsTests.cs
+++ b/XiansAi.Server.Tests/IntegrationTests/AdminApi/AdminTemplateEndpointsTests.cs
@@ -21,11 +21,11 @@ public class AdminTemplateEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         // Create a system-scoped agent (template)
         using var scope = _factory.Services.CreateScope();
         var agentRepository = scope.ServiceProvider.GetRequiredService<IAgentRepository>();
-        
+
         var template = new Agent
         {
             Id = ObjectId.GenerateNewId().ToString(),
@@ -42,7 +42,7 @@ public class AdminTemplateEndpointsTests : AdminApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var content = await response.Content.ReadAsStringAsync();
         Assert.NotNull(content);
     }
@@ -54,11 +54,11 @@ public class AdminTemplateEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         // Create a system-scoped agent (template)
         using var scope = _factory.Services.CreateScope();
         var agentRepository = scope.ServiceProvider.GetRequiredService<IAgentRepository>();
-        
+
         var template = new Agent
         {
             Id = ObjectId.GenerateNewId().ToString(),
@@ -75,7 +75,7 @@ public class AdminTemplateEndpointsTests : AdminApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var result = await ReadAsJsonAsync<Agent>(response);
         Assert.NotNull(result);
         Assert.Equal(template.Id, result.Id);
@@ -88,7 +88,7 @@ public class AdminTemplateEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         var invalidId = ObjectId.GenerateNewId().ToString();
 
         // Act
@@ -105,11 +105,11 @@ public class AdminTemplateEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         // Create a system-scoped agent (template)
         using var scope = _factory.Services.CreateScope();
         var agentRepository = scope.ServiceProvider.GetRequiredService<IAgentRepository>();
-        
+
         var template = new Agent
         {
             Id = ObjectId.GenerateNewId().ToString(),
@@ -120,7 +120,7 @@ public class AdminTemplateEndpointsTests : AdminApiIntegrationTestBase
             CreatedAt = DateTime.UtcNow
         };
         await agentRepository.CreateAsync(template);
-        
+
         var request = new
         {
             description = "Updated description",
@@ -141,11 +141,11 @@ public class AdminTemplateEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         // Create a system-scoped agent (template)
         using var scope = _factory.Services.CreateScope();
         var agentRepository = scope.ServiceProvider.GetRequiredService<IAgentRepository>();
-        
+
         var template = new Agent
         {
             Id = ObjectId.GenerateNewId().ToString(),
@@ -171,11 +171,11 @@ public class AdminTemplateEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         // Create a system-scoped agent (template)
         using var scope = _factory.Services.CreateScope();
         var agentRepository = scope.ServiceProvider.GetRequiredService<IAgentRepository>();
-        
+
         var template = new Agent
         {
             Id = ObjectId.GenerateNewId().ToString(),
@@ -196,4 +196,3 @@ public class AdminTemplateEndpointsTests : AdminApiIntegrationTestBase
         Assert.NotEqual(HttpStatusCode.Forbidden, response.StatusCode);
     }
 }
-

--- a/XiansAi.Server.Tests/IntegrationTests/AdminApi/AdminTenantEndpointsTests.cs
+++ b/XiansAi.Server.Tests/IntegrationTests/AdminApi/AdminTenantEndpointsTests.cs
@@ -23,7 +23,7 @@ public class AdminTenantEndpointsTests : AdminApiIntegrationTestBase
         // Arrange
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
-        
+
         await CreateTestTenantAsync(tenantId);
         await CreateTestTenantAsync($"tenant-2-{Guid.NewGuid()}");
 
@@ -32,7 +32,7 @@ public class AdminTenantEndpointsTests : AdminApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var content = await response.Content.ReadAsStringAsync();
         Assert.NotNull(content);
     }
@@ -43,7 +43,7 @@ public class AdminTenantEndpointsTests : AdminApiIntegrationTestBase
         // Arrange
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
-        
+
         var tenant = await CreateTestTenantAsync(tenantId);
 
         // Act
@@ -51,7 +51,7 @@ public class AdminTenantEndpointsTests : AdminApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var result = await ReadAsJsonAsync<Tenant>(response);
         Assert.NotNull(result);
         Assert.Equal(tenant.TenantId, result.TenantId);
@@ -127,7 +127,7 @@ public class AdminTenantEndpointsTests : AdminApiIntegrationTestBase
         // Arrange
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
-        
+
         var invalidTenantId = $"non-existent-{Guid.NewGuid()}";
 
         // Act
@@ -171,9 +171,9 @@ public class AdminTenantEndpointsTests : AdminApiIntegrationTestBase
         // Arrange
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
-        
+
         var tenant = await CreateTestTenantAsync(tenantId);
-        
+
         var request = new
         {
             name = "Updated Tenant Name",
@@ -185,7 +185,7 @@ public class AdminTenantEndpointsTests : AdminApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var result = await ReadAsJsonAsync<Tenant>(response);
         Assert.NotNull(result);
         Assert.Equal(request.name, result.Name);
@@ -197,7 +197,7 @@ public class AdminTenantEndpointsTests : AdminApiIntegrationTestBase
         // Arrange
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
-        
+
         var tenant = await CreateTestTenantAsync(tenantId);
 
         // Act
@@ -205,7 +205,7 @@ public class AdminTenantEndpointsTests : AdminApiIntegrationTestBase
 
         // Assert
         Assert.True(response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.NoContent);
-        
+
         // Verify deletion
         var getResponse = await GetAsync($"/api/v1/admin/tenants/{tenantId}");
         Assert.Equal(HttpStatusCode.NotFound, getResponse.StatusCode);
@@ -217,7 +217,7 @@ public class AdminTenantEndpointsTests : AdminApiIntegrationTestBase
         // Arrange
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
-        
+
         var invalidTenantId = $"non-existent-{Guid.NewGuid()}";
 
         // Act
@@ -227,5 +227,3 @@ public class AdminTenantEndpointsTests : AdminApiIntegrationTestBase
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 }
-
-

--- a/XiansAi.Server.Tests/IntegrationTests/AdminApi/WorkflowManagementEndpointsTests.cs
+++ b/XiansAi.Server.Tests/IntegrationTests/AdminApi/WorkflowManagementEndpointsTests.cs
@@ -17,7 +17,7 @@ public class WorkflowManagementEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         var request = new
         {
             workflowType = "test-workflow",
@@ -41,7 +41,7 @@ public class WorkflowManagementEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         var workflowId = $"workflow-{Guid.NewGuid()}";
 
         // Act
@@ -66,7 +66,7 @@ public class WorkflowManagementEndpointsTests : AdminApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var content = await response.Content.ReadAsStringAsync();
         Assert.NotNull(content);
     }
@@ -78,7 +78,7 @@ public class WorkflowManagementEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         var workflowId = $"workflow-{Guid.NewGuid()}";
 
         // Act
@@ -97,7 +97,7 @@ public class WorkflowManagementEndpointsTests : AdminApiIntegrationTestBase
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId);
-        
+
         var workflowId = $"workflow-{Guid.NewGuid()}";
 
         // Act
@@ -109,5 +109,3 @@ public class WorkflowManagementEndpointsTests : AdminApiIntegrationTestBase
         Assert.NotEqual(HttpStatusCode.Forbidden, response.StatusCode);
     }
 }
-
-

--- a/XiansAi.Server.Tests/IntegrationTests/AgentApi/ActivityHistoryTests.cs
+++ b/XiansAi.Server.Tests/IntegrationTests/AgentApi/ActivityHistoryTests.cs
@@ -11,20 +11,12 @@ using Shared.Services;
 
 namespace Tests.IntegrationTests.AgentApi;
 
-
 public class ActivityHistoryTests : IntegrationTestBase, IClassFixture<MongoDbFixture>
 {
-    
-    /*
-    dotnet test --filter "FullyQualifiedName~ActivityHistoryTests"
-    */
     public ActivityHistoryTests(MongoDbFixture mongoFixture) : base(mongoFixture)
     {
     }
 
-    /*
-    dotnet test --filter "FullyQualifiedName=Tests.IntegrationTests.AgentApi.ActivityHistoryTests.CreateActivityHistory_WithValidData_ReturnsOk"
-    */
     [Fact]
     public async Task CreateActivityHistory_WithValidData_ReturnsOk()
     {
@@ -61,7 +53,4 @@ public class ActivityHistoryTests : IntegrationTestBase, IClassFixture<MongoDbFi
         // Wait for background tasks to complete with a reasonable timeout
         await backgroundTaskService.WaitForCompletionAsync(TimeSpan.FromSeconds(5));
     }
-    
-    // Removed: CreateActivityHistory_WithInvalidData_ReturnsBadRequest
-    // Removed: CreateActivityHistory_VerifyDataInsertedIntoMongoDB
-} 
+}

--- a/XiansAi.Server.Tests/IntegrationTests/AgentApi/ActivityHistoryTests.cs
+++ b/XiansAi.Server.Tests/IntegrationTests/AgentApi/ActivityHistoryTests.cs
@@ -45,11 +45,11 @@ public class ActivityHistoryTests : IntegrationTestBase, IClassFixture<MongoDbFi
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var responseContent = await response.Content.ReadAsStringAsync();
         Assert.Contains("Activity history creation queued", responseContent);
-        
+
         // Wait for background tasks to complete before test ends
         // This prevents MongoDB connection errors when the test fixture is disposed
         var backgroundTaskService = _factory.Services.GetRequiredService<IBackgroundTaskService>();
-        
+
         // Wait for background tasks to complete with a reasonable timeout
         await backgroundTaskService.WaitForCompletionAsync(TimeSpan.FromSeconds(5));
     }

--- a/XiansAi.Server.Tests/IntegrationTests/AgentApi/CacheEndpointTests.cs
+++ b/XiansAi.Server.Tests/IntegrationTests/AgentApi/CacheEndpointTests.cs
@@ -8,9 +8,6 @@ namespace Tests.IntegrationTests.AgentApi;
 
 public class CacheEndpointTests : IntegrationTestBase, IClassFixture<MongoDbFixture>
 {
-    /*
-    dotnet test --filter "FullyQualifiedName~CacheEndpointTests"    
-    */
     public CacheEndpointTests(MongoDbFixture mongoFixture) : base(mongoFixture)
     {
     }
@@ -28,16 +25,13 @@ public class CacheEndpointTests : IntegrationTestBase, IClassFixture<MongoDbFixt
         Assert.Equal(System.Net.HttpStatusCode.NotFound, response.StatusCode);
     }
 
-    /*
-    dotnet test --filter "FullyQualifiedName=Tests.IntegrationTests.AgentApi.CacheEndpointTests.SetAndGetCacheValue_ReturnsExpectedResult"
-    */
     [Fact]
     public async Task SetAndGetCacheValue_ReturnsExpectedResult()
     {
         // Arrange
         string testKey = "test-key";
         var testValue = JsonDocument.Parse("{\"test\": \"value\"}").RootElement;
-        
+
         // Act - Set cache value
         var setRequest = new CacheSetRequest
         {
@@ -45,14 +39,14 @@ public class CacheEndpointTests : IntegrationTestBase, IClassFixture<MongoDbFixt
             Value = testValue
         };
         var setResponse = await _client.PostAsJsonAsync("/api/agent/cache/set", setRequest);
-        
+
         // Assert - Set cache value
         setResponse.EnsureSuccessStatusCode();
-        
+
         // Act - Get cache value
         var getRequest = new CacheKeyRequest { Key = testKey };
         var getResponse = await _client.PostAsJsonAsync("/api/agent/cache/get", getRequest);
-        
+
         // Assert - Get cache value
         getResponse.EnsureSuccessStatusCode();
         var content = await getResponse.Content.ReadFromJsonAsync<JsonElement>();
@@ -75,14 +69,14 @@ public class CacheEndpointTests : IntegrationTestBase, IClassFixture<MongoDbFixt
             RelativeExpirationMinutes = relativeExpirationMinutes
         };
         var setResponse = await _client.PostAsJsonAsync("/api/agent/cache/set", setRequest);
-        
+
         // Assert - Set cache value
         setResponse.EnsureSuccessStatusCode();
-        
+
         // Act - Get cache value
         var getRequest = new CacheKeyRequest { Key = testKey };
         var getResponse = await _client.PostAsJsonAsync("/api/agent/cache/get", getRequest);
-        
+
         // Assert - Get cache value
         getResponse.EnsureSuccessStatusCode();
         var content = await getResponse.Content.ReadFromJsonAsync<JsonElement>();
@@ -95,7 +89,7 @@ public class CacheEndpointTests : IntegrationTestBase, IClassFixture<MongoDbFixt
         // Arrange
         string testKey = "delete-test-key";
         var testValue = JsonDocument.Parse("{\"test\": \"delete\"}").RootElement;
-        
+
         var setRequest = new CacheSetRequest
         {
             Key = testKey,
@@ -109,10 +103,10 @@ public class CacheEndpointTests : IntegrationTestBase, IClassFixture<MongoDbFixt
 
         // Assert
         Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
-        
+
         // Verify key is deleted
         var getRequest = new CacheKeyRequest { Key = testKey };
         var getResponse = await _client.PostAsJsonAsync("/api/agent/cache/get", getRequest);
         Assert.Equal(System.Net.HttpStatusCode.NotFound, getResponse.StatusCode);
     }
-} 
+}

--- a/XiansAi.Server.Tests/IntegrationTests/AgentApi/ConversationEndpointsTests.cs
+++ b/XiansAi.Server.Tests/IntegrationTests/AgentApi/ConversationEndpointsTests.cs
@@ -12,18 +12,12 @@ namespace Tests.IntegrationTests.AgentApi;
 
 public class ConversationEndpointsTests : IntegrationTestBase, IClassFixture<MongoDbFixture>
 {
-    /*
-    dotnet test --filter "FullyQualifiedName~ConversationEndpointsTests"
-    */
     private const string TestUserId = "test-user-id";
 
     public ConversationEndpointsTests(MongoDbFixture mongoFixture) : base(mongoFixture)
     {
     }
 
-    /*
-    dotnet test --filter "FullyQualifiedName=Tests.IntegrationTests.AgentApi.ConversationEndpointsTests.GetLastTaskId_WithTaskIdInHistory_ReturnsLastTaskId"
-    */
     [Fact]
     public async Task GetLastTaskId_WithTaskIdInHistory_ReturnsLastTaskId()
     {
@@ -64,9 +58,6 @@ public class ConversationEndpointsTests : IntegrationTestBase, IClassFixture<Mon
         Assert.Equal("\"latest-task-id\"", taskId); // JSON string is quoted
     }
 
-    /*
-    dotnet test --filter "FullyQualifiedName=Tests.IntegrationTests.AgentApi.ConversationEndpointsTests.GetLastTaskId_WithWorkflowId_ReturnsLastTaskId"
-    */
     [Fact]
     public async Task GetLastTaskId_WithWorkflowId_ReturnsLastTaskId()
     {
@@ -92,9 +83,6 @@ public class ConversationEndpointsTests : IntegrationTestBase, IClassFixture<Mon
         Assert.Equal("\"task-id-from-workflow\"", taskId);
     }
 
-    /*
-    dotnet test --filter "FullyQualifiedName=Tests.IntegrationTests.AgentApi.ConversationEndpointsTests.GetLastTaskId_WithScope_ReturnsLastTaskIdForScope"
-    */
     [Fact]
     public async Task GetLastTaskId_WithScope_ReturnsLastTaskIdForScope()
     {
@@ -130,9 +118,6 @@ public class ConversationEndpointsTests : IntegrationTestBase, IClassFixture<Mon
         Assert.Equal("\"billing-task-id\"", taskId);
     }
 
-    /*
-    dotnet test --filter "FullyQualifiedName=Tests.IntegrationTests.AgentApi.ConversationEndpointsTests.GetLastTaskId_WithNullScope_ReturnsLastTaskIdForNullScope"
-    */
     [Fact]
     public async Task GetLastTaskId_WithNullScope_ReturnsLastTaskIdForNullScope()
     {
@@ -168,9 +153,6 @@ public class ConversationEndpointsTests : IntegrationTestBase, IClassFixture<Mon
         Assert.Equal("\"default-task-id\"", taskId);
     }
 
-    /*
-    dotnet test --filter "FullyQualifiedName=Tests.IntegrationTests.AgentApi.ConversationEndpointsTests.GetLastTaskId_WithMessagesWithoutTaskId_IgnoresMessagesWithoutTaskId"
-    */
     [Fact]
     public async Task GetLastTaskId_WithMessagesWithoutTaskId_IgnoresMessagesWithoutTaskId()
     {
@@ -221,9 +203,6 @@ public class ConversationEndpointsTests : IntegrationTestBase, IClassFixture<Mon
         Assert.Equal("\"latest-valid-task-id\"", taskId);
     }
 
-    /*
-    dotnet test --filter "FullyQualifiedName=Tests.IntegrationTests.AgentApi.ConversationEndpointsTests.GetLastTaskId_WithNoTaskIdsInHistory_ReturnsNull"
-    */
     [Fact]
     public async Task GetLastTaskId_WithNoTaskIdsInHistory_ReturnsNull()
     {
@@ -242,9 +221,6 @@ public class ConversationEndpointsTests : IntegrationTestBase, IClassFixture<Mon
         Assert.True(content == "null" || content == "", "Expected JSON null or empty string when no task id found");
     }
 
-    /*
-    dotnet test --filter "FullyQualifiedName=Tests.IntegrationTests.AgentApi.ConversationEndpointsTests.GetLastTaskId_WithMissingWorkflowTypeAndId_ReturnsBadRequest"
-    */
     [Fact]
     public async Task GetLastTaskId_WithMissingWorkflowTypeAndId_ReturnsBadRequest()
     {
@@ -261,9 +237,6 @@ public class ConversationEndpointsTests : IntegrationTestBase, IClassFixture<Mon
         Assert.Contains("WorkflowId is required", content);
     }
 
-    /*
-    dotnet test --filter "FullyQualifiedName=Tests.IntegrationTests.AgentApi.ConversationEndpointsTests.GetLastTaskId_WithMissingParticipantId_ReturnsBadRequest"
-    */
     [Fact]
     public async Task GetLastTaskId_WithMissingParticipantId_ReturnsBadRequest()
     {
@@ -283,9 +256,6 @@ public class ConversationEndpointsTests : IntegrationTestBase, IClassFixture<Mon
         }
     }
 
-    /*
-    dotnet test --filter "FullyQualifiedName=Tests.IntegrationTests.AgentApi.ConversationEndpointsTests.GetLastTaskId_WithDifferentParticipant_ReturnsCorrectTaskId"
-    */
     [Fact]
     public async Task GetLastTaskId_WithDifferentParticipant_ReturnsCorrectTaskId()
     {
@@ -329,9 +299,6 @@ public class ConversationEndpointsTests : IntegrationTestBase, IClassFixture<Mon
         Assert.Equal("\"task-id-participant-2\"", taskId2);
     }
 
-    /*
-    dotnet test --filter "FullyQualifiedName=Tests.IntegrationTests.AgentApi.ConversationEndpointsTests.GetLastIncomingOrigin_WithScopeFilter_ReturnsCorrectOrigin"
-    */
     [Fact]
     public async Task GetLastIncomingOrigin_WithScopeFilter_ReturnsCorrectOrigin()
     {
@@ -348,8 +315,8 @@ public class ConversationEndpointsTests : IntegrationTestBase, IClassFixture<Mon
         // Message 3: default scope (null), newest - should be returned when scope is null
         await CreateTestMessageAsync(workflowId, workflowType, participantId, scope: null, origin: "origin-default-new", createdAt: DateTime.UtcNow, threadId: threadId);
 
-        using var scope2 = _factory.Services.CreateScope();
-        var repo = scope2.ServiceProvider.GetRequiredService<IConversationRepository>();
+        using var serviceScope = _factory.Services.CreateScope();
+        var repo = serviceScope.ServiceProvider.GetRequiredService<IConversationRepository>();
 
         var resultNullScope = await repo.GetLastIncomingOriginAsync(threadId, TestTenantId, null);
         Assert.Equal("origin-default-new", resultNullScope);
@@ -371,8 +338,8 @@ public class ConversationEndpointsTests : IntegrationTestBase, IClassFixture<Mon
         string? origin = null,
         string? threadId = null)
     {
-        using var scope2 = _factory.Services.CreateScope();
-        var databaseService = scope2.ServiceProvider.GetRequiredService<IDatabaseService>();
+        using var serviceScope = _factory.Services.CreateScope();
+        var databaseService = serviceScope.ServiceProvider.GetRequiredService<IDatabaseService>();
 
         var message = new ConversationMessage
         {
@@ -403,4 +370,3 @@ public class ConversationEndpointsTests : IntegrationTestBase, IClassFixture<Mon
         return message;
     }
 }
-

--- a/XiansAi.Server.Tests/IntegrationTests/AgentApi/InstructionsEndpointTests.cs
+++ b/XiansAi.Server.Tests/IntegrationTests/AgentApi/InstructionsEndpointTests.cs
@@ -8,16 +8,10 @@ namespace Tests.IntegrationTests.AgentApi;
 
 public class InstructionsEndpointTests : IntegrationTestBase, IClassFixture<MongoDbFixture>
 {
-    /*
-    dotnet test --filter "FullyQualifiedName~InstructionsEndpointTests"
-    */
     public InstructionsEndpointTests(MongoDbFixture mongoFixture) : base(mongoFixture)
     {
     }
 
-    /*
-    dotnet test --filter "FullyQualifiedName=Tests.IntegrationTests.AgentApi.InstructionsEndpointTests.GetLatestInstruction_ReturnsLatestInstruction"
-    */
     [Fact]
     public async Task GetLatestInstruction_ReturnsLatestInstruction()
     {
@@ -82,9 +76,6 @@ public class InstructionsEndpointTests : IntegrationTestBase, IClassFixture<Mong
         Assert.Equal("v3", result.Version);
     }
 
-    /*
-    dotnet test --filter "FullyQualifiedName=Tests.IntegrationTests.AgentApi.InstructionsEndpointTests.GetLatestInstruction_WithNonExistentName_ReturnsNotFound"
-    */
     [Fact]
     public async Task GetLatestInstruction_WithNonExistentName_ReturnsNotFound()
     {

--- a/XiansAi.Server.Tests/IntegrationTests/AgentApi/InstructionsEndpointTests.cs
+++ b/XiansAi.Server.Tests/IntegrationTests/AgentApi/InstructionsEndpointTests.cs
@@ -17,7 +17,7 @@ public class InstructionsEndpointTests : IntegrationTestBase, IClassFixture<Mong
     {
         // Arrange - Create a unique name for this test run
         string testInstructionName = $"test-instruction-{Guid.NewGuid()}";
-        
+
         // Insert multiple instructions with the same name but different timestamps
         var knowledge = new List<Knowledge>
         {
@@ -68,7 +68,7 @@ public class InstructionsEndpointTests : IntegrationTestBase, IClassFixture<Mong
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var result = await response.Content.ReadFromJsonAsync<Knowledge>();
         Assert.NotNull(result);
         Assert.Equal(testInstructionName, result.Name);
@@ -88,4 +88,4 @@ public class InstructionsEndpointTests : IntegrationTestBase, IClassFixture<Mong
         // Assert
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
-} 
+}

--- a/XiansAi.Server.Tests/IntegrationTests/AgentApi/LogsEndpointTests.cs
+++ b/XiansAi.Server.Tests/IntegrationTests/AgentApi/LogsEndpointTests.cs
@@ -8,7 +8,6 @@ using Tests.TestUtils;
 using Features.AgentApi.Models;
 using Features.AgentApi.Services.Lib;
 
-
 namespace Tests.IntegrationTests.AgentApi;
 
 public class LogsEndpointTests : IntegrationTestBase, IClassFixture<MongoDbFixture>
@@ -21,7 +20,6 @@ public class LogsEndpointTests : IntegrationTestBase, IClassFixture<MongoDbFixtu
         Converters = { new JsonStringEnumConverter() }
     };
 
-    //dotnet test --filter "FullyQualifiedName~LogsEndpointTests"
     public LogsEndpointTests(MongoDbFixture mongoFixture) : base(mongoFixture)
     {
     }
@@ -45,7 +43,7 @@ public class LogsEndpointTests : IntegrationTestBase, IClassFixture<MongoDbFixtu
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var result = await response.Content.ReadFromJsonAsync<Log>(JsonReadOptions);
         Assert.NotNull(result);
         Assert.Equal(logRequest.Message, result.Message);
@@ -63,7 +61,7 @@ public class LogsEndpointTests : IntegrationTestBase, IClassFixture<MongoDbFixtu
             new LogRequest
             {
                 Message = "First log message",
-                Level = Microsoft.Extensions.Logging.LogLevel.Information,
+                Level = LogLevel.Information,
                 WorkflowId = ObjectId.GenerateNewId().ToString(),
                 WorkflowRunId = ObjectId.GenerateNewId().ToString(),
                 WorkflowType = "TestWorkflowType1",
@@ -72,7 +70,7 @@ public class LogsEndpointTests : IntegrationTestBase, IClassFixture<MongoDbFixtu
             new LogRequest
             {
                 Message = "Second log message",
-                Level = Microsoft.Extensions.Logging.LogLevel.Warning,
+                Level = LogLevel.Warning,
                 WorkflowId = ObjectId.GenerateNewId().ToString(),
                 WorkflowRunId = ObjectId.GenerateNewId().ToString(),
                 WorkflowType = "TestWorkflowType2",
@@ -85,16 +83,16 @@ public class LogsEndpointTests : IntegrationTestBase, IClassFixture<MongoDbFixtu
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var results = await response.Content.ReadFromJsonAsync<Log[]>(JsonReadOptions);
         Assert.NotNull(results);
         Assert.Equal(2, results.Length);
-        
+
         Assert.Equal(logRequests[0].Message, results[0].Message);
         Assert.Equal(logRequests[0].Level, results[0].Level);
         Assert.Equal(logRequests[0].WorkflowId, results[0].WorkflowId);
         Assert.Equal(logRequests[0].WorkflowRunId, results[0].WorkflowRunId);
-        
+
         Assert.Equal(logRequests[1].Message, results[1].Message);
         Assert.Equal(logRequests[1].Level, results[1].Level);
         Assert.Equal(logRequests[1].WorkflowId, results[1].WorkflowId);
@@ -108,7 +106,7 @@ public class LogsEndpointTests : IntegrationTestBase, IClassFixture<MongoDbFixtu
         var logRequest = new LogRequest
         {
             Message = "Test log message",
-            Level = Microsoft.Extensions.Logging.LogLevel.Information,
+            Level = LogLevel.Information,
             WorkflowId = null!, // This should trigger validation
             WorkflowRunId = ObjectId.GenerateNewId().ToString(),
             WorkflowType = "TestWorkflowType",
@@ -121,4 +119,4 @@ public class LogsEndpointTests : IntegrationTestBase, IClassFixture<MongoDbFixtu
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
-} 
+}

--- a/XiansAi.Server.Tests/IntegrationTests/UserApi/WebhookEndpointsTests.cs
+++ b/XiansAi.Server.Tests/IntegrationTests/UserApi/WebhookEndpointsTests.cs
@@ -87,7 +87,7 @@ public class WebhookEndpointsTests : IntegrationTestBase
         // Should get past authentication - Temporal errors are expected in test environment
         Assert.NotEqual(HttpStatusCode.Unauthorized, response.StatusCode);
         // May return BadRequest or InternalServerError due to Temporal not being configured
-        Assert.True(response.StatusCode == HttpStatusCode.BadRequest || 
+        Assert.True(response.StatusCode == HttpStatusCode.BadRequest ||
                    response.StatusCode == HttpStatusCode.InternalServerError ||
                    response.StatusCode == HttpStatusCode.OK);
     }
@@ -215,4 +215,3 @@ public class WebhookEndpointsTests : IntegrationTestBase
         }
     }
 }
-

--- a/XiansAi.Server.Tests/IntegrationTests/WebApi/AgentEndpointsTests.cs
+++ b/XiansAi.Server.Tests/IntegrationTests/WebApi/AgentEndpointsTests.cs
@@ -32,9 +32,9 @@ public class AgentEndpointsTests : WebApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var agentNames = await response.Content.ReadFromJsonAsync<List<string>>();
-        
+
         Assert.NotNull(agentNames);
         Assert.Contains("test-agent-1", agentNames);
         Assert.Contains("test-agent-2", agentNames);
@@ -48,9 +48,9 @@ public class AgentEndpointsTests : WebApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var agentNames = await response.Content.ReadFromJsonAsync<List<string>>();
-        
+
         Assert.NotNull(agentNames);
         // Note: May contain agents from other tests running in parallel, so we just check it's a valid response
         Assert.True(agentNames.Count >= 0);
@@ -69,11 +69,11 @@ public class AgentEndpointsTests : WebApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var groupedDefinitions = await response.Content.ReadFromJsonAsync<List<AgentWithDefinitions>>();
-        
+
         Assert.NotNull(groupedDefinitions);
-        
+
         // Find our specific agent in the results (may contain agents from other tests)
         var targetAgent = groupedDefinitions.FirstOrDefault(a => a.Agent.Name == "grouped-test-agent");
         Assert.NotNull(targetAgent);
@@ -93,17 +93,17 @@ public class AgentEndpointsTests : WebApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var groupedDefinitions = await response.Content.ReadFromJsonAsync<List<AgentWithDefinitions>>();
-        
+
         Assert.NotNull(groupedDefinitions);
-        
+
         // Find our specific agent in the results (may contain agents from other tests)
         var targetAgent = groupedDefinitions.FirstOrDefault(a => a.Agent.Name == "basic-test-agent");
         Assert.NotNull(targetAgent);
         Assert.Equal("basic-test-agent", targetAgent.Agent.Name);
         Assert.Single(targetAgent.Definitions);
-        
+
         var definition = targetAgent.Definitions.First();
         Assert.Equal("TestWorkflow", definition.WorkflowType);
         // Basic data should not include full source code
@@ -122,9 +122,9 @@ public class AgentEndpointsTests : WebApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var definitions = await response.Content.ReadFromJsonAsync<List<FlowDefinition>>();
-        
+
         Assert.NotNull(definitions);
         Assert.Single(definitions);
         Assert.Equal("TestWorkflow", definitions.First().WorkflowType);
@@ -201,9 +201,9 @@ public class AgentEndpointsTests : WebApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var deleteResult = await response.Content.ReadFromJsonAsync<AgentDeleteResult>();
-        
+
         Assert.NotNull(deleteResult);
         Assert.Equal("Agent and its associated flow definitions deleted successfully", deleteResult.Message);
 
@@ -248,7 +248,7 @@ public class AgentEndpointsTests : WebApiIntegrationTestBase
     {
         using var scope = _factory.Services.CreateScope();
         var agentRepository = scope.ServiceProvider.GetRequiredService<IAgentRepository>();
-        
+
         var agent = new Agent
         {
             Id = ObjectId.GenerateNewId().ToString(),
@@ -269,7 +269,7 @@ public class AgentEndpointsTests : WebApiIntegrationTestBase
     {
         using var scope = _factory.Services.CreateScope();
         var agentRepository = scope.ServiceProvider.GetRequiredService<IAgentRepository>();
-        
+
         var agent = new Agent
         {
             Id = ObjectId.GenerateNewId().ToString(),
@@ -290,7 +290,7 @@ public class AgentEndpointsTests : WebApiIntegrationTestBase
     {
         using var scope = _factory.Services.CreateScope();
         var flowDefinitionRepository = scope.ServiceProvider.GetRequiredService<IFlowDefinitionRepository>();
-        
+
         var flowDefinition = new FlowDefinition
         {
             Id = ObjectId.GenerateNewId().ToString(),
@@ -325,4 +325,4 @@ public class AgentEndpointsTests : WebApiIntegrationTestBase
         await flowDefinitionRepository.CreateAsync(flowDefinition);
         return flowDefinition;
     }
-} 
+}

--- a/XiansAi.Server.Tests/IntegrationTests/WebApi/ApiKeyEndpointsTests.cs
+++ b/XiansAi.Server.Tests/IntegrationTests/WebApi/ApiKeyEndpointsTests.cs
@@ -169,7 +169,7 @@ public class ApiKeyEndpointsTests : WebApiIntegrationTestBase
 
         // Assert
         // Should return error for empty name - may return OK if validation is lenient
-        Assert.True(response.StatusCode == HttpStatusCode.BadRequest || 
+        Assert.True(response.StatusCode == HttpStatusCode.BadRequest ||
                    response.StatusCode == HttpStatusCode.InternalServerError ||
                    response.StatusCode == HttpStatusCode.OK);
     }
@@ -221,4 +221,3 @@ public class ApiKeyMetadata
     public string CreatedBy { get; set; } = string.Empty;
     public DateTime? LastRotatedAt { get; set; }
 }
-

--- a/XiansAi.Server.Tests/IntegrationTests/WebApi/AuditingEndpointsTests.cs
+++ b/XiansAi.Server.Tests/IntegrationTests/WebApi/AuditingEndpointsTests.cs
@@ -35,16 +35,16 @@ public class AuditingEndpointsTests : WebApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var content = await response.Content.ReadAsStringAsync();
         var jsonDoc = JsonDocument.Parse(content);
-        
+
         Assert.True(jsonDoc.RootElement.TryGetProperty("totalCount", out var totalCountElement));
         Assert.True(jsonDoc.RootElement.TryGetProperty("participants", out var participantsElement));
-        
+
         var totalCount = totalCountElement.GetInt64();
         var participants = participantsElement.EnumerateArray().Select(p => p.GetString()).ToList();
-        
+
         Assert.True(totalCount >= 2);
         Assert.Contains("participant-1", participants);
         Assert.Contains("participant-2", participants);
@@ -65,14 +65,14 @@ public class AuditingEndpointsTests : WebApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var content = await response.Content.ReadAsStringAsync();
         var jsonDoc = JsonDocument.Parse(content);
-        
+
         Assert.True(jsonDoc.RootElement.TryGetProperty("page", out var pageElement));
         Assert.True(jsonDoc.RootElement.TryGetProperty("pageSize", out var pageSizeElement));
         Assert.True(jsonDoc.RootElement.TryGetProperty("totalPages", out var totalPagesElement));
-        
+
         Assert.Equal(2, pageElement.GetInt32());
         Assert.Equal(10, pageSizeElement.GetInt32());
         Assert.True(totalPagesElement.GetInt32() >= 3);
@@ -91,10 +91,10 @@ public class AuditingEndpointsTests : WebApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var content = await response.Content.ReadAsStringAsync();
         var workflowTypes = JsonSerializer.Deserialize<string[]>(content);
-        
+
         Assert.NotNull(workflowTypes);
         Assert.Contains("WorkflowType1", workflowTypes);
         Assert.Contains("WorkflowType2", workflowTypes);
@@ -114,10 +114,10 @@ public class AuditingEndpointsTests : WebApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var content = await response.Content.ReadAsStringAsync();
         var workflowIds = JsonSerializer.Deserialize<string[]>(content);
-        
+
         Assert.NotNull(workflowIds);
         Assert.Contains("workflow-1", workflowIds);
         Assert.Contains("workflow-2", workflowIds);
@@ -136,16 +136,16 @@ public class AuditingEndpointsTests : WebApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var content = await response.Content.ReadAsStringAsync();
         var jsonDoc = JsonDocument.Parse(content);
-        
+
         Assert.True(jsonDoc.RootElement.TryGetProperty("totalCount", out var totalCountElement));
         Assert.True(jsonDoc.RootElement.TryGetProperty("logs", out var logsElement));
-        
+
         var totalCount = totalCountElement.GetInt64();
         var logs = logsElement.EnumerateArray().ToList();
-        
+
         Assert.True(totalCount >= 2);
         Assert.True(logs.Count >= 2);
     }
@@ -163,14 +163,14 @@ public class AuditingEndpointsTests : WebApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var content = await response.Content.ReadAsStringAsync();
         var jsonDoc = JsonDocument.Parse(content);
-        
+
         Assert.True(jsonDoc.RootElement.TryGetProperty("logs", out var logsElement));
-        
+
         var logs = logsElement.EnumerateArray().ToList();
-        
+
         foreach (var log in logs)
         {
             if (log.TryGetProperty("participantId", out var participantIdElement))
@@ -196,7 +196,7 @@ public class AuditingEndpointsTests : WebApiIntegrationTestBase
         // Arrange
         await CreateTestAgentAsync("critical-agent-1");
         await CreateTestAgentAsync("critical-agent-2");
-        
+
         await CreateTestLogAsync("critical-agent-1", "participant-1", logLevel: LogLevel.Critical);
         await CreateTestLogAsync("critical-agent-2", "participant-2", logLevel: LogLevel.Critical);
 
@@ -205,10 +205,10 @@ public class AuditingEndpointsTests : WebApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var content = await response.Content.ReadAsStringAsync();
         var criticalGroups = JsonSerializer.Deserialize<AgentCriticalGroup[]>(content);
-        
+
         Assert.NotNull(criticalGroups);
         Assert.True(criticalGroups.Length >= 2);
     }
@@ -217,7 +217,7 @@ public class AuditingEndpointsTests : WebApiIntegrationTestBase
     {
         using var scope = _factory.Services.CreateScope();
         var agentRepository = scope.ServiceProvider.GetRequiredService<IAgentRepository>();
-        
+
         var agent = new Agent
         {
             Id = ObjectId.GenerateNewId().ToString(),
@@ -235,15 +235,15 @@ public class AuditingEndpointsTests : WebApiIntegrationTestBase
     }
 
     private async Task CreateTestLogAsync(
-        string agentName, 
-        string participantId = "test-participant", 
+        string agentName,
+        string participantId = "test-participant",
         string workflowType = "TestWorkflow",
         string workflowId = "test-workflow-id",
         LogLevel logLevel = LogLevel.Information)
     {
         using var scope = _factory.Services.CreateScope();
         var logRepository = scope.ServiceProvider.GetRequiredService<ILogRepository>();
-        
+
         var log = new Log
         {
             Id = ObjectId.GenerateNewId().ToString(),
@@ -264,4 +264,4 @@ public class AuditingEndpointsTests : WebApiIntegrationTestBase
         var collection = mongoDatabase.GetCollection<Log>("logs");
         await collection.InsertOneAsync(log);
     }
-} 
+}

--- a/XiansAi.Server.Tests/IntegrationTests/WebApi/KnowledgeEndpointsTests.cs
+++ b/XiansAi.Server.Tests/IntegrationTests/WebApi/KnowledgeEndpointsTests.cs
@@ -15,10 +15,6 @@ public class KnowledgeEndpointsTests : WebApiIntegrationTestBase
 {
     private const string TestUserId = "test-user";
 
-    /*
-    dotnet test --filter "FullyQualifiedName=Tests.IntegrationTests.WebApi.KnowledgeEndpointsTests.GetLatestAll_WithValidTenant_ReturnsKnowledgeList"
-    */
-
     public KnowledgeEndpointsTests(MongoDbFixture mongoDbFixture) : base(mongoDbFixture)
     {
     }
@@ -37,11 +33,11 @@ public class KnowledgeEndpointsTests : WebApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var groupedResponse = await ReadAsJsonAsync<GroupedKnowledgeResponse>(response);
         Assert.NotNull(groupedResponse);
         Assert.True(groupedResponse.Groups.Count >= 2);
-        
+
         var groupNames = groupedResponse.Groups.Select(g => g.Name).ToList();
         Assert.Contains("knowledge-1", groupNames);
         Assert.Contains("knowledge-2", groupNames);
@@ -60,7 +56,7 @@ public class KnowledgeEndpointsTests : WebApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var result = await ReadAsJsonAsync<Knowledge>(response);
         Assert.NotNull(result);
         Assert.Equal(knowledge.Id, result.Id);
@@ -101,7 +97,7 @@ public class KnowledgeEndpointsTests : WebApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var result = await ReadAsJsonAsync<Knowledge>(response);
         Assert.NotNull(result);
         Assert.Equal("new-knowledge", result.Name);
@@ -113,29 +109,24 @@ public class KnowledgeEndpointsTests : WebApiIntegrationTestBase
         Assert.NotEmpty(result.Version);
     }
 
-    /*
-    dotnet test --filter "FullyQualifiedName=Tests.IntegrationTests.WebApi.KnowledgeEndpointsTests.GetLatestByName_WithValidNameAndAgent_ReturnsKnowledge"
-    */
     [Fact]
     public async Task GetLatestByName_WithValidNameAndAgent_ReturnsKnowledge()
     {
         // Arrange
         var agentName = $"test-agent-{Guid.NewGuid()}";
         await CreateTestAgentAsync(agentName);
-        var knowledge1 = await CreateTestKnowledgeAsync("test-knowledge", agentName, "Old content", createdAt: DateTime.UtcNow.AddHours(-1));
-        var knowledge2 = await CreateTestKnowledgeAsync("test-knowledge", agentName, "Latest content");
+        await CreateTestKnowledgeAsync("test-knowledge", agentName, "Old content", createdAt: DateTime.UtcNow.AddHours(-1));
+        await CreateTestKnowledgeAsync("test-knowledge", agentName, "Latest content");
 
         // Act
         var response = await GetAsync($"/api/client/knowledge/latest?name=test-knowledge&agent={agentName}");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var result = await ReadAsJsonAsync<Knowledge>(response);
         Assert.NotNull(result);
         Assert.Equal("test-knowledge", result.Name);
-        //Assert.Equal("Latest content", result.Content);
-        //Assert.Equal(knowledge2.Id, result.Id);
     }
 
     [Fact]
@@ -165,7 +156,7 @@ public class KnowledgeEndpointsTests : WebApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         // Verify deletion
         var getResponse = await GetAsync($"/api/client/knowledge/{knowledge.Id}");
         Assert.Equal(HttpStatusCode.NotFound, getResponse.StatusCode);
@@ -198,7 +189,7 @@ public class KnowledgeEndpointsTests : WebApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         // Verify deletion
         var getResponse1 = await GetAsync($"/api/client/knowledge/{knowledge1.Id}");
         var getResponse2 = await GetAsync($"/api/client/knowledge/{knowledge2.Id}");
@@ -221,14 +212,13 @@ public class KnowledgeEndpointsTests : WebApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var result = await ReadAsJsonAsync<Knowledge[]>(response);
         Assert.NotNull(result);
         Assert.Equal(3, result.Length);
-        
+
         // Verify they are ordered by creation time (most recent first)
         Assert.Equal("Version 3", result[0].Content);
-
     }
 
     [Fact]
@@ -243,7 +233,7 @@ public class KnowledgeEndpointsTests : WebApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var result = await ReadAsJsonAsync<Knowledge[]>(response);
         Assert.NotNull(result);
         Assert.Empty(result);
@@ -257,10 +247,10 @@ public class KnowledgeEndpointsTests : WebApiIntegrationTestBase
         var agentName2 = $"other-agent-{Guid.NewGuid()}";
         await CreateTestAgentAsync(agentName1);
         await CreateTestAgentAsync(agentName2);
-        
+
         // Create knowledge for authorized agent
         await CreateTestKnowledgeAsync("authorized-knowledge", agentName1, "Authorized content");
-        
+
         // Create knowledge for agent2 (should not be returned when querying for agent1)
         await CreateTestKnowledgeAsync("other-agent-knowledge", agentName2, "Other content");
 
@@ -269,10 +259,10 @@ public class KnowledgeEndpointsTests : WebApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var groupedResponse = await ReadAsJsonAsync<GroupedKnowledgeResponse>(response);
         Assert.NotNull(groupedResponse);
-        
+
         var groupNames = groupedResponse.Groups.Select(g => g.Name).ToList();
         Assert.Contains("authorized-knowledge", groupNames);
         Assert.DoesNotContain("other-agent-knowledge", groupNames);
@@ -306,10 +296,10 @@ public class KnowledgeEndpointsTests : WebApiIntegrationTestBase
         // Assert
         Assert.Equal(HttpStatusCode.OK, response1.StatusCode);
         Assert.Equal(HttpStatusCode.OK, response2.StatusCode);
-        
+
         var result1 = await ReadAsJsonAsync<Knowledge>(response1);
         var result2 = await ReadAsJsonAsync<Knowledge>(response2);
-        
+
         Assert.NotNull(result1);
         Assert.NotNull(result2);
         Assert.NotEqual(result1.Version, result2.Version);
@@ -322,14 +312,14 @@ public class KnowledgeEndpointsTests : WebApiIntegrationTestBase
     {
         using var scope = _factory.Services.CreateScope();
         var agentRepository = scope.ServiceProvider.GetRequiredService<IAgentRepository>();
-        
+
         // Check if agent already exists to avoid duplicate key errors
         var existingAgent = await agentRepository.GetByNameAsync(agentName, TestTenantId, TestUserId, []);
         if (existingAgent != null)
         {
             return existingAgent;
         }
-        
+
         var agent = new Agent
         {
             Id = ObjectId.GenerateNewId().ToString(),
@@ -347,15 +337,15 @@ public class KnowledgeEndpointsTests : WebApiIntegrationTestBase
     }
 
     private async Task<Knowledge> CreateTestKnowledgeAsync(
-        string name, 
-        string agentName, 
+        string name,
+        string agentName,
         string content,
         string type = "text",
         DateTime? createdAt = null)
     {
         using var scope = _factory.Services.CreateScope();
         var knowledgeRepository = scope.ServiceProvider.GetRequiredService<IKnowledgeRepository>();
-        
+
         var knowledge = new Knowledge
         {
             Id = ObjectId.GenerateNewId().ToString(),
@@ -372,4 +362,4 @@ public class KnowledgeEndpointsTests : WebApiIntegrationTestBase
         await knowledgeRepository.CreateAsync(knowledge);
         return knowledge;
     }
-} 
+}

--- a/XiansAi.Server.Tests/IntegrationTests/WebApi/LogsEndpointsTests.cs
+++ b/XiansAi.Server.Tests/IntegrationTests/WebApi/LogsEndpointsTests.cs
@@ -29,7 +29,7 @@ public class LogsEndpointsTests : WebApiIntegrationTestBase, IClassFixture<Mongo
         var workflowRunId = ObjectId.GenerateNewId().ToString();
         var log1 = await CreateTestLogAsync(workflowRunId: workflowRunId, message: "First log");
         var log2 = await CreateTestLogAsync(workflowRunId: workflowRunId, message: "Second log");
-        
+
         // Create a log with different workflow run ID to ensure filtering
         await CreateTestLogAsync(workflowRunId: ObjectId.GenerateNewId().ToString(), message: "Different workflow");
 
@@ -38,7 +38,7 @@ public class LogsEndpointsTests : WebApiIntegrationTestBase, IClassFixture<Mongo
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var logs = await ReadAsJsonAsync<List<Log>>(response);
         Assert.NotNull(logs);
         Assert.Equal(2, logs.Count);
@@ -50,7 +50,7 @@ public class LogsEndpointsTests : WebApiIntegrationTestBase, IClassFixture<Mongo
     {
         // Arrange
         var workflowRunId = ObjectId.GenerateNewId().ToString();
-        
+
         // Create 5 logs for the same workflow run
         for (int i = 0; i < 5; i++)
         {
@@ -62,7 +62,7 @@ public class LogsEndpointsTests : WebApiIntegrationTestBase, IClassFixture<Mongo
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var logs = await ReadAsJsonAsync<List<Log>>(response);
         Assert.NotNull(logs);
         Assert.Equal(3, logs.Count);
@@ -82,7 +82,7 @@ public class LogsEndpointsTests : WebApiIntegrationTestBase, IClassFixture<Mongo
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var logs = await ReadAsJsonAsync<List<Log>>(response);
         Assert.NotNull(logs);
         Assert.Single(logs);
@@ -100,7 +100,7 @@ public class LogsEndpointsTests : WebApiIntegrationTestBase, IClassFixture<Mongo
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var logs = await ReadAsJsonAsync<List<Log>>(response);
         Assert.NotNull(logs);
         Assert.Empty(logs);
@@ -128,7 +128,7 @@ public class LogsEndpointsTests : WebApiIntegrationTestBase, IClassFixture<Mongo
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var logs = await ReadAsJsonAsync<List<Log>>(response);
         Assert.NotNull(logs);
         Assert.Empty(logs);
@@ -148,7 +148,7 @@ public class LogsEndpointsTests : WebApiIntegrationTestBase, IClassFixture<Mongo
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var logs = await ReadAsJsonAsync<List<Log>>(response);
         Assert.NotNull(logs);
         Assert.Equal(3, logs.Count);
@@ -188,4 +188,4 @@ public class LogsEndpointsTests : WebApiIntegrationTestBase, IClassFixture<Mongo
 
         return log;
     }
-} 
+}

--- a/XiansAi.Server.Tests/IntegrationTests/WebApi/MessagingEndpointsTests.cs
+++ b/XiansAi.Server.Tests/IntegrationTests/WebApi/MessagingEndpointsTests.cs
@@ -32,7 +32,7 @@ public class MessagingEndpointsTests : WebApiIntegrationTestBase, IClassFixture<
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var threads = await ReadAsJsonAsync<List<ConversationThread>>(response);
         Assert.NotNull(threads);
         Assert.True(threads.Count >= 2);
@@ -221,13 +221,20 @@ public class MessagingEndpointsTests : WebApiIntegrationTestBase, IClassFixture<
         return thread;
     }
 
+    /// <summary>
+    /// Creates a test message. The scope is normalized so that null, empty, and
+    /// whitespace-only values are all treated as the default (unscoped) topic.
+    /// </summary>
     private async Task<ConversationMessage> CreateTestMessageAsync(
         string threadId,
         string content = "Test message",
-        MessageDirection direction = MessageDirection.Incoming)
+        MessageDirection direction = MessageDirection.Incoming,
+        string? scope = null)
     {
-        using var scope = _factory.Services.CreateScope();
-        var databaseService = scope.ServiceProvider.GetRequiredService<IDatabaseService>();
+        using var serviceScope = _factory.Services.CreateScope();
+        var databaseService = serviceScope.ServiceProvider.GetRequiredService<IDatabaseService>();
+
+        var normalizedScope = string.IsNullOrWhiteSpace(scope) ? null : scope.Trim();
 
         var message = new ConversationMessage
         {
@@ -242,6 +249,7 @@ public class MessagingEndpointsTests : WebApiIntegrationTestBase, IClassFixture<
             CreatedBy = TestUserId,
             Direction = direction,
             Text = content,
+            Scope = normalizedScope,
             Status = MessageStatus.DeliveredToWorkflow,
             Data = new Dictionary<string, object>
             {
@@ -259,77 +267,38 @@ public class MessagingEndpointsTests : WebApiIntegrationTestBase, IClassFixture<
 
     private async Task<ConversationThread?> GetThreadByIdAsync(string threadId)
     {
-        using var scope = _factory.Services.CreateScope();
-        var databaseService = scope.ServiceProvider.GetRequiredService<IDatabaseService>();
+        using var serviceScope = _factory.Services.CreateScope();
+        var databaseService = serviceScope.ServiceProvider.GetRequiredService<IDatabaseService>();
         var database = await databaseService.GetDatabaseAsync();
         var collection = database.GetCollection<ConversationThread>("conversation_thread");
-        
+
         return await collection.Find(t => t.Id == threadId).FirstOrDefaultAsync();
     }
-
-    private async Task<ConversationMessage> CreateTestMessageWithScopeAsync(
-        string threadId,
-        string? scope = null,
-        string content = "Test message",
-        MessageDirection direction = MessageDirection.Incoming)
-    {
-        using var scope2 = _factory.Services.CreateScope();
-        var databaseService = scope2.ServiceProvider.GetRequiredService<IDatabaseService>();
-
-        // Normalize scope: empty string and whitespace should be treated as null (default topic)
-        var normalizedScope = string.IsNullOrWhiteSpace(scope) ? null : scope.Trim();
-
-        var message = new ConversationMessage
-        {
-            Id = ObjectId.GenerateNewId().ToString(),
-            ThreadId = threadId,
-            TenantId = TestTenantId,
-            ParticipantId = $"test-participant-{Guid.NewGuid()}",
-            WorkflowId = $"test-workflow-{Guid.NewGuid()}",
-            WorkflowType = "TestWorkflowType",
-            CreatedAt = DateTime.UtcNow,
-            UpdatedAt = DateTime.UtcNow,
-            CreatedBy = TestUserId,
-            Direction = direction,
-            Text = content,
-            Scope = normalizedScope,  // Use normalized scope
-            Status = MessageStatus.DeliveredToWorkflow
-        };
-
-        // Insert directly into repository
-        var database = await databaseService.GetDatabaseAsync();
-        var collection = database.GetCollection<ConversationMessage>("conversation_message");
-        await collection.InsertOneAsync(message);
-
-        return message;
-    }
-
-    #region Topics Tests
 
     [Fact]
     public async Task GetTopics_WithValidThreadId_ReturnsTopics()
     {
         // Arrange
         var thread = await CreateTestThreadAsync();
-        
+
         // Create messages with different scopes
-        await CreateTestMessageWithScopeAsync(thread.Id, scope: "billing", content: "Billing question");
+        await CreateTestMessageAsync(thread.Id, scope: "billing", content: "Billing question");
         await Task.Delay(10);
-        await CreateTestMessageWithScopeAsync(thread.Id, scope: "support", content: "Support question");
+        await CreateTestMessageAsync(thread.Id, scope: "support", content: "Support question");
         await Task.Delay(10);
-        await CreateTestMessageWithScopeAsync(thread.Id, scope: null, content: "General message");
+        await CreateTestMessageAsync(thread.Id, scope: null, content: "General message");
 
         // Act
         var response = await GetAsync($"/api/client/messaging/threads/{thread.Id}/topics?page=1&pageSize=50");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        
+
         var result = await ReadAsJsonAsync<TopicsResult>(response);
         Assert.NotNull(result);
         Assert.NotNull(result.Topics);
         Assert.Equal(3, result.Topics.Count); // billing, support, null
-        
+
         // Verify pagination metadata
         Assert.NotNull(result.Pagination);
         Assert.Equal(1, result.Pagination.CurrentPage);
@@ -337,7 +306,7 @@ public class MessagingEndpointsTests : WebApiIntegrationTestBase, IClassFixture<
         Assert.Equal(3, result.Pagination.TotalTopics);
         Assert.Equal(1, result.Pagination.TotalPages);
         Assert.False(result.Pagination.HasMore);
-        
+
         // Verify topics are sorted by most recent activity
         Assert.Equal("General message", result.Topics[0].Scope == null ? "General message" : result.Topics[0].Scope);
         Assert.Equal(1, result.Topics.First(t => t.Scope == null).MessageCount);
@@ -350,11 +319,11 @@ public class MessagingEndpointsTests : WebApiIntegrationTestBase, IClassFixture<
     {
         // Arrange
         var thread = await CreateTestThreadAsync();
-        
+
         // Create messages with 5 different scopes
         for (int i = 0; i < 5; i++)
         {
-            await CreateTestMessageWithScopeAsync(thread.Id, scope: $"topic-{i}", content: $"Message {i}");
+            await CreateTestMessageAsync(thread.Id, scope: $"topic-{i}", content: $"Message {i}");
             await Task.Delay(10); // Ensure different timestamps
         }
 
@@ -435,12 +404,12 @@ public class MessagingEndpointsTests : WebApiIntegrationTestBase, IClassFixture<
     {
         // Arrange
         var thread = await CreateTestThreadAsync();
-        
+
         // Create messages with different scopes
-        await CreateTestMessageWithScopeAsync(thread.Id, scope: "billing", content: "Billing message 1");
-        await CreateTestMessageWithScopeAsync(thread.Id, scope: "billing", content: "Billing message 2");
-        await CreateTestMessageWithScopeAsync(thread.Id, scope: "support", content: "Support message");
-        await CreateTestMessageWithScopeAsync(thread.Id, scope: null, content: "General message");
+        await CreateTestMessageAsync(thread.Id, scope: "billing", content: "Billing message 1");
+        await CreateTestMessageAsync(thread.Id, scope: "billing", content: "Billing message 2");
+        await CreateTestMessageAsync(thread.Id, scope: "support", content: "Support message");
+        await CreateTestMessageAsync(thread.Id, scope: null, content: "General message");
 
         // Act - Filter by "billing" scope
         var response = await GetAsync($"/api/client/messaging/threads/{thread.Id}/messages?page=1&pageSize=50&scope=billing");
@@ -458,17 +427,17 @@ public class MessagingEndpointsTests : WebApiIntegrationTestBase, IClassFixture<
     {
         // Arrange
         var thread = await CreateTestThreadAsync();
-        
+
         // Create messages with null scope
-        await CreateTestMessageWithScopeAsync(thread.Id, scope: null, content: "Message with null scope");
+        await CreateTestMessageAsync(thread.Id, scope: null, content: "Message with null scope");
         await Task.Delay(10);
-        
+
         // Create messages with empty string scope (should be normalized to null)
-        await CreateTestMessageWithScopeAsync(thread.Id, scope: "", content: "Message with empty scope");
+        await CreateTestMessageAsync(thread.Id, scope: "", content: "Message with empty scope");
         await Task.Delay(10);
-        
+
         // Create messages with whitespace scope (should be normalized to null)
-        await CreateTestMessageWithScopeAsync(thread.Id, scope: "   ", content: "Message with whitespace scope");
+        await CreateTestMessageAsync(thread.Id, scope: "   ", content: "Message with whitespace scope");
 
         // Act
         var response = await GetAsync($"/api/client/messaging/threads/{thread.Id}/topics?page=1&pageSize=50");
@@ -477,17 +446,15 @@ public class MessagingEndpointsTests : WebApiIntegrationTestBase, IClassFixture<
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var result = await ReadAsJsonAsync<TopicsResult>(response);
         Assert.NotNull(result);
-        
+
         // Should only have ONE topic (the default topic with scope = null)
         Assert.Single(result.Topics);
-        
+
         // The single topic should be the default topic (null scope)
         var defaultTopic = result.Topics[0];
         Assert.Null(defaultTopic.Scope);
-        
+
         // Should contain all 3 messages
         Assert.Equal(3, defaultTopic.MessageCount);
     }
-
-    #endregion
-} 
+}

--- a/XiansAi.Server.Tests/IntegrationTests/WebApi/PermissionsEndpointsTests.cs
+++ b/XiansAi.Server.Tests/IntegrationTests/WebApi/PermissionsEndpointsTests.cs
@@ -230,4 +230,3 @@ public class UserPermissionDto
     public string UserId { get; set; } = string.Empty;
     public string PermissionLevel { get; set; } = string.Empty;
 }
-

--- a/XiansAi.Server.Tests/IntegrationTests/WebApi/TenantEndpointsTests.cs
+++ b/XiansAi.Server.Tests/IntegrationTests/WebApi/TenantEndpointsTests.cs
@@ -42,4 +42,4 @@ public class TenantEndpointsTests : WebApiIntegrationTestBase
         // Assert - invalid data (empty TenantId) must be rejected
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
-} 
+}

--- a/XiansAi.Server.Tests/IntegrationTests/WebApi/UserManagementEndpointsTests.cs
+++ b/XiansAi.Server.Tests/IntegrationTests/WebApi/UserManagementEndpointsTests.cs
@@ -110,7 +110,7 @@ public class UserManagementEndpointsTests : WebApiIntegrationTestBase
         var response = await PutAsJsonAsync("/api/users/update", updateDto);
 
         // Assert
-        Assert.True(response.StatusCode == HttpStatusCode.NotFound || 
+        Assert.True(response.StatusCode == HttpStatusCode.NotFound ||
                    response.StatusCode == HttpStatusCode.BadRequest ||
                    response.StatusCode == HttpStatusCode.InternalServerError);
     }
@@ -198,4 +198,3 @@ public class UserInfo
     public string Name { get; set; } = string.Empty;
     public string Email { get; set; } = string.Empty;
 }
-

--- a/XiansAi.Server.Tests/IntegrationTests/WebApi/WebApiIntegrationTestBase.cs
+++ b/XiansAi.Server.Tests/IntegrationTests/WebApi/WebApiIntegrationTestBase.cs
@@ -59,4 +59,4 @@ public abstract class WebApiIntegrationTestBase : IntegrationTestBase
         PropertyNameCaseInsensitive = true,
         Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
     };
-} 
+}

--- a/XiansAi.Server.Tests/TestUtils/IntegrationTestBase.cs
+++ b/XiansAi.Server.Tests/TestUtils/IntegrationTestBase.cs
@@ -20,26 +20,26 @@ public abstract class IntegrationTestBase : IClassFixture<MongoDbFixture>
     protected IntegrationTestBase(MongoDbFixture mongoFixture, string? environment = null)
     {
         _mongoFixture = mongoFixture;
-        
+
         // Initialize environment variables for certificate authentication
         // This should be done before creating the factory to ensure proper configuration
         TestCertificateHelper.Initialize();
-        
+
         _factory = new XiansAiWebApplicationFactory(mongoFixture, environment);
-        
+
         var httpClient = _factory.CreateClient(new WebApplicationFactoryClientOptions
         {
             AllowAutoRedirect = false,
             HandleCookies = true,
             BaseAddress = new Uri("http://localhost")
         });
-        
+
         // Configure client with authentication
         ConfigureClientWithAuth(httpClient);
-        
+
         // Create retry client
         _client = new RetryHttpClient(httpClient, () => ConfigureClientWithAuth(httpClient));
-        
+
         _database = _mongoFixture.Database;
     }
 
@@ -48,19 +48,19 @@ public abstract class IntegrationTestBase : IClassFixture<MongoDbFixture>
         _client?.DisposeAsync();
         return Task.CompletedTask;
     }
-    
+
     protected virtual void ConfigureClientWithAuth(HttpClient client)
     {
         try
         {
-            if (client == null) 
+            if (client == null)
             {
                 throw new InvalidOperationException("Client is not initialized");
             }
-            
+
             // Clear existing headers
             client.DefaultRequestHeaders.Clear();
-            
+
             // Add API key for API endpoints
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", TestApiKey);
 
@@ -116,12 +116,12 @@ public abstract class IntegrationTestBase : IClassFixture<MongoDbFixture>
             }
 
             response = await _client.SendAsync(request);
-            
+
             // Check if response is not a retryable status code or we've reached max retries
-            bool isTimeout = response.StatusCode == HttpStatusCode.RequestTimeout || 
+            bool isTimeout = response.StatusCode == HttpStatusCode.RequestTimeout ||
                              response.StatusCode == HttpStatusCode.GatewayTimeout;
             bool shouldRetry = response.StatusCode == HttpStatusCode.Unauthorized || isTimeout;
-            
+
             if (!shouldRetry || retryCount == maxRetries)
             {
                 return response;
@@ -142,4 +142,4 @@ public abstract class IntegrationTestBase : IClassFixture<MongoDbFixture>
 
         return response;
     }
-} 
+}

--- a/XiansAi.Server.Tests/TestUtils/MongoDbFixture.cs
+++ b/XiansAi.Server.Tests/TestUtils/MongoDbFixture.cs
@@ -43,33 +43,33 @@ public class MongoDbFixture : IDisposable
         {
             // Create a null logger for testing
             _logger = new NullLogger<MongoDbClientService>();
-            
+
             // Start MongoDB instance with replica set
-        _runner = MongoDbRunner.Start(singleNodeReplSet: true);
-            
+            _runner = MongoDbRunner.Start(singleNodeReplSet: true);
+
             // Wait for replica set to be ready
             WaitForReplicaSet();
-        
-        // Create client and database
+
+            // Create client and database
             var settings = MongoClientSettings.FromConnectionString(_runner.ConnectionString);
             settings.ServerSelectionTimeout = TimeSpan.FromSeconds(10);
             settings.ConnectTimeout = TimeSpan.FromSeconds(10);
             _client = new MongoClient(settings);
-        _database = _client.GetDatabase(_databaseName);
+            _database = _client.GetDatabase(_databaseName);
 
-        // Configure MongoDB settings
-        MongoConfig = new MongoDBConfig
-        {
-            ConnectionString = _runner.ConnectionString,
-            DatabaseName = _databaseName
-        };
+            // Configure MongoDB settings
+            MongoConfig = new MongoDBConfig
+            {
+                ConnectionString = _runner.ConnectionString,
+                DatabaseName = _databaseName
+            };
 
-        // Create client service
-        var emptyConfig = new ConfigurationBuilder().Build();
-        _mongoClientService = new MongoDbClientService(new TestMongoDbContext(MongoConfig), _logger, emptyConfig);
+            // Create client service
+            var emptyConfig = new ConfigurationBuilder().Build();
+            _mongoClientService = new MongoDbClientService(new TestMongoDbContext(MongoConfig), _logger, emptyConfig);
 
-        // Initialize collections and indexes
-        InitializeCollections();
+            // Initialize collections and indexes
+            InitializeCollections();
 
             // Verify database is accessible
             var ping = _database.RunCommand<BsonDocument>(new BsonDocument("ping", 1));
@@ -77,7 +77,6 @@ public class MongoDbFixture : IDisposable
             {
                 throw new Exception("Failed to connect to MongoDB test instance");
             }
-            
         }
         catch (Exception ex)
         {
@@ -102,8 +101,8 @@ public class MongoDbFixture : IDisposable
             {
                 var db = tempClient.GetDatabase("admin");
                 var result = db.RunCommand<BsonDocument>(new BsonDocument("replSetGetStatus", 1));
-                
-                if (result["ok"].AsDouble == 1.0 && 
+
+                if (result["ok"].AsDouble == 1.0 &&
                     result["members"].AsBsonArray.Any(m => m["stateStr"].AsString == "PRIMARY"))
                 {
                     return;
@@ -124,102 +123,102 @@ public class MongoDbFixture : IDisposable
     private void InitializeCollections()
     {
         try
-    {
-        // Create collections with required indexes
-        var collections = new[]
         {
-            "agents",
-            "conversations",
-            "messages",
-            "logs",
-            "tenants",
-            "users",
-            "webhooks",
-            "activity_history",
-            "flow_definitions",
-                "instructions",
-                "knowledge"  // Added missing collection
-        };
-
-        foreach (var collectionName in collections)
-        {
-            if (!CollectionExists(collectionName))
+            // Create collections with required indexes
+            var collections = new[]
             {
-                _database.CreateCollection(collectionName);
-            }
-        }
+                "agents",
+                "conversations",
+                "messages",
+                "logs",
+                "tenants",
+                "users",
+                "webhooks",
+                "activity_history",
+                "flow_definitions",
+                "instructions",
+                "knowledge"
+            };
 
-        // Create indexes
-        var messagesCollection = _database.GetCollection<BsonDocument>("messages");
-        var conversationsCollection = _database.GetCollection<BsonDocument>("conversations");
-        var logsCollection = _database.GetCollection<BsonDocument>("logs");
-        var tenantsCollection = _database.GetCollection<BsonDocument>("tenants");
-        var usersCollection = _database.GetCollection<BsonDocument>("users");
+            foreach (var collectionName in collections)
+            {
+                if (!CollectionExists(collectionName))
+                {
+                    _database.CreateCollection(collectionName);
+                }
+            }
+
+            // Create indexes
+            var messagesCollection = _database.GetCollection<BsonDocument>("messages");
+            var conversationsCollection = _database.GetCollection<BsonDocument>("conversations");
+            var logsCollection = _database.GetCollection<BsonDocument>("logs");
+            var tenantsCollection = _database.GetCollection<BsonDocument>("tenants");
+            var usersCollection = _database.GetCollection<BsonDocument>("users");
             var webhooksCollection = _database.GetCollection<BsonDocument>("webhooks");
             var knowledgeCollection = _database.GetCollection<BsonDocument>("knowledge");
 
-        // Messages indexes
-        messagesCollection.Indexes.CreateMany(new[]
-        {
-            new CreateIndexModel<BsonDocument>(
-                Builders<BsonDocument>.IndexKeys
-                    .Ascending("thread_id")
-                    .Ascending("created_at")),
-            new CreateIndexModel<BsonDocument>(
-                Builders<BsonDocument>.IndexKeys
-                    .Ascending("tenant_id"))
-        });
+            // Messages indexes
+            messagesCollection.Indexes.CreateMany(new[]
+            {
+                new CreateIndexModel<BsonDocument>(
+                    Builders<BsonDocument>.IndexKeys
+                        .Ascending("thread_id")
+                        .Ascending("created_at")),
+                new CreateIndexModel<BsonDocument>(
+                    Builders<BsonDocument>.IndexKeys
+                        .Ascending("tenant_id"))
+            });
 
-        // Conversations indexes
-        conversationsCollection.Indexes.CreateMany(new[]
-        {
-            new CreateIndexModel<BsonDocument>(
-                Builders<BsonDocument>.IndexKeys
-                    .Ascending("tenant_id")),
-            new CreateIndexModel<BsonDocument>(
-                Builders<BsonDocument>.IndexKeys
-                    .Ascending("created_at"))
-        });
+            // Conversations indexes
+            conversationsCollection.Indexes.CreateMany(new[]
+            {
+                new CreateIndexModel<BsonDocument>(
+                    Builders<BsonDocument>.IndexKeys
+                        .Ascending("tenant_id")),
+                new CreateIndexModel<BsonDocument>(
+                    Builders<BsonDocument>.IndexKeys
+                        .Ascending("created_at"))
+            });
 
-        // Logs indexes
-        logsCollection.Indexes.CreateMany(new[]
-        {
-            new CreateIndexModel<BsonDocument>(
-                Builders<BsonDocument>.IndexKeys
-                    .Ascending("tenant_id")),
-            new CreateIndexModel<BsonDocument>(
-                Builders<BsonDocument>.IndexKeys
+            // Logs indexes
+            logsCollection.Indexes.CreateMany(new[]
+            {
+                new CreateIndexModel<BsonDocument>(
+                    Builders<BsonDocument>.IndexKeys
+                        .Ascending("tenant_id")),
+                new CreateIndexModel<BsonDocument>(
+                    Builders<BsonDocument>.IndexKeys
                         .Ascending("created_at")),
                 new CreateIndexModel<BsonDocument>(
                     Builders<BsonDocument>.IndexKeys
                         .Ascending("workflow_run_id"))
-        });
-        
-        // Tenants indexes
-        tenantsCollection.Indexes.CreateMany(new[]
-        {
-            new CreateIndexModel<BsonDocument>(
-                Builders<BsonDocument>.IndexKeys
-                    .Ascending("tenant_id"),
-                new CreateIndexOptions { Unique = true }),
-            new CreateIndexModel<BsonDocument>(
-                Builders<BsonDocument>.IndexKeys
-                    .Ascending("domain"),
-                new CreateIndexOptions { Unique = true })
-        });
+            });
 
-        // Users indexes
-        usersCollection.Indexes.CreateMany(new[]
-        {
-            new CreateIndexModel<BsonDocument>(
-                Builders<BsonDocument>.IndexKeys
-                    .Ascending("user_id"),
-                new CreateIndexOptions { Unique = true }),
-            new CreateIndexModel<BsonDocument>(
-                Builders<BsonDocument>.IndexKeys
-                    .Ascending("email"),
-                new CreateIndexOptions { Unique = true })
-        });
+            // Tenants indexes
+            tenantsCollection.Indexes.CreateMany(new[]
+            {
+                new CreateIndexModel<BsonDocument>(
+                    Builders<BsonDocument>.IndexKeys
+                        .Ascending("tenant_id"),
+                    new CreateIndexOptions { Unique = true }),
+                new CreateIndexModel<BsonDocument>(
+                    Builders<BsonDocument>.IndexKeys
+                        .Ascending("domain"),
+                    new CreateIndexOptions { Unique = true })
+            });
+
+            // Users indexes
+            usersCollection.Indexes.CreateMany(new[]
+            {
+                new CreateIndexModel<BsonDocument>(
+                    Builders<BsonDocument>.IndexKeys
+                        .Ascending("user_id"),
+                    new CreateIndexOptions { Unique = true }),
+                new CreateIndexModel<BsonDocument>(
+                    Builders<BsonDocument>.IndexKeys
+                        .Ascending("email"),
+                    new CreateIndexOptions { Unique = true })
+            });
 
             // Webhooks indexes
             webhooksCollection.Indexes.CreateMany(new[]
@@ -262,12 +261,12 @@ public class MongoDbFixture : IDisposable
     public void Dispose()
     {
         try
-    {
-        _runner?.Dispose();
+        {
+            _runner?.Dispose();
         }
         catch
         {
             // Ignore disposal errors
         }
     }
-} 
+}

--- a/XiansAi.Server.Tests/TestUtils/RetryHttpClient.cs
+++ b/XiansAi.Server.Tests/TestUtils/RetryHttpClient.cs
@@ -45,7 +45,7 @@ public class RetryHttpClient : IAsyncDisposable
             }
 
             response = await _innerClient.SendAsync(requestClone, cancellationToken);
-            
+
             if (response.StatusCode != HttpStatusCode.Unauthorized || retryCount == _maxRetries)
             {
                 return response;
@@ -99,4 +99,4 @@ public class RetryHttpClient : IAsyncDisposable
         _innerClient.Dispose();
         await ValueTask.CompletedTask;
     }
-} 
+}

--- a/XiansAi.Server.Tests/TestUtils/TestAuthHandler.cs
+++ b/XiansAi.Server.Tests/TestUtils/TestAuthHandler.cs
@@ -86,4 +86,4 @@ public class TestAuthHandler : AuthenticationHandler<TestAuthenticationOptions>
             return Task.FromResult(AuthenticateResult.Fail("Authentication failed"));
         }
     }
-} 
+}

--- a/XiansAi.Server.Tests/TestUtils/TestCertificateHelper.cs
+++ b/XiansAi.Server.Tests/TestUtils/TestCertificateHelper.cs
@@ -14,31 +14,31 @@ public static class TestCertificateHelper
     private static string? _rootCertificate;
     private static string? _rootPrivateKey;
     private static X509Certificate2? _testCertificate;
-    
+
     public static void Initialize(string envPath = ".env")
     {
         // Double-check locking pattern for thread safety
         if (_isInitialized) return;
-        
+
         lock (_lock)
         {
             if (_isInitialized) return;
-            
+
             try
             {
                 // Get an absolute path to the .env file in the test project root
                 string testProjectDirectory = Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "../../../"));
                 string fullEnvPath = Path.Combine(testProjectDirectory, envPath);
-                
+
                 if (!File.Exists(fullEnvPath))
                 {
                     // Create a default .env file if it doesn't exist
                     File.WriteAllText(fullEnvPath, "APP_SERVER_API_KEY=test-api-key");
                 }
-                
+
                 // Load environment variables
                 Env.Load(fullEnvPath);
-                
+
                 // Cache the API key
                 _apiKey = Environment.GetEnvironmentVariable("APP_SERVER_API_KEY");
                 if (string.IsNullOrEmpty(_apiKey))
@@ -52,7 +52,7 @@ public static class TestCertificateHelper
                 {
                     GenerateTestCertificates();
                 }
-                
+
                 _isInitialized = true;
             }
             catch (Exception ex)
@@ -67,7 +67,7 @@ public static class TestCertificateHelper
             }
         }
     }
-    
+
     public static string LoadApiKeyFromEnv()
     {
         // Ensure initialization before accessing the API key
@@ -75,13 +75,13 @@ public static class TestCertificateHelper
         {
             Initialize();
         }
-        
+
         // Double-check that we have a valid API key
         if (string.IsNullOrEmpty(_apiKey))
         {
             throw new InvalidOperationException("API key is null or empty after initialization.");
         }
-        
+
         return _apiKey;
     }
 
@@ -92,7 +92,7 @@ public static class TestCertificateHelper
         {
             Initialize();
         }
-        
+
         return _rootCertificate ?? Convert.ToBase64String(_testCertificate!.RawData);
     }
 
@@ -103,7 +103,7 @@ public static class TestCertificateHelper
         {
             Initialize();
         }
-        
+
         return _rootPrivateKey ?? Convert.ToBase64String(_testCertificate!.GetRSAPrivateKey()!.ExportRSAPrivateKey());
     }
 
@@ -138,4 +138,4 @@ public static class TestCertificateHelper
         _rootCertificate = Convert.ToBase64String(cert.RawData);
         _rootPrivateKey = Convert.ToBase64String(cert.GetRSAPrivateKey()!.ExportRSAPrivateKey());
     }
-} 
+}

--- a/XiansAi.Server.Tests/TestUtils/XiansAiWebApplicationFactory.cs
+++ b/XiansAi.Server.Tests/TestUtils/XiansAiWebApplicationFactory.cs
@@ -112,7 +112,7 @@ public class XiansAiWebApplicationFactory : WebApplicationFactory<Program>
             {
                 var logger = sp.GetRequiredService<ILogger<CertificateGenerator>>();
                 var env = sp.GetRequiredService<IWebHostEnvironment>();
-                
+
                 // Create a test configuration with dummy certificate data
                 var testConfig = new ConfigurationBuilder()
                     .AddInMemoryCollection(new Dictionary<string, string?>
@@ -121,7 +121,7 @@ public class XiansAiWebApplicationFactory : WebApplicationFactory<Program>
                         ["Certificates:AppServerCertPassword"] = "test-password"
                     })
                     .Build();
-                    
+
                 return new CertificateGenerator(testConfig, logger, env);
             });
 
@@ -188,14 +188,14 @@ public class XiansAiWebApplicationFactory : WebApplicationFactory<Program>
                     policy.AuthenticationSchemes.Add("Test");
                     policy.RequireAuthenticatedUser();
                 });
-                
+
                 options.AddPolicy("RequireTenantAuth", policy =>
                 {
-                    policy.AuthenticationSchemes.Clear(); 
+                    policy.AuthenticationSchemes.Clear();
                     policy.AuthenticationSchemes.Add("Test");
                     policy.RequireAuthenticatedUser();
                 });
-                
+
                 options.AddPolicy("RequireTenantAuthWithoutConfig", policy =>
                 {
                     policy.AuthenticationSchemes.Clear();
@@ -264,4 +264,4 @@ public class XiansAiWebApplicationFactory : WebApplicationFactory<Program>
         }
         base.Dispose(disposing);
     }
-} 
+}

--- a/XiansAi.Server.Tests/UnitTests/Shared/UrlValidatorTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Shared/UrlValidatorTests.cs
@@ -137,4 +137,3 @@ public class UrlValidatorTests
         Assert.NotEmpty(errorMessage);
     }
 }
-

--- a/XiansAi.Server.Tests/UnitTests/Shared/Utils/Serialization/TimeSpanTypeConverterTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Shared/Utils/Serialization/TimeSpanTypeConverterTests.cs
@@ -9,17 +9,17 @@ namespace Tests.UnitTests.Shared.Utils.Serialization;
 public class TimeSpanTypeConverterTests
 {
     private readonly TimeSpanTypeConverter _converter = new();
-    
+
     private readonly ISerializer _serializer = new SerializerBuilder()
         .WithNamingConvention(UnderscoredNamingConvention.Instance)
         .WithTypeConverter(new TimeSpanTypeConverter())
         .Build();
-    
+
     private readonly IDeserializer _deserializer = new DeserializerBuilder()
         .WithNamingConvention(UnderscoredNamingConvention.Instance)
         .WithTypeConverter(new TimeSpanTypeConverter())
         .Build();
-    
+
     public static IEnumerable<object[]> ValidTimeSpanData => new List<object[]>
     {
         new object[] { "30d", TimeSpan.FromDays(30) },
@@ -78,7 +78,7 @@ public class TimeSpanTypeConverterTests
         var yaml = _serializer.Serialize(new Foo<TimeSpan> { TimeToLive = input }).Trim();
         Assert.Equal(expectedYaml, yaml);
     }
-    
+
     [Fact]
     public void WriteYaml_NullTimeSpan_SerializesToNull()
     {
@@ -103,7 +103,7 @@ public class TimeSpanTypeConverterTests
         parser.Consume<StreamEnd>();
         return result;
     }
-    
+
     private class Foo<T>
     {
         public T TimeToLive { get; init; } = default!;
@@ -135,4 +135,4 @@ public class TimeSpanTypeConverterTests
 
         Assert.Equal(TimeSpan.Zero, result.TimeToLive);
     }
-} 
+}


### PR DESCRIPTION
…ntTests

- Removed commented-out test execution commands and outdated test methods from ActivityHistoryTests and InstructionsEndpointTests.
- Streamlined the test classes for better readability and maintainability.

These changes enhance the clarity and focus of the integration tests, ensuring they are up-to-date and easier to navigate.