### PR TITLE
feat(api): add activation existence check endpoint

### DIFF
--- a/XiansAi.Server.Src/Features/AgentApi/Endpoints/ActivationEndpoint.cs
+++ b/XiansAi.Server.Src/Features/AgentApi/Endpoints/ActivationEndpoint.cs
@@ -2,7 +2,9 @@ using Microsoft.AspNetCore.Mvc;
 using Features.AgentApi.Auth;
 using Shared.Auth;
 using Shared.Repositories;
+using Shared.Services;
 using Shared.Utils;
+using Shared.Utils.Services;
 
 namespace Features.AgentApi.Endpoints;
 
@@ -101,5 +103,35 @@ public static class ActivationEndpoints
         
         .WithSummary("Get workflow input parameters for an activation")
         .WithDescription("Returns the ordered list of input values configured for a specific workflow type ");
+
+        activationGroup.MapGet("/exists", async (
+            [FromQuery] string activationName,
+            [FromQuery] string agentName,
+            [FromServices] IActivationValidationService activationValidationService,
+            [FromServices] ITenantContext tenantContext) =>
+        {
+            var tenantId = tenantContext.TenantId;
+
+            if (string.IsNullOrWhiteSpace(tenantId))
+            {
+                _logger.LogWarning("TenantId could not be resolved from certificate context");
+                return Results.Problem("TenantId could not be resolved", statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            _logger.LogInformation(
+                "Checking activation existence: activationName={ActivationName}, agentName={AgentName}, tenantId={TenantId}",
+                LogSanitizer.Sanitize(activationName), LogSanitizer.Sanitize(agentName), LogSanitizer.Sanitize(tenantId));
+
+            var result = await activationValidationService.ValidateActivationAsync(tenantId, agentName, activationName);
+            return result.ToHttpResult();
+        })
+        .WithName("Check Activation Exists")
+        .Produces(StatusCodes.Status200OK)
+        .ProducesProblem(StatusCodes.Status400BadRequest)
+        .ProducesProblem(StatusCodes.Status404NotFound)
+        .ProducesProblem(StatusCodes.Status409Conflict)
+        .ProducesProblem(StatusCodes.Status500InternalServerError)
+        .WithSummary("Check whether an activation exists and is active")
+        .WithDescription("Returns 200 when the activation exists and is active for the agent in the current tenant; 404 when not found; 409 when deactivated.");
     }
 }

--- a/XiansAi.Server.Tests/IntegrationTests/AgentApi/ActivationEndpointTests.cs
+++ b/XiansAi.Server.Tests/IntegrationTests/AgentApi/ActivationEndpointTests.cs
@@ -1,0 +1,91 @@
+using System.Net;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Bson;
+using Shared.Data;
+using Shared.Data.Models;
+using Tests.TestUtils;
+
+namespace Tests.IntegrationTests.AgentApi;
+
+/// <summary>
+/// Integration tests for the AgentApi activation group's "/exists" endpoint, covering the
+/// active, not-found, and deactivated activation paths through the real database-backed repository.
+/// </summary>
+public class ActivationEndpointTests : IntegrationTestBase
+{
+    public ActivationEndpointTests(MongoDbFixture mongoFixture) : base(mongoFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Exists_ForActiveActivation_ReturnsOk()
+    {
+        var agentName = $"test-agent-{Guid.NewGuid()}";
+        var activationName = $"test-activation-{Guid.NewGuid()}";
+        await CreateTestActivationAsync(agentName, activationName, active: true);
+
+        var response = await _client.GetAsync(
+            $"/api/agent/activation/exists?activationName={activationName}&agentName={agentName}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Exists_ForUnknownActivation_ReturnsNotFound()
+    {
+        var agentName = $"test-agent-{Guid.NewGuid()}";
+        var activationName = $"nonexistent-activation-{Guid.NewGuid()}";
+
+        var response = await _client.GetAsync(
+            $"/api/agent/activation/exists?activationName={activationName}&agentName={agentName}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Exists_ForDeactivatedActivation_ReturnsConflict()
+    {
+        var agentName = $"test-agent-{Guid.NewGuid()}";
+        var activationName = $"test-activation-{Guid.NewGuid()}";
+        await CreateTestActivationAsync(agentName, activationName, active: false);
+
+        var response = await _client.GetAsync(
+            $"/api/agent/activation/exists?activationName={activationName}&agentName={agentName}");
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Exists_WithoutRequiredQueryParams_ReturnsBadRequest()
+    {
+        // Both 'activationName' and 'agentName' are required query parameters, so model binding rejects the request.
+        var response = await _client.GetAsync("/api/agent/activation/exists");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    private async Task<AgentActivation> CreateTestActivationAsync(string agentName, string activationName, bool active)
+    {
+        using var serviceScope = _factory.Services.CreateScope();
+        var databaseService = serviceScope.ServiceProvider.GetRequiredService<IDatabaseService>();
+
+        var activation = new AgentActivation
+        {
+            Id = ObjectId.GenerateNewId().ToString(),
+            Name = activationName,
+            AgentName = agentName,
+            CreatedBy = "test-user",
+            CreatedAt = DateTime.UtcNow,
+            TenantId = TestTenantId,
+            Active = active,
+            ActivatedAt = active ? DateTime.UtcNow : null,
+            DeactivatedAt = active ? null : DateTime.UtcNow
+        };
+
+        var database = await databaseService.GetDatabaseAsync();
+        var collection = database.GetCollection<AgentActivation>("activations");
+        await collection.InsertOneAsync(activation);
+
+        return activation;
+    }
+}


### PR DESCRIPTION
- Introduced a new endpoint to verify the existence and active status of an activation for a specific agent within the current tenant.
- Implemented validation logic to ensure tenant ID resolution and enhanced logging for better traceability.
- The endpoint returns appropriate HTTP status codes based on the activation's status, improving the API's usability and clarity.

These changes enhance the functionality of the Agent API by providing a mechanism to check activation states, contributing to better management of agent activations.