### PR TITLE
feat(api): add optional metadata support to tenants (#442)

### DIFF
--- a/XiansAi.Server.Src/Features/AdminApi/Endpoints/AdminTenantEndpoints.cs
+++ b/XiansAi.Server.Src/Features/AdminApi/Endpoints/AdminTenantEndpoints.cs
@@ -93,6 +93,111 @@ public static class AdminTenantEndpoints
         .Produces(StatusCodes.Status403Forbidden)
         ;
 
+        // Get Tenant Metadata - SysAdmin only. This is the only endpoint that returns
+        // metadata with Secret values decrypted; tenant payloads elsewhere carry the
+        // stored (encrypted) form.
+        adminTenantGroup.MapGet("/{tenantId}/metadata", async (
+            string tenantId,
+            HttpContext httpContext,
+            [FromServices] ITenantContext tenantContext,
+            [FromServices] ITenantService tenantService,
+            [FromServices] ILogger<ITenantService> logger) =>
+        {
+            if (tenantContext.UserRoles?.Contains(SystemRoles.SysAdmin) != true)
+            {
+                logger.LogWarning("Access denied: Get tenant metadata requires SysAdmin role. User: {UserId}", tenantContext.LoggedInUser);
+                return Results.Json(
+                    new { message = "Access denied: Only system administrators can retrieve tenant metadata" },
+                    statusCode: StatusCodes.Status403Forbidden);
+            }
+
+            var bypassCache = httpContext.Request.IsNoCacheRequested();
+            var result = await tenantService.GetTenantMetadata(tenantId, httpContext.RequestAborted, bypassCache);
+            return result.ToHttpResult();
+        })
+        .WithName("GetTenantMetadata")
+        .Produces(StatusCodes.Status403Forbidden)
+        ;
+
+        // Get a single Tenant Metadata entry by key (case-insensitive) - SysAdmin only.
+        // Returns the entry with its value decrypted when the type is Secret.
+        adminTenantGroup.MapGet("/{tenantId}/metadata/{key}", async (
+            string tenantId,
+            string key,
+            HttpContext httpContext,
+            [FromServices] ITenantContext tenantContext,
+            [FromServices] ITenantService tenantService,
+            [FromServices] ILogger<ITenantService> logger) =>
+        {
+            if (tenantContext.UserRoles?.Contains(SystemRoles.SysAdmin) != true)
+            {
+                logger.LogWarning("Access denied: Get tenant metadata requires SysAdmin role. User: {UserId}", tenantContext.LoggedInUser);
+                return Results.Json(
+                    new { message = "Access denied: Only system administrators can retrieve tenant metadata" },
+                    statusCode: StatusCodes.Status403Forbidden);
+            }
+
+            var bypassCache = httpContext.Request.IsNoCacheRequested();
+            var result = await tenantService.GetTenantMetadataByKey(tenantId, key, httpContext.RequestAborted, bypassCache);
+            return result.ToHttpResult();
+        })
+        .WithName("GetTenantMetadataByKey")
+        .Produces(StatusCodes.Status403Forbidden)
+        .Produces(StatusCodes.Status404NotFound)
+        ;
+
+        // Upsert a single Tenant Metadata entry by key (case-insensitive) - SysAdmin only.
+        // Adds the entry when the key does not exist, otherwise replaces its value/type.
+        // Secret values are encrypted before persisting.
+        adminTenantGroup.MapPut("/{tenantId}/metadata/{key}", async (
+            string tenantId,
+            string key,
+            [FromBody] UpsertTenantMetadataRequest request,
+            [FromServices] ITenantContext tenantContext,
+            [FromServices] ITenantService tenantService,
+            [FromServices] ILogger<ITenantService> logger) =>
+        {
+            if (tenantContext.UserRoles?.Contains(SystemRoles.SysAdmin) != true)
+            {
+                logger.LogWarning("Access denied: Upsert tenant metadata requires SysAdmin role. User: {UserId}", tenantContext.LoggedInUser);
+                return Results.Json(
+                    new { message = "Access denied: Only system administrators can modify tenant metadata" },
+                    statusCode: StatusCodes.Status403Forbidden);
+            }
+
+            var result = await tenantService.UpsertTenantMetadata(tenantId, key, request);
+            return result.ToHttpResult();
+        })
+        .WithName("UpsertTenantMetadata")
+        .Produces(StatusCodes.Status400BadRequest)
+        .Produces(StatusCodes.Status403Forbidden)
+        .Produces(StatusCodes.Status404NotFound)
+        ;
+
+        // Delete a single Tenant Metadata entry by key (case-insensitive) - SysAdmin only.
+        adminTenantGroup.MapDelete("/{tenantId}/metadata/{key}", async (
+            string tenantId,
+            string key,
+            [FromServices] ITenantContext tenantContext,
+            [FromServices] ITenantService tenantService,
+            [FromServices] ILogger<ITenantService> logger) =>
+        {
+            if (tenantContext.UserRoles?.Contains(SystemRoles.SysAdmin) != true)
+            {
+                logger.LogWarning("Access denied: Delete tenant metadata requires SysAdmin role. User: {UserId}", tenantContext.LoggedInUser);
+                return Results.Json(
+                    new { message = "Access denied: Only system administrators can modify tenant metadata" },
+                    statusCode: StatusCodes.Status403Forbidden);
+            }
+
+            var result = await tenantService.DeleteTenantMetadata(tenantId, key);
+            return result.ToHttpResult();
+        })
+        .WithName("DeleteTenantMetadata")
+        .Produces(StatusCodes.Status403Forbidden)
+        .Produces(StatusCodes.Status404NotFound)
+        ;
+
         // Get Tenant Logo - serves the image so the (potentially large) base64 payload
         // does not have to be embedded in every tenant response.
         adminTenantGroup.MapGet("/{tenantId}/logo", async (

--- a/XiansAi.Server.Src/Shared/Configuration/SharedConfiguration.cs
+++ b/XiansAi.Server.Src/Shared/Configuration/SharedConfiguration.cs
@@ -231,6 +231,7 @@ public static class SharedConfiguration
         builder.Services.AddScoped<ITenantOidcConfigService, TenantOidcConfigService>();
         builder.Services.AddScoped<ISecretVaultService, SecretVaultService>();
         builder.Services.AddSingleton<ISecureEncryptionService, SecureEncryptionService>();
+        builder.Services.AddSingleton<ITenantMetadataProtector, TenantMetadataProtector>();
 
         // Configure JSON serialization options for minimal APIs
         // This ensures enums are serialized as strings instead of numeric values

--- a/XiansAi.Server.Src/Shared/Data/Models/Tenant.cs
+++ b/XiansAi.Server.Src/Shared/Data/Models/Tenant.cs
@@ -2,6 +2,7 @@ using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 using Shared.Data.Models.Validation;
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 
 namespace Shared.Data.Models;
 
@@ -69,6 +70,9 @@ public class Tenant : ModelValidatorBase<Tenant>
     [BsonElement("enabled")]
     public bool Enabled { get; set; } = true;
 
+    [BsonElement("metadata")]
+    public List<TenantMetadata>? Metadata { get; set; }
+
     public override void Validate()
     {
         // Call base validation (Data Annotations)
@@ -114,6 +118,22 @@ public class Tenant : ModelValidatorBase<Tenant>
                 permission.Validate();
             }
         }
+
+        if (Metadata != null)
+        {
+            foreach (var metadata in Metadata)
+            {
+                metadata.Validate();
+            }
+
+            var duplicateKey = Metadata
+                .GroupBy(m => m.Key, StringComparer.OrdinalIgnoreCase)
+                .FirstOrDefault(g => g.Count() > 1);
+            if (duplicateKey != null)
+            {
+                throw new ValidationException($"Duplicate metadata key: {duplicateKey.Key}");
+            }
+        }
     }
         /// <summary>
     /// Returns a shallow copy of this tenant. Use when returning from cache so callers cannot mutate the cached original.
@@ -135,7 +155,8 @@ public class Tenant : ModelValidatorBase<Tenant>
             CreatedAt = CreatedAt,
             CreatedBy = CreatedBy,
             UpdatedAt = UpdatedAt,
-            Enabled = Enabled
+            Enabled = Enabled,
+            Metadata = Metadata?.Select(m => m.Copy()).ToList()
         };
     }
 
@@ -157,7 +178,8 @@ public class Tenant : ModelValidatorBase<Tenant>
             Enabled = this.Enabled,
             Logo = this.Logo,
             Agents = this.Agents,
-            Permissions = this.Permissions
+            Permissions = this.Permissions,
+            Metadata = this.Metadata?.Select(m => m.SanitizeAndReturn()).ToList()
         };
 
         return sanitizedTenant;
@@ -378,5 +400,71 @@ public class Flow : ModelValidatorBase<Flow>
         sanitizedFlow.Validate();
 
         return sanitizedFlow;
+    }
+}
+
+/// <summary>
+/// How a tenant metadata value is stored. Extensible: new types can be added
+/// without changing the metadata design.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum MetadataType
+{
+    PlainText,
+    Secret
+}
+
+/// <summary>
+/// A single optional key/value metadata entry on a tenant. Values of type
+/// <see cref="MetadataType.Secret"/> are encrypted at rest and decrypted before
+/// being returned to API consumers.
+/// </summary>
+public class TenantMetadata : ModelValidatorBase<TenantMetadata>
+{
+    [BsonElement("key")]
+    [Required(ErrorMessage = "Metadata key is required")]
+    [StringLength(100, MinimumLength = 1, ErrorMessage = "Metadata key must be between 1 and 100 characters")]
+    [RegularExpression(@"^[a-zA-Z0-9._-]+$", ErrorMessage = "Metadata key contains invalid characters")]
+    public required string Key { get; set; }
+
+    // No pattern/length restriction: the value may be arbitrary plaintext or ciphertext.
+    [BsonElement("value")]
+    [Required(AllowEmptyStrings = true, ErrorMessage = "Metadata value is required")]
+    public required string Value { get; set; }
+
+    [BsonElement("type")]
+    [BsonRepresentation(BsonType.String)]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public MetadataType Type { get; set; } = MetadataType.PlainText;
+
+    /// <summary>
+    /// Returns a copy so callers cannot mutate the original (e.g. a cached tenant).
+    /// </summary>
+    public TenantMetadata Copy()
+    {
+        return new TenantMetadata
+        {
+            Key = Key,
+            Value = Value,
+            Type = Type
+        };
+    }
+
+    public override TenantMetadata SanitizeAndReturn()
+    {
+        return new TenantMetadata
+        {
+            Key = ValidationHelpers.SanitizeString(this.Key),
+            // Never sanitize the value: it may be ciphertext or legitimate free text.
+            Value = this.Value,
+            Type = this.Type
+        };
+    }
+
+    public override TenantMetadata SanitizeAndValidate()
+    {
+        var sanitized = this.SanitizeAndReturn();
+        sanitized.Validate();
+        return sanitized;
     }
 }

--- a/XiansAi.Server.Src/Shared/Services/TenantMetadataProtector.cs
+++ b/XiansAi.Server.Src/Shared/Services/TenantMetadataProtector.cs
@@ -1,0 +1,76 @@
+using Shared.Data.Models;
+
+namespace Shared.Services;
+
+/// <summary>
+/// Encrypts and decrypts tenant metadata values of type <see cref="MetadataType.Secret"/>
+/// using the existing <see cref="ISecureEncryptionService"/> (AES-256-GCM keyed from
+/// EncryptionKeys:BaseSecret). The tenant's immutable TenantId is used as the unique
+/// secret so each tenant gets an isolated derived key, mirroring the per-record pattern
+/// used by the secret vault.
+/// </summary>
+public interface ITenantMetadataProtector
+{
+    /// <summary>Returns a new list with Secret values encrypted. Never mutates the input.</summary>
+    List<TenantMetadata>? Protect(List<TenantMetadata>? metadata, string tenantId);
+
+    /// <summary>Returns a new list with Secret values decrypted. Never mutates the input.</summary>
+    List<TenantMetadata>? Unprotect(List<TenantMetadata>? metadata, string tenantId);
+}
+
+public class TenantMetadataProtector : ITenantMetadataProtector
+{
+    private readonly ISecureEncryptionService _encryption;
+
+    public TenantMetadataProtector(ISecureEncryptionService encryption)
+    {
+        _encryption = encryption ?? throw new ArgumentNullException(nameof(encryption));
+    }
+
+    public List<TenantMetadata>? Protect(List<TenantMetadata>? metadata, string tenantId)
+    {
+        return Transform(metadata, tenantId, encrypt: true);
+    }
+
+    public List<TenantMetadata>? Unprotect(List<TenantMetadata>? metadata, string tenantId)
+    {
+        return Transform(metadata, tenantId, encrypt: false);
+    }
+
+    private List<TenantMetadata>? Transform(List<TenantMetadata>? metadata, string tenantId, bool encrypt)
+    {
+        if (metadata == null || metadata.Count == 0)
+        {
+            return metadata;
+        }
+
+        if (string.IsNullOrWhiteSpace(tenantId))
+        {
+            throw new ArgumentException("Tenant ID must be provided to protect metadata", nameof(tenantId));
+        }
+
+        var result = new List<TenantMetadata>(metadata.Count);
+        foreach (var item in metadata)
+        {
+            var copy = item.Copy();
+            if (copy.Type == MetadataType.Secret)
+            {
+                try
+                {
+                    copy.Value = encrypt
+                        ? _encryption.Encrypt(copy.Value, tenantId)
+                        : _encryption.Decrypt(copy.Value, tenantId);
+                }
+                catch (Exception ex)
+                {
+                    // Never include the value or any key material in the error.
+                    var operation = encrypt ? "encrypt" : "decrypt";
+                    throw new InvalidOperationException(
+                        $"Failed to {operation} metadata value for key '{copy.Key}' of tenant '{tenantId}'", ex);
+                }
+            }
+            result.Add(copy);
+        }
+        return result;
+    }
+}

--- a/XiansAi.Server.Src/Shared/Services/TenantService.cs
+++ b/XiansAi.Server.Src/Shared/Services/TenantService.cs
@@ -21,6 +21,7 @@ public class CreateTenantRequest
     public Logo? Logo { get; set; }
     public string? Theme { get; set; }
     public string? Timezone { get; set; }
+    public List<TenantMetadata>? Metadata { get; set; }
 }
 
 public class UpdateTenantRequest
@@ -32,11 +33,18 @@ public class UpdateTenantRequest
     public string? Theme { get; set; }
     public string? Timezone { get; set; }
     public bool? Enabled { get; set; }
+    public List<TenantMetadata>? Metadata { get; set; }
 }
 
 public class UpdateTenantThemeRequest
 {
     public string? Theme { get; set; }
+}
+
+public class UpsertTenantMetadataRequest
+{
+    public required string Value { get; set; }
+    public MetadataType Type { get; set; } = MetadataType.PlainText;
 }
 
 public class TenantCreatedResult
@@ -60,6 +68,10 @@ public interface ITenantService
     Task<ServiceResult<Tenant>> GetTenantById(string id);
     Task<ServiceResult<Tenant>> GetTenantByDomain(string domain);
     Task<ServiceResult<Tenant>> GetTenantByTenantId(string tenantId, CancellationToken cancellationToken = default, bool bypassCache = false);
+    Task<ServiceResult<List<TenantMetadata>>> GetTenantMetadata(string tenantId, CancellationToken cancellationToken = default, bool bypassCache = false);
+    Task<ServiceResult<TenantMetadata>> GetTenantMetadataByKey(string tenantId, string key, CancellationToken cancellationToken = default, bool bypassCache = false);
+    Task<ServiceResult<TenantMetadata>> UpsertTenantMetadata(string tenantId, string key, UpsertTenantMetadataRequest request);
+    Task<ServiceResult<bool>> DeleteTenantMetadata(string tenantId, string key);
     Task<ServiceResult<Tenant>> GetCurrentTenantInfo(CancellationToken cancellationToken = default);
     Task<ServiceResult<List<Tenant>>> GetAllTenants();
     Task<ServiceResult<TenantListResult>> GetAllTenants(int? page, int? pageSize, string? search = null);
@@ -79,6 +91,7 @@ public class TenantService : ITenantService
     private readonly ITenantContext _tenantContext;
     private readonly IRoleManagementService _roleManagementService;
     private readonly IWebhookEventPublisher _webhookEventPublisher;
+    private readonly ITenantMetadataProtector _metadataProtector;
 
 
     public TenantService(
@@ -87,7 +100,8 @@ public class TenantService : ITenantService
         ILogger<TenantService> logger,
         ITenantContext tenantContext,
         IRoleManagementService roleManagementService,
-        IWebhookEventPublisher webhookEventPublisher)
+        IWebhookEventPublisher webhookEventPublisher,
+        ITenantMetadataProtector metadataProtector)
     {
         _tenantRepository = tenantRepository ?? throw new ArgumentNullException(nameof(tenantRepository));
         _tenantCacheService = tenantCacheService ?? throw new ArgumentNullException(nameof(tenantCacheService));
@@ -95,6 +109,7 @@ public class TenantService : ITenantService
         _tenantContext = tenantContext ?? throw new ArgumentNullException(nameof(tenantContext));
         _roleManagementService = roleManagementService ?? throw new ArgumentNullException(nameof(roleManagementService));
         _webhookEventPublisher = webhookEventPublisher ?? throw new ArgumentNullException(nameof(webhookEventPublisher));
+        _metadataProtector = metadataProtector ?? throw new ArgumentNullException(nameof(metadataProtector));
     }
 
     private string EnsureTenantAccessOrThrow(string tenantId)
@@ -230,6 +245,219 @@ public class TenantService : ITenantService
         {
             _logger.LogError(ex, "Error retrieving tenant with tenant ID {TenantId}", LogSanitizer.Sanitize(tenantId));
             return ServiceResult<Tenant>.InternalServerError("An error occurred while retrieving the tenant.");
+        }
+    }
+
+    /// <summary>
+    /// Returns the tenant's metadata with Secret values decrypted. This is the only
+    /// place decrypted metadata is exposed; all other tenant reads return the stored
+    /// (encrypted) form so secrets never travel with general tenant payloads.
+    /// </summary>
+    public async Task<ServiceResult<List<TenantMetadata>>> GetTenantMetadata(string tenantId, CancellationToken cancellationToken = default, bool bypassCache = false)
+    {
+        try
+        {
+            tenantId = Tenant.SanitizeAndValidateTenantId(tenantId);
+            var accessibleTenantId = _tenantContext.AuthorizedTenantIds?.FirstOrDefault(t => t == tenantId);
+            if (accessibleTenantId == null)
+            {
+                _logger.LogWarning("Unauthorized access attempt to metadata of tenant {TenantId}", LogSanitizer.Sanitize(tenantId));
+                return ServiceResult<List<TenantMetadata>>.Forbidden("Access denied: insufficient permissions");
+            }
+
+            var tenant = await _tenantCacheService.GetByTenantIdAsync(tenantId, cancellationToken, bypassCache);
+            if (tenant == null)
+            {
+                _logger.LogWarning("Tenant with tenant ID {TenantId} not found", LogSanitizer.Sanitize(tenantId));
+                return ServiceResult<List<TenantMetadata>>.NotFound("Tenant not found");
+            }
+
+            var metadata = _metadataProtector.Unprotect(tenant.Metadata, tenant.TenantId) ?? new List<TenantMetadata>();
+            return ServiceResult<List<TenantMetadata>>.Success(metadata);
+        }
+        catch (ValidationException ex)
+        {
+            _logger.LogWarning("Validation failed while retrieving tenant metadata: {Message}", LogSanitizer.Sanitize(ex.Message));
+            return ServiceResult<List<TenantMetadata>>.BadRequest($"Validation failed: {ex.Message}");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error retrieving metadata for tenant {TenantId}", LogSanitizer.Sanitize(tenantId));
+            return ServiceResult<List<TenantMetadata>>.InternalServerError("An error occurred while retrieving the tenant metadata.");
+        }
+    }
+
+    /// <summary>
+    /// Returns a single tenant metadata entry by key (case-insensitive), with the value
+    /// decrypted when the entry is of type Secret. Only the requested entry is decrypted.
+    /// </summary>
+    public async Task<ServiceResult<TenantMetadata>> GetTenantMetadataByKey(string tenantId, string key, CancellationToken cancellationToken = default, bool bypassCache = false)
+    {
+        try
+        {
+            tenantId = Tenant.SanitizeAndValidateTenantId(tenantId);
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                return ServiceResult<TenantMetadata>.BadRequest("Metadata key is required");
+            }
+
+            var accessibleTenantId = _tenantContext.AuthorizedTenantIds?.FirstOrDefault(t => t == tenantId);
+            if (accessibleTenantId == null)
+            {
+                _logger.LogWarning("Unauthorized access attempt to metadata of tenant {TenantId}", LogSanitizer.Sanitize(tenantId));
+                return ServiceResult<TenantMetadata>.Forbidden("Access denied: insufficient permissions");
+            }
+
+            var tenant = await _tenantCacheService.GetByTenantIdAsync(tenantId, cancellationToken, bypassCache);
+            if (tenant == null)
+            {
+                _logger.LogWarning("Tenant with tenant ID {TenantId} not found", LogSanitizer.Sanitize(tenantId));
+                return ServiceResult<TenantMetadata>.NotFound("Tenant not found");
+            }
+
+            var entry = tenant.Metadata?.FirstOrDefault(m => string.Equals(m.Key, key, StringComparison.OrdinalIgnoreCase));
+            if (entry == null)
+            {
+                _logger.LogWarning("Metadata key {Key} not found for tenant {TenantId}", LogSanitizer.Sanitize(key), LogSanitizer.Sanitize(tenantId));
+                return ServiceResult<TenantMetadata>.NotFound("Metadata key not found");
+            }
+
+            var decrypted = _metadataProtector.Unprotect(new List<TenantMetadata> { entry }, tenant.TenantId)!.Single();
+            return ServiceResult<TenantMetadata>.Success(decrypted);
+        }
+        catch (ValidationException ex)
+        {
+            _logger.LogWarning("Validation failed while retrieving tenant metadata by key: {Message}", LogSanitizer.Sanitize(ex.Message));
+            return ServiceResult<TenantMetadata>.BadRequest($"Validation failed: {ex.Message}");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error retrieving metadata key {Key} for tenant {TenantId}", LogSanitizer.Sanitize(key), LogSanitizer.Sanitize(tenantId));
+            return ServiceResult<TenantMetadata>.InternalServerError("An error occurred while retrieving the tenant metadata.");
+        }
+    }
+
+    /// <summary>
+    /// Adds a metadata entry, or updates value/type when the key (case-insensitive) already
+    /// exists. Secret values are encrypted before persisting; the response echoes the entry
+    /// as provided by the caller.
+    /// </summary>
+    public async Task<ServiceResult<TenantMetadata>> UpsertTenantMetadata(string tenantId, string key, UpsertTenantMetadataRequest request)
+    {
+        try
+        {
+            tenantId = Tenant.SanitizeAndValidateTenantId(tenantId);
+
+            var existingTenant = await _tenantRepository.GetByTenantIdAsync(tenantId);
+            if (existingTenant == null)
+            {
+                _logger.LogWarning("Tenant with tenant ID {TenantId} not found for metadata upsert", LogSanitizer.Sanitize(tenantId));
+                return ServiceResult<TenantMetadata>.NotFound("Tenant not found");
+            }
+
+            EnsureTenantAccessOrThrow(existingTenant.TenantId);
+
+            var entry = new TenantMetadata
+            {
+                Key = key,
+                Value = request.Value,
+                Type = request.Type
+            };
+            var validatedEntry = entry.SanitizeAndValidate();
+
+            var protectedEntry = _metadataProtector.Protect([validatedEntry], existingTenant.TenantId)!.Single();
+
+            var metadata = existingTenant.Metadata ?? [];
+            var index = metadata.FindIndex(m => string.Equals(m.Key, validatedEntry.Key, StringComparison.OrdinalIgnoreCase));
+            if (index >= 0)
+            {
+                metadata[index] = protectedEntry;
+            }
+            else
+            {
+                metadata.Add(protectedEntry);
+            }
+            existingTenant.Metadata = metadata;
+
+            var persistResult = await PersistTenantUpdate(existingTenant, existingTenant.Id);
+            if (!persistResult.IsSuccess)
+            {
+                return ServiceResult<TenantMetadata>.Failure(
+                    persistResult.ErrorMessage ?? "Failed to update tenant metadata.", persistResult.StatusCode);
+            }
+
+            return ServiceResult<TenantMetadata>.Success(validatedEntry);
+        }
+        catch (ValidationException ex)
+        {
+            _logger.LogWarning("Validation failed while upserting tenant metadata: {Message}", LogSanitizer.Sanitize(ex.Message));
+            return ServiceResult<TenantMetadata>.BadRequest($"Validation failed: {ex.Message}");
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            _logger.LogWarning("Access denied: {Message}", LogSanitizer.Sanitize(ex.Message));
+            return ServiceResult<TenantMetadata>.Forbidden("Access denied: insufficient permissions");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error upserting metadata key {Key} for tenant {TenantId}", LogSanitizer.Sanitize(key), LogSanitizer.Sanitize(tenantId));
+            return ServiceResult<TenantMetadata>.InternalServerError("An error occurred while updating the tenant metadata.");
+        }
+    }
+
+    /// <summary>
+    /// Removes a single metadata entry by key (case-insensitive).
+    /// </summary>
+    public async Task<ServiceResult<bool>> DeleteTenantMetadata(string tenantId, string key)
+    {
+        try
+        {
+            tenantId = Tenant.SanitizeAndValidateTenantId(tenantId);
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                return ServiceResult<bool>.BadRequest("Metadata key is required");
+            }
+
+            var existingTenant = await _tenantRepository.GetByTenantIdAsync(tenantId);
+            if (existingTenant == null)
+            {
+                _logger.LogWarning("Tenant with tenant ID {TenantId} not found for metadata delete", LogSanitizer.Sanitize(tenantId));
+                return ServiceResult<bool>.NotFound("Tenant not found");
+            }
+
+            EnsureTenantAccessOrThrow(existingTenant.TenantId);
+
+            var removed = existingTenant.Metadata?.RemoveAll(
+                m => string.Equals(m.Key, key, StringComparison.OrdinalIgnoreCase)) ?? 0;
+            if (removed == 0)
+            {
+                _logger.LogWarning("Metadata key {Key} not found for tenant {TenantId}", LogSanitizer.Sanitize(key), LogSanitizer.Sanitize(tenantId));
+                return ServiceResult<bool>.NotFound("Metadata key not found");
+            }
+
+            var persistResult = await PersistTenantUpdate(existingTenant, existingTenant.Id);
+            if (!persistResult.IsSuccess)
+            {
+                return ServiceResult<bool>.Failure(
+                    persistResult.ErrorMessage ?? "Failed to update tenant metadata.", persistResult.StatusCode);
+            }
+
+            return ServiceResult<bool>.Success(true);
+        }
+        catch (ValidationException ex)
+        {
+            _logger.LogWarning("Validation failed while deleting tenant metadata: {Message}", LogSanitizer.Sanitize(ex.Message));
+            return ServiceResult<bool>.BadRequest($"Validation failed: {ex.Message}");
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            _logger.LogWarning("Access denied: {Message}", LogSanitizer.Sanitize(ex.Message));
+            return ServiceResult<bool>.Forbidden("Access denied: insufficient permissions");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error deleting metadata key {Key} for tenant {TenantId}", LogSanitizer.Sanitize(key), LogSanitizer.Sanitize(tenantId));
+            return ServiceResult<bool>.InternalServerError("An error occurred while deleting the tenant metadata.");
         }
     }
 
@@ -401,13 +629,16 @@ public class TenantService : ITenantService
                 Enabled = false,
                 CreatedBy = finalCreatedBy,
                 CreatedAt = DateTime.UtcNow,
-                UpdatedAt = DateTime.UtcNow
+                UpdatedAt = DateTime.UtcNow,
+                Metadata = request.Metadata
             };
             _logger.LogInformation("Tenant object created with CreatedBy: {CreatedBy}", LogSanitizer.Sanitize(tenant.CreatedBy));
-            
+
             var validatedTenant = tenant.SanitizeAndValidate();
             _logger.LogInformation("After sanitization, CreatedBy: {CreatedBy}", LogSanitizer.Sanitize(validatedTenant.CreatedBy));
 
+            // Persist with Secret metadata values encrypted.
+            validatedTenant.Metadata = _metadataProtector.Protect(validatedTenant.Metadata, validatedTenant.TenantId);
 
             await _tenantRepository.CreateAsync(validatedTenant);
             _logger.LogInformation("Created new tenant with ID {Id} and CreatedBy: {CreatedBy}", LogSanitizer.Sanitize(validatedTenant.Id), LogSanitizer.Sanitize(validatedTenant.CreatedBy));
@@ -485,6 +716,9 @@ public class TenantService : ITenantService
 
             if (request.Timezone != null)
                 existingTenant.Timezone = request.Timezone;
+
+            if (request.Metadata != null)
+                existingTenant.Metadata = _metadataProtector.Protect(request.Metadata, existingTenant.TenantId);
 
             var result = await PersistTenantUpdate(existingTenant, id);
 

--- a/XiansAi.Server.Tests/IntegrationTests/AdminApi/AdminTenantEndpointsTests.cs
+++ b/XiansAi.Server.Tests/IntegrationTests/AdminApi/AdminTenantEndpointsTests.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
 using Shared.Data.Models;
 using Xunit;
 using Tests.TestUtils;
@@ -264,5 +267,399 @@ public class AdminTenantEndpointsTests : AdminApiIntegrationTestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateTenant_WithMetadata_EncryptsSecretAtRest_AndNeverExposesItInTenantPayloads()
+    {
+        // Arrange
+        var tenantId = $"test-tenant-{Guid.NewGuid()}";
+        await ConfigureAdminApiClientAsync(tenantId);
+        await CreateTestTenantAsync(tenantId);
+
+        const string secretValue = "sk-super-secret-openai-key";
+        var newTenantId = $"new-tenant-{Guid.NewGuid()}";
+        var request = new
+        {
+            tenantId = newTenantId,
+            name = "Tenant With Metadata",
+            domain = $"{newTenantId}.test.com",
+            metadata = new[]
+            {
+                new { key = "OpenAiKey", value = secretValue, type = "Secret" },
+                new { key = "Region", value = "WestEurope", type = "PlainText" }
+            }
+        };
+
+        // Act
+        var response = await PostAsJsonAsync("/api/v1/admin/tenants", request);
+
+        // Assert - the create response never carries the decrypted secret
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.DoesNotContain(secretValue, content);
+        using var json = JsonDocument.Parse(content);
+        var metadata = json.RootElement.GetProperty("tenant").GetProperty("metadata");
+        Assert.Equal(2, metadata.GetArrayLength());
+        Assert.Equal("WestEurope", GetMetadataValue(metadata, "Region"));
+
+        // Assert - the stored document has the Secret value encrypted, PlainText verbatim
+        var stored = await GetStoredTenantAsync(newTenantId);
+        Assert.NotNull(stored.Metadata);
+        var storedSecret = stored.Metadata!.Single(m => m.Key == "OpenAiKey");
+        Assert.NotEqual(secretValue, storedSecret.Value);
+        Assert.Equal(MetadataType.Secret, storedSecret.Type);
+        var storedPlain = stored.Metadata!.Single(m => m.Key == "Region");
+        Assert.Equal("WestEurope", storedPlain.Value);
+        Assert.Equal(MetadataType.PlainText, storedPlain.Type);
+
+        // Assert - GET tenant never carries the decrypted secret either
+        var getResponse = await GetAsync($"/api/v1/admin/tenants/{newTenantId}");
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+        var getContent = await getResponse.Content.ReadAsStringAsync();
+        Assert.DoesNotContain(secretValue, getContent);
+    }
+
+    [Fact]
+    public async Task GetTenantMetadata_ReturnsDecryptedValues()
+    {
+        // Arrange
+        var tenantId = $"test-tenant-{Guid.NewGuid()}";
+        await ConfigureAdminApiClientAsync(tenantId);
+        await CreateTestTenantAsync(tenantId);
+
+        const string secretValue = "sk-super-secret-openai-key";
+        var newTenantId = $"new-tenant-{Guid.NewGuid()}";
+        var request = new
+        {
+            tenantId = newTenantId,
+            name = "Tenant With Metadata",
+            domain = $"{newTenantId}.test.com",
+            metadata = new[]
+            {
+                new { key = "OpenAiKey", value = secretValue, type = "Secret" },
+                new { key = "Region", value = "WestEurope", type = "PlainText" }
+            }
+        };
+        var createResponse = await PostAsJsonAsync("/api/v1/admin/tenants", request);
+        Assert.Equal(HttpStatusCode.OK, createResponse.StatusCode);
+
+        // Act - the dedicated metadata endpoint is the only place secrets are decrypted
+        var response = await GetAsync($"/api/v1/admin/tenants/{newTenantId}/metadata");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var metadata = await ReadAsJsonAsync<List<TenantMetadata>>(response);
+        Assert.NotNull(metadata);
+        Assert.Equal(2, metadata!.Count);
+        Assert.Equal(secretValue, metadata.Single(m => m.Key == "OpenAiKey").Value);
+        Assert.Equal(MetadataType.Secret, metadata.Single(m => m.Key == "OpenAiKey").Type);
+        Assert.Equal("WestEurope", metadata.Single(m => m.Key == "Region").Value);
+    }
+
+    [Fact]
+    public async Task GetTenantMetadataByKey_ReturnsDecryptedValue()
+    {
+        // Arrange
+        var tenantId = $"test-tenant-{Guid.NewGuid()}";
+        await ConfigureAdminApiClientAsync(tenantId);
+        await CreateTestTenantAsync(tenantId);
+
+        const string secretValue = "sk-super-secret-openai-key";
+        var request = new
+        {
+            metadata = new[]
+            {
+                new { key = "OpenAiKey", value = secretValue, type = "Secret" },
+                new { key = "Region", value = "WestEurope", type = "PlainText" }
+            }
+        };
+        var patchResponse = await PatchAsJsonAsync($"/api/v1/admin/tenants/{tenantId}", request);
+        Assert.Equal(HttpStatusCode.OK, patchResponse.StatusCode);
+
+        // Act - lookup is case-insensitive
+        var response = await GetAsync($"/api/v1/admin/tenants/{tenantId}/metadata/openaikey");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var entry = await ReadAsJsonAsync<TenantMetadata>(response);
+        Assert.NotNull(entry);
+        Assert.Equal("OpenAiKey", entry!.Key);
+        Assert.Equal(secretValue, entry.Value);
+        Assert.Equal(MetadataType.Secret, entry.Type);
+
+        // Act + Assert - PlainText entry comes back verbatim
+        var plainResponse = await GetAsync($"/api/v1/admin/tenants/{tenantId}/metadata/Region");
+        Assert.Equal(HttpStatusCode.OK, plainResponse.StatusCode);
+        var plainEntry = await ReadAsJsonAsync<TenantMetadata>(plainResponse);
+        Assert.Equal("WestEurope", plainEntry!.Value);
+    }
+
+    [Fact]
+    public async Task GetTenantMetadataByKey_WithUnknownKey_ReturnsNotFound()
+    {
+        // Arrange
+        var tenantId = $"test-tenant-{Guid.NewGuid()}";
+        await ConfigureAdminApiClientAsync(tenantId);
+        await CreateTestTenantAsync(tenantId);
+
+        // Act
+        var response = await GetAsync($"/api/v1/admin/tenants/{tenantId}/metadata/no-such-key");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpsertTenantMetadata_AddsNewSecretEntry()
+    {
+        // Arrange
+        var tenantId = $"test-tenant-{Guid.NewGuid()}";
+        await ConfigureAdminApiClientAsync(tenantId);
+        await CreateTestTenantAsync(tenantId);
+
+        const string secretValue = "sk-upserted-secret";
+        var request = new { value = secretValue, type = "Secret" };
+
+        // Act
+        var response = await PutAsJsonAsync($"/api/v1/admin/tenants/{tenantId}/metadata/OpenAiKey", request);
+
+        // Assert - response echoes the entry as provided
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var entry = await ReadAsJsonAsync<TenantMetadata>(response);
+        Assert.NotNull(entry);
+        Assert.Equal("OpenAiKey", entry!.Key);
+        Assert.Equal(secretValue, entry.Value);
+        Assert.Equal(MetadataType.Secret, entry.Type);
+
+        // Assert - stored encrypted
+        var stored = await GetStoredTenantAsync(tenantId);
+        var storedEntry = stored.Metadata!.Single(m => m.Key == "OpenAiKey");
+        Assert.NotEqual(secretValue, storedEntry.Value);
+
+        // Assert - dedicated endpoint decrypts it
+        var getResponse = await GetAsync($"/api/v1/admin/tenants/{tenantId}/metadata/OpenAiKey");
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+        var fetched = await ReadAsJsonAsync<TenantMetadata>(getResponse);
+        Assert.Equal(secretValue, fetched!.Value);
+    }
+
+    [Fact]
+    public async Task UpsertTenantMetadata_UpdatesExistingKey_AndPreservesOtherEntries()
+    {
+        // Arrange - seed two entries via PATCH
+        var tenantId = $"test-tenant-{Guid.NewGuid()}";
+        await ConfigureAdminApiClientAsync(tenantId);
+        await CreateTestTenantAsync(tenantId);
+
+        var seed = new
+        {
+            metadata = new[]
+            {
+                new { key = "OpenAiKey", value = "original-secret", type = "Secret" },
+                new { key = "Region", value = "WestEurope", type = "PlainText" }
+            }
+        };
+        var seedResponse = await PatchAsJsonAsync($"/api/v1/admin/tenants/{tenantId}", seed);
+        Assert.Equal(HttpStatusCode.OK, seedResponse.StatusCode);
+        var seededRegion = (await GetStoredTenantAsync(tenantId)).Metadata!.Single(m => m.Key == "Region");
+
+        // Act - update by key, case-insensitive, changing value and type
+        var request = new { value = "NorthEurope", type = "PlainText" };
+        var response = await PutAsJsonAsync($"/api/v1/admin/tenants/{tenantId}/metadata/region", request);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var stored = await GetStoredTenantAsync(tenantId);
+        Assert.Equal(2, stored.Metadata!.Count);
+        Assert.Equal("NorthEurope", stored.Metadata!.Single(m => string.Equals(m.Key, "region", StringComparison.OrdinalIgnoreCase)).Value);
+
+        // The untouched Secret entry keeps its exact stored ciphertext
+        var untouched = stored.Metadata!.Single(m => m.Key == "OpenAiKey");
+        Assert.NotEqual("original-secret", untouched.Value);
+        Assert.Equal(MetadataType.Secret, untouched.Type);
+    }
+
+    [Fact]
+    public async Task UpsertTenantMetadata_WithInvalidKey_ReturnsBadRequest()
+    {
+        // Arrange
+        var tenantId = $"test-tenant-{Guid.NewGuid()}";
+        await ConfigureAdminApiClientAsync(tenantId);
+        await CreateTestTenantAsync(tenantId);
+
+        var request = new { value = "some-value", type = "PlainText" };
+
+        // Act - key contains characters outside ^[a-zA-Z0-9._-]+$
+        var response = await PutAsJsonAsync($"/api/v1/admin/tenants/{tenantId}/metadata/bad%20key%21", request);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteTenantMetadata_RemovesEntry_AndPreservesOthers()
+    {
+        // Arrange
+        var tenantId = $"test-tenant-{Guid.NewGuid()}";
+        await ConfigureAdminApiClientAsync(tenantId);
+        await CreateTestTenantAsync(tenantId);
+
+        var seed = new
+        {
+            metadata = new[]
+            {
+                new { key = "OpenAiKey", value = "secret-to-delete", type = "Secret" },
+                new { key = "Region", value = "WestEurope", type = "PlainText" }
+            }
+        };
+        var seedResponse = await PatchAsJsonAsync($"/api/v1/admin/tenants/{tenantId}", seed);
+        Assert.Equal(HttpStatusCode.OK, seedResponse.StatusCode);
+
+        // Act - delete by key, case-insensitive
+        var response = await DeleteAsync($"/api/v1/admin/tenants/{tenantId}/metadata/openaikey");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var stored = await GetStoredTenantAsync(tenantId);
+        Assert.Single(stored.Metadata!);
+        Assert.Equal("Region", stored.Metadata![0].Key);
+
+        var getResponse = await GetAsync($"/api/v1/admin/tenants/{tenantId}/metadata/OpenAiKey");
+        Assert.Equal(HttpStatusCode.NotFound, getResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteTenantMetadata_WithUnknownKey_ReturnsNotFound()
+    {
+        // Arrange
+        var tenantId = $"test-tenant-{Guid.NewGuid()}";
+        await ConfigureAdminApiClientAsync(tenantId);
+        await CreateTestTenantAsync(tenantId);
+
+        // Act
+        var response = await DeleteAsync($"/api/v1/admin/tenants/{tenantId}/metadata/no-such-key");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetTenantMetadata_ForTenantWithoutMetadata_ReturnsEmptyList()
+    {
+        // Arrange
+        var tenantId = $"test-tenant-{Guid.NewGuid()}";
+        await ConfigureAdminApiClientAsync(tenantId);
+        await CreateTestTenantAsync(tenantId);
+
+        // Act
+        var response = await GetAsync($"/api/v1/admin/tenants/{tenantId}/metadata");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var metadata = await ReadAsJsonAsync<List<TenantMetadata>>(response);
+        Assert.NotNull(metadata);
+        Assert.Empty(metadata!);
+    }
+
+    [Fact]
+    public async Task UpdateTenant_WithMetadata_ReplacesIt_AndOmittingMetadataPreservesIt()
+    {
+        // Arrange
+        var tenantId = $"test-tenant-{Guid.NewGuid()}";
+        await ConfigureAdminApiClientAsync(tenantId);
+        await CreateTestTenantAsync(tenantId);
+
+        const string secretValue = "patched-secret-value";
+        var request = new
+        {
+            metadata = new[]
+            {
+                new { key = "OpenAiKey", value = secretValue, type = "Secret" }
+            }
+        };
+
+        // Act - PATCH with metadata
+        var response = await PatchAsJsonAsync($"/api/v1/admin/tenants/{tenantId}", request);
+
+        // Assert - the update response never carries the decrypted secret; stored value is encrypted
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var responseContent = await response.Content.ReadAsStringAsync();
+        Assert.DoesNotContain(secretValue, responseContent);
+
+        var stored = await GetStoredTenantAsync(tenantId);
+        Assert.NotNull(stored.Metadata);
+        Assert.NotEqual(secretValue, stored.Metadata!.Single(m => m.Key == "OpenAiKey").Value);
+
+        // Assert - the dedicated metadata endpoint returns the new value decrypted
+        var metadataResponse = await GetAsync($"/api/v1/admin/tenants/{tenantId}/metadata");
+        Assert.Equal(HttpStatusCode.OK, metadataResponse.StatusCode);
+        var decrypted = await ReadAsJsonAsync<List<TenantMetadata>>(metadataResponse);
+        Assert.NotNull(decrypted);
+        Assert.Equal(secretValue, decrypted!.Single(m => m.Key == "OpenAiKey").Value);
+
+        // Act - PATCH without metadata must preserve the existing metadata untouched
+        var nameOnlyResponse = await PatchAsJsonAsync($"/api/v1/admin/tenants/{tenantId}", new { name = "Renamed Tenant" });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, nameOnlyResponse.StatusCode);
+        var afterNameUpdate = await GetStoredTenantAsync(tenantId);
+        Assert.NotNull(afterNameUpdate.Metadata);
+        Assert.Equal(
+            stored.Metadata!.Single(m => m.Key == "OpenAiKey").Value,
+            afterNameUpdate.Metadata!.Single(m => m.Key == "OpenAiKey").Value);
+    }
+
+    [Fact]
+    public async Task CreateTenant_WithDuplicateMetadataKeys_ReturnsBadRequest()
+    {
+        // Arrange
+        var tenantId = $"test-tenant-{Guid.NewGuid()}";
+        await ConfigureAdminApiClientAsync(tenantId);
+        await CreateTestTenantAsync(tenantId);
+
+        var duplicateTenantId = $"new-tenant-{Guid.NewGuid()}";
+        var request = new
+        {
+            tenantId = duplicateTenantId,
+            name = "Tenant With Duplicate Metadata",
+            domain = $"{duplicateTenantId}.test.com",
+            metadata = new[]
+            {
+                new { key = "Region", value = "WestEurope", type = "PlainText" },
+                new { key = "region", value = "NorthEurope", type = "PlainText" }
+            }
+        };
+
+        // Act
+        var response = await PostAsJsonAsync("/api/v1/admin/tenants", request);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Reads the tenant document as persisted in MongoDB (bypassing the service layer decryption).
+    /// </summary>
+    private async Task<Tenant> GetStoredTenantAsync(string tenantId)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var tenantRepository = scope.ServiceProvider.GetRequiredService<Shared.Repositories.ITenantRepository>();
+        var tenant = await tenantRepository.GetByTenantIdAsync(tenantId);
+        Assert.NotNull(tenant);
+        return tenant!;
+    }
+
+    private static string? GetMetadataValue(JsonElement metadataArray, string key)
+    {
+        foreach (var item in metadataArray.EnumerateArray())
+        {
+            if (item.GetProperty("key").GetString() == key)
+            {
+                return item.GetProperty("value").GetString();
+            }
+        }
+        return null;
     }
 }

--- a/XiansAi.Server.Tests/UnitTests/Shared/Data/Models/TenantMetadataTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Shared/Data/Models/TenantMetadataTests.cs
@@ -1,0 +1,174 @@
+using System.ComponentModel.DataAnnotations;
+using MongoDB.Bson;
+using Shared.Data.Models;
+using Xunit;
+
+namespace Tests.UnitTests.Shared.Data.Models;
+
+public class TenantMetadataTests
+{
+    private static Tenant CreateValidTenant(List<TenantMetadata>? metadata = null)
+    {
+        return new Tenant
+        {
+            Id = ObjectId.GenerateNewId().ToString(),
+            TenantId = "test-tenant",
+            Name = "Test Tenant",
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = "unit-test",
+            Metadata = metadata
+        };
+    }
+
+    [Fact]
+    public void Type_DefaultsToPlainText()
+    {
+        var entry = new TenantMetadata { Key = "Region", Value = "WestEurope" };
+
+        Assert.Equal(MetadataType.PlainText, entry.Type);
+    }
+
+    [Theory]
+    [InlineData("bad key")]
+    [InlineData("bad!key")]
+    [InlineData("bad/key")]
+    public void Validate_WithInvalidKeyCharacters_Throws(string key)
+    {
+        var entry = new TenantMetadata { Key = key, Value = "v" };
+
+        Assert.Throws<ValidationException>(() => entry.Validate());
+    }
+
+    [Fact]
+    public void Validate_WithTooLongKey_Throws()
+    {
+        var entry = new TenantMetadata { Key = new string('a', 101), Value = "v" };
+
+        Assert.Throws<ValidationException>(() => entry.Validate());
+    }
+
+    [Fact]
+    public void Validate_WithValidEntry_Passes()
+    {
+        var entry = new TenantMetadata { Key = "Open-Ai.Key_1", Value = "any value at all!", Type = MetadataType.Secret };
+
+        entry.Validate();
+    }
+
+    [Fact]
+    public void SanitizeAndReturn_SanitizesKey_ButNeverTouchesValue()
+    {
+        // Value may be ciphertext or free text and must pass through byte-for-byte.
+        const string value = "  ci+pher/text==with $trange&chars\t ";
+        var entry = new TenantMetadata { Key = " OpenAiKey ", Value = value };
+
+        var sanitized = entry.SanitizeAndReturn();
+
+        Assert.Equal("OpenAiKey", sanitized.Key);
+        Assert.Equal(value, sanitized.Value);
+    }
+
+    [Fact]
+    public void Copy_ReturnsIndependentInstance()
+    {
+        var original = new TenantMetadata { Key = "OpenAiKey", Value = "original", Type = MetadataType.Secret };
+
+        var copy = original.Copy();
+        copy.Value = "mutated";
+        copy.Type = MetadataType.PlainText;
+
+        Assert.Equal("original", original.Value);
+        Assert.Equal(MetadataType.Secret, original.Type);
+    }
+
+    [Fact]
+    public void TenantValidate_WithDuplicateMetadataKeys_CaseInsensitive_Throws()
+    {
+        var tenant = CreateValidTenant(new List<TenantMetadata>
+        {
+            new() { Key = "Region", Value = "WestEurope" },
+            new() { Key = "region", Value = "NorthEurope" }
+        });
+
+        var ex = Assert.Throws<ValidationException>(() => tenant.Validate());
+        Assert.Contains("Duplicate metadata key", ex.Message);
+    }
+
+    [Fact]
+    public void TenantValidate_WithValidMetadata_Passes()
+    {
+        var tenant = CreateValidTenant(new List<TenantMetadata>
+        {
+            new() { Key = "OpenAiKey", Value = "sk-x", Type = MetadataType.Secret },
+            new() { Key = "Region", Value = "WestEurope" }
+        });
+
+        tenant.Validate();
+    }
+
+    [Fact]
+    public void TenantValidate_WithoutMetadata_Passes()
+    {
+        var tenant = CreateValidTenant(metadata: null);
+
+        tenant.Validate();
+    }
+
+    [Fact]
+    public void TenantValidate_WithInvalidMetadataEntry_Throws()
+    {
+        var tenant = CreateValidTenant(new List<TenantMetadata>
+        {
+            new() { Key = "invalid key!", Value = "v" }
+        });
+
+        Assert.Throws<ValidationException>(() => tenant.Validate());
+    }
+
+    [Fact]
+    public void ShallowCopy_DeepCopiesMetadata_SoCopyMutationDoesNotAffectOriginal()
+    {
+        // The cache returns ShallowCopy() results; callers must not be able to
+        // mutate cached metadata through the copy.
+        var tenant = CreateValidTenant(new List<TenantMetadata>
+        {
+            new() { Key = "OpenAiKey", Value = "ciphertext", Type = MetadataType.Secret }
+        });
+
+        var copy = tenant.ShallowCopy();
+        copy.Metadata![0].Value = "mutated";
+        copy.Metadata.Add(new TenantMetadata { Key = "Extra", Value = "x" });
+
+        Assert.Equal("ciphertext", tenant.Metadata![0].Value);
+        Assert.Single(tenant.Metadata);
+    }
+
+    [Fact]
+    public void ShallowCopy_WithNullMetadata_KeepsNull()
+    {
+        var tenant = CreateValidTenant(metadata: null);
+
+        var copy = tenant.ShallowCopy();
+
+        Assert.Null(copy.Metadata);
+    }
+
+    [Fact]
+    public void SanitizeAndReturn_CarriesMetadataThrough()
+    {
+        // SanitizeAndReturn enumerates properties manually; metadata must not be dropped
+        // (it is called on every create/update via SanitizeAndValidate).
+        var tenant = CreateValidTenant(new List<TenantMetadata>
+        {
+            new() { Key = "OpenAiKey", Value = "ciphertext", Type = MetadataType.Secret }
+        });
+
+        var sanitized = tenant.SanitizeAndReturn();
+
+        Assert.NotNull(sanitized.Metadata);
+        Assert.Single(sanitized.Metadata!);
+        Assert.Equal("OpenAiKey", sanitized.Metadata![0].Key);
+        Assert.Equal("ciphertext", sanitized.Metadata[0].Value);
+        Assert.Equal(MetadataType.Secret, sanitized.Metadata[0].Type);
+    }
+}

--- a/XiansAi.Server.Tests/UnitTests/Shared/Repositories/TenantRepositoryMetadataTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Shared/Repositories/TenantRepositoryMetadataTests.cs
@@ -1,0 +1,180 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Moq;
+using Shared.Data;
+using Shared.Data.Models;
+using Shared.Repositories;
+using Tests.TestUtils;
+using Xunit;
+
+namespace Tests.UnitTests.Shared.Repositories;
+
+/// <summary>
+/// DB-level tests for tenant metadata persistence: real MongoDB (ephemeral fixture),
+/// real TenantRepository. Verifies BSON round-trips and backward compatibility with
+/// documents that predate the metadata field.
+/// </summary>
+public class TenantRepositoryMetadataTests : IClassFixture<MongoDbFixture>
+{
+    private readonly IMongoCollection<Tenant> _collection;
+    private readonly IMongoCollection<BsonDocument> _rawCollection;
+    private readonly TenantRepository _repository;
+
+    public TenantRepositoryMetadataTests(MongoDbFixture fixture)
+    {
+        _collection = fixture.Database.GetCollection<Tenant>("tenants");
+        _rawCollection = fixture.Database.GetCollection<BsonDocument>("tenants");
+
+        var clientService = new Mock<IMongoDbClientService>();
+        clientService.Setup(x => x.GetCollection<Tenant>("tenants")).Returns(_collection);
+        _repository = new TenantRepository(clientService.Object, NullLogger<TenantRepository>.Instance);
+    }
+
+    private static Tenant NewTenant(string tenantId, List<TenantMetadata>? metadata = null)
+    {
+        return new Tenant
+        {
+            Id = ObjectId.GenerateNewId().ToString(),
+            TenantId = tenantId,
+            Name = $"Tenant {tenantId}",
+            Domain = $"{tenantId}.test.com",
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = "db-test",
+            Metadata = metadata
+        };
+    }
+
+    [Fact]
+    public async Task CreateAsync_PersistsMetadata_AndRoundTripsThroughGetByTenantId()
+    {
+        var tenantId = $"db-meta-{Guid.NewGuid()}";
+        var tenant = NewTenant(tenantId, new List<TenantMetadata>
+        {
+            new() { Key = "OpenAiKey", Value = "base64-ciphertext==", Type = MetadataType.Secret },
+            new() { Key = "Region", Value = "WestEurope", Type = MetadataType.PlainText }
+        });
+
+        await _repository.CreateAsync(tenant);
+        var fetched = await _repository.GetByTenantIdAsync(tenantId);
+
+        Assert.NotNull(fetched?.Metadata);
+        Assert.Equal(2, fetched!.Metadata!.Count);
+        var secret = fetched.Metadata!.Single(m => m.Key == "OpenAiKey");
+        Assert.Equal("base64-ciphertext==", secret.Value);
+        Assert.Equal(MetadataType.Secret, secret.Type);
+        Assert.Equal(MetadataType.PlainText, fetched.Metadata!.Single(m => m.Key == "Region").Type);
+    }
+
+    [Fact]
+    public async Task Metadata_IsStoredWithSnakeCaseFields_AndTypeAsString()
+    {
+        var tenantId = $"db-meta-{Guid.NewGuid()}";
+        await _repository.CreateAsync(NewTenant(tenantId, new List<TenantMetadata>
+        {
+            new() { Key = "OpenAiKey", Value = "cipher", Type = MetadataType.Secret }
+        }));
+
+        var raw = await _rawCollection.Find(new BsonDocument("tenant_id", tenantId)).FirstAsync();
+        var entry = raw["metadata"].AsBsonArray[0].AsBsonDocument;
+
+        Assert.Equal("OpenAiKey", entry["key"].AsString);
+        Assert.Equal("cipher", entry["value"].AsString);
+        // Enum must be stored as a readable string, not an int, for forward compatibility
+        Assert.Equal(BsonType.String, entry["type"].BsonType);
+        Assert.Equal("Secret", entry["type"].AsString);
+    }
+
+    [Fact]
+    public async Task LegacyDocument_WithoutMetadataField_DeserializesWithNullMetadata()
+    {
+        // Simulates a tenant document created before the metadata feature existed.
+        var tenantId = $"db-legacy-{Guid.NewGuid()}";
+        await _rawCollection.InsertOneAsync(new BsonDocument
+        {
+            ["_id"] = ObjectId.GenerateNewId(),
+            ["tenant_id"] = tenantId,
+            ["name"] = "Legacy Tenant",
+            ["domain"] = $"{tenantId}.test.com",
+            ["created_at"] = DateTime.UtcNow,
+            ["created_by"] = "db-test",
+            ["enabled"] = true
+        });
+
+        var fetched = await _repository.GetByTenantIdAsync(tenantId);
+
+        Assert.NotNull(fetched);
+        Assert.Null(fetched!.Metadata);
+    }
+
+    [Fact]
+    public async Task Document_WithUnknownExtraFields_StillDeserializes()
+    {
+        // Simulates rollback safety in reverse: a newer schema's extra fields must not
+        // break this version's deserialization ([BsonIgnoreExtraElements]).
+        var tenantId = $"db-extra-{Guid.NewGuid()}";
+        await _rawCollection.InsertOneAsync(new BsonDocument
+        {
+            ["_id"] = ObjectId.GenerateNewId(),
+            ["tenant_id"] = tenantId,
+            ["name"] = "Future Tenant",
+            ["domain"] = $"{tenantId}.test.com",
+            ["created_at"] = DateTime.UtcNow,
+            ["created_by"] = "db-test",
+            ["enabled"] = true,
+            ["metadata"] = new BsonArray
+            {
+                new BsonDocument { ["key"] = "K", ["value"] = "V", ["type"] = "PlainText" }
+            },
+            ["some_future_field"] = "ignored"
+        });
+
+        var fetched = await _repository.GetByTenantIdAsync(tenantId);
+
+        Assert.NotNull(fetched);
+        Assert.Single(fetched!.Metadata!);
+        Assert.Equal("K", fetched.Metadata![0].Key);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ReplacesMetadata()
+    {
+        var tenantId = $"db-update-{Guid.NewGuid()}";
+        var tenant = NewTenant(tenantId, new List<TenantMetadata>
+        {
+            new() { Key = "Region", Value = "WestEurope", Type = MetadataType.PlainText }
+        });
+        await _repository.CreateAsync(tenant);
+
+        tenant.Metadata = new List<TenantMetadata>
+        {
+            new() { Key = "Region", Value = "NorthEurope", Type = MetadataType.PlainText },
+            new() { Key = "OpenAiKey", Value = "cipher", Type = MetadataType.Secret }
+        };
+        var updated = await _repository.UpdateAsync(tenant.Id, tenant);
+
+        Assert.True(updated);
+        var fetched = await _repository.GetByTenantIdAsync(tenantId);
+        Assert.Equal(2, fetched!.Metadata!.Count);
+        Assert.Equal("NorthEurope", fetched.Metadata!.Single(m => m.Key == "Region").Value);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_CanClearMetadata()
+    {
+        var tenantId = $"db-clear-{Guid.NewGuid()}";
+        var tenant = NewTenant(tenantId, new List<TenantMetadata>
+        {
+            new() { Key = "Region", Value = "WestEurope", Type = MetadataType.PlainText }
+        });
+        await _repository.CreateAsync(tenant);
+
+        tenant.Metadata = null;
+        var updated = await _repository.UpdateAsync(tenant.Id, tenant);
+
+        Assert.True(updated);
+        var fetched = await _repository.GetByTenantIdAsync(tenantId);
+        Assert.NotNull(fetched);
+        Assert.Null(fetched!.Metadata);
+    }
+}

--- a/XiansAi.Server.Tests/UnitTests/Shared/Services/TenantMetadataProtectorTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Shared/Services/TenantMetadataProtectorTests.cs
@@ -1,0 +1,144 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shared.Data.Models;
+using Shared.Services;
+using Xunit;
+
+namespace Tests.UnitTests.Shared.Services;
+
+public class TenantMetadataProtectorTests
+{
+    private const string BaseSecret = "unit-test-base-secret-min-32-chars-padding-padding";
+    private const string TenantId = "test-tenant";
+
+    private readonly TenantMetadataProtector _protector;
+
+    public TenantMetadataProtectorTests()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["EncryptionKeys:BaseSecret"] = BaseSecret
+            })
+            .Build();
+        var encryption = new SecureEncryptionService(NullLogger<SecureEncryptionService>.Instance, configuration);
+        _protector = new TenantMetadataProtector(encryption);
+    }
+
+    [Fact]
+    public void Protect_EncryptsSecretValues_AndUnprotectRoundTrips()
+    {
+        var metadata = new List<TenantMetadata>
+        {
+            new() { Key = "OpenAiKey", Value = "sk-super-secret", Type = MetadataType.Secret }
+        };
+
+        var protectedList = _protector.Protect(metadata, TenantId);
+
+        Assert.NotNull(protectedList);
+        Assert.NotEqual("sk-super-secret", protectedList[0].Value);
+        // Ciphertext is base64 (nonce | tag | cipher)
+        Assert.NotEmpty(Convert.FromBase64String(protectedList[0].Value));
+
+        var unprotectedList = _protector.Unprotect(protectedList, TenantId);
+
+        Assert.NotNull(unprotectedList);
+        Assert.Equal("sk-super-secret", unprotectedList[0].Value);
+        Assert.Equal("OpenAiKey", unprotectedList[0].Key);
+        Assert.Equal(MetadataType.Secret, unprotectedList[0].Type);
+    }
+
+    [Fact]
+    public void Protect_LeavesPlainTextValuesUntouched()
+    {
+        var metadata = new List<TenantMetadata>
+        {
+            new() { Key = "Region", Value = "WestEurope", Type = MetadataType.PlainText }
+        };
+
+        var protectedList = _protector.Protect(metadata, TenantId);
+
+        Assert.NotNull(protectedList);
+        Assert.Equal("WestEurope", protectedList[0].Value);
+    }
+
+    [Fact]
+    public void Protect_DoesNotMutateInputList()
+    {
+        var item = new TenantMetadata { Key = "OpenAiKey", Value = "sk-super-secret", Type = MetadataType.Secret };
+        var metadata = new List<TenantMetadata> { item };
+
+        _protector.Protect(metadata, TenantId);
+
+        Assert.Equal("sk-super-secret", item.Value);
+    }
+
+    [Fact]
+    public void ProtectAndUnprotect_PassThroughNullAndEmptyLists()
+    {
+        Assert.Null(_protector.Protect(null, TenantId));
+        Assert.Null(_protector.Unprotect(null, TenantId));
+
+        var empty = new List<TenantMetadata>();
+        Assert.Same(empty, _protector.Protect(empty, TenantId));
+        Assert.Same(empty, _protector.Unprotect(empty, TenantId));
+    }
+
+    [Fact]
+    public void Unprotect_WithWrongTenantId_Throws_WithoutLeakingValue()
+    {
+        var metadata = new List<TenantMetadata>
+        {
+            new() { Key = "OpenAiKey", Value = "sk-super-secret", Type = MetadataType.Secret }
+        };
+        var protectedList = _protector.Protect(metadata, TenantId);
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => _protector.Unprotect(protectedList, "another-tenant"));
+
+        Assert.Contains("OpenAiKey", ex.Message);
+        Assert.DoesNotContain("sk-super-secret", ex.Message);
+        Assert.DoesNotContain(protectedList![0].Value, ex.Message);
+    }
+
+    [Fact]
+    public void Unprotect_WithCorruptedCiphertext_Throws_WithoutLeakingValue()
+    {
+        var metadata = new List<TenantMetadata>
+        {
+            new() { Key = "OpenAiKey", Value = "not-a-valid-ciphertext", Type = MetadataType.Secret }
+        };
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => _protector.Unprotect(metadata, TenantId));
+
+        Assert.Contains("OpenAiKey", ex.Message);
+        Assert.DoesNotContain("not-a-valid-ciphertext", ex.Message);
+    }
+
+    [Fact]
+    public void Protect_WithEmptySecretValue_RoundTrips()
+    {
+        var metadata = new List<TenantMetadata>
+        {
+            new() { Key = "EmptySecret", Value = string.Empty, Type = MetadataType.Secret }
+        };
+
+        var protectedList = _protector.Protect(metadata, TenantId);
+        Assert.NotEqual(string.Empty, protectedList![0].Value);
+
+        var unprotectedList = _protector.Unprotect(protectedList, TenantId);
+        Assert.Equal(string.Empty, unprotectedList![0].Value);
+    }
+
+    [Fact]
+    public void Protect_WithoutTenantId_Throws()
+    {
+        var metadata = new List<TenantMetadata>
+        {
+            new() { Key = "OpenAiKey", Value = "sk-super-secret", Type = MetadataType.Secret }
+        };
+
+        Assert.Throws<ArgumentException>(() => _protector.Protect(metadata, ""));
+    }
+}

--- a/XiansAi.Server.Tests/UnitTests/Shared/Services/TenantServiceMetadataTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Shared/Services/TenantServiceMetadataTests.cs
@@ -1,0 +1,387 @@
+using Features.WebApi.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using MongoDB.Bson;
+using Moq;
+using Shared.Auth;
+using Shared.Data.Models;
+using Shared.Repositories;
+using Shared.Services;
+using Shared.Utils.Services;
+using Xunit;
+
+namespace Tests.UnitTests.Shared.Services;
+
+/// <summary>
+/// Unit tests for the metadata-related logic in TenantService. Repository, cache and
+/// context are mocked; encryption uses the real TenantMetadataProtector +
+/// SecureEncryptionService so ciphertext behavior is genuine.
+/// </summary>
+public class TenantServiceMetadataTests
+{
+    private const string BaseSecret = "unit-test-base-secret-min-32-chars-padding-padding";
+    private const string TenantId = "test-tenant";
+    private const string SecretValue = "sk-super-secret";
+
+    private readonly Mock<ITenantRepository> _repo = new();
+    private readonly Mock<ITenantCacheService> _cache = new();
+    private readonly Mock<ITenantContext> _context = new();
+    private readonly Mock<IRoleManagementService> _roles = new();
+    private readonly Mock<IWebhookEventPublisher> _webhooks = new();
+    private readonly TenantMetadataProtector _protector;
+    private readonly TenantService _service;
+
+    public TenantServiceMetadataTests()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["EncryptionKeys:BaseSecret"] = BaseSecret
+            })
+            .Build();
+        _protector = new TenantMetadataProtector(
+            new SecureEncryptionService(NullLogger<SecureEncryptionService>.Instance, configuration));
+
+        _context.Setup(x => x.UserRoles).Returns(new[] { SystemRoles.SysAdmin });
+        _context.Setup(x => x.AuthorizedTenantIds).Returns(new List<string> { TenantId });
+        _context.Setup(x => x.TenantId).Returns(TenantId);
+        _context.Setup(x => x.LoggedInUser).Returns("unit-test-admin");
+
+        _repo.Setup(x => x.CreateAsync(It.IsAny<Tenant>())).Returns(Task.CompletedTask);
+        _repo.Setup(x => x.UpdateAsync(It.IsAny<string>(), It.IsAny<Tenant>())).ReturnsAsync(true);
+        _webhooks.Setup(x => x.PublishAsync(It.IsAny<string>(), It.IsAny<object?>(), It.IsAny<string?>()))
+            .Returns(Task.CompletedTask);
+
+        _service = new TenantService(
+            _repo.Object,
+            _cache.Object,
+            NullLogger<TenantService>.Instance,
+            _context.Object,
+            _roles.Object,
+            _webhooks.Object,
+            _protector);
+    }
+
+    private static Tenant CreateStoredTenant(List<TenantMetadata>? metadata = null)
+    {
+        return new Tenant
+        {
+            Id = ObjectId.GenerateNewId().ToString(),
+            TenantId = TenantId,
+            Name = "Test Tenant",
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = "unit-test-admin",
+            Metadata = metadata
+        };
+    }
+
+    private List<TenantMetadata> EncryptedMetadata(params TenantMetadata[] entries)
+        => _protector.Protect(entries.ToList(), TenantId)!;
+
+    // ---------- CreateTenant ----------
+
+    [Fact]
+    public async Task CreateTenant_WithSecretMetadata_PersistsEncryptedValue_AndPlainTextVerbatim()
+    {
+        Tenant? persisted = null;
+        _repo.Setup(x => x.CreateAsync(It.IsAny<Tenant>()))
+            .Callback<Tenant>(t => persisted = t)
+            .Returns(Task.CompletedTask);
+
+        var result = await _service.CreateTenant(new CreateTenantRequest
+        {
+            TenantId = TenantId,
+            Name = "Test Tenant",
+            Metadata = new List<TenantMetadata>
+            {
+                new() { Key = "OpenAiKey", Value = SecretValue, Type = MetadataType.Secret },
+                new() { Key = "Region", Value = "WestEurope", Type = MetadataType.PlainText }
+            }
+        });
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(persisted?.Metadata);
+        var storedSecret = persisted!.Metadata!.Single(m => m.Key == "OpenAiKey");
+        Assert.NotEqual(SecretValue, storedSecret.Value);
+        Assert.Equal(SecretValue, _protector.Unprotect(new List<TenantMetadata> { storedSecret }, TenantId)![0].Value);
+        Assert.Equal("WestEurope", persisted.Metadata!.Single(m => m.Key == "Region").Value);
+    }
+
+    [Fact]
+    public async Task CreateTenant_ResponseNeverCarriesPlaintextSecret()
+    {
+        var result = await _service.CreateTenant(new CreateTenantRequest
+        {
+            TenantId = TenantId,
+            Name = "Test Tenant",
+            Metadata = new List<TenantMetadata>
+            {
+                new() { Key = "OpenAiKey", Value = SecretValue, Type = MetadataType.Secret }
+            }
+        });
+
+        Assert.True(result.IsSuccess);
+        Assert.NotEqual(SecretValue, result.Data!.Tenant.Metadata!.Single().Value);
+    }
+
+    [Fact]
+    public async Task CreateTenant_WithoutMetadata_PersistsNullMetadata()
+    {
+        Tenant? persisted = null;
+        _repo.Setup(x => x.CreateAsync(It.IsAny<Tenant>()))
+            .Callback<Tenant>(t => persisted = t)
+            .Returns(Task.CompletedTask);
+
+        var result = await _service.CreateTenant(new CreateTenantRequest
+        {
+            TenantId = TenantId,
+            Name = "Test Tenant"
+        });
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(persisted);
+        Assert.Null(persisted!.Metadata);
+    }
+
+    [Fact]
+    public async Task CreateTenant_WithDuplicateMetadataKeys_ReturnsBadRequest()
+    {
+        var result = await _service.CreateTenant(new CreateTenantRequest
+        {
+            TenantId = TenantId,
+            Name = "Test Tenant",
+            Metadata = new List<TenantMetadata>
+            {
+                new() { Key = "Region", Value = "a" },
+                new() { Key = "region", Value = "b" }
+            }
+        });
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(StatusCode.BadRequest, result.StatusCode);
+        _repo.Verify(x => x.CreateAsync(It.IsAny<Tenant>()), Times.Never);
+    }
+
+    // ---------- UpdateTenant ----------
+
+    [Fact]
+    public async Task UpdateTenant_WithMetadata_EncryptsBeforePersist()
+    {
+        var stored = CreateStoredTenant();
+        _repo.Setup(x => x.GetByIdAsync(stored.Id)).ReturnsAsync(stored);
+        Tenant? persisted = null;
+        _repo.Setup(x => x.UpdateAsync(stored.Id, It.IsAny<Tenant>()))
+            .Callback<string, Tenant>((_, t) => persisted = t)
+            .ReturnsAsync(true);
+
+        var result = await _service.UpdateTenant(stored.Id, new UpdateTenantRequest
+        {
+            Metadata = new List<TenantMetadata>
+            {
+                new() { Key = "OpenAiKey", Value = SecretValue, Type = MetadataType.Secret }
+            }
+        });
+
+        Assert.True(result.IsSuccess);
+        Assert.NotEqual(SecretValue, persisted!.Metadata!.Single().Value);
+    }
+
+    [Fact]
+    public async Task UpdateTenant_WithoutMetadata_PreservesStoredCiphertextUnchanged()
+    {
+        var encrypted = EncryptedMetadata(new TenantMetadata { Key = "OpenAiKey", Value = SecretValue, Type = MetadataType.Secret });
+        var originalCiphertext = encrypted[0].Value;
+        var stored = CreateStoredTenant(encrypted);
+        _repo.Setup(x => x.GetByIdAsync(stored.Id)).ReturnsAsync(stored);
+        Tenant? persisted = null;
+        _repo.Setup(x => x.UpdateAsync(stored.Id, It.IsAny<Tenant>()))
+            .Callback<string, Tenant>((_, t) => persisted = t)
+            .ReturnsAsync(true);
+
+        var result = await _service.UpdateTenant(stored.Id, new UpdateTenantRequest { Name = "Renamed" });
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(originalCiphertext, persisted!.Metadata!.Single().Value);
+    }
+
+    // ---------- GetTenantMetadata ----------
+
+    [Fact]
+    public async Task GetTenantMetadata_DecryptsSecret_AndReturnsPlainTextVerbatim()
+    {
+        var stored = CreateStoredTenant(EncryptedMetadata(
+            new TenantMetadata { Key = "OpenAiKey", Value = SecretValue, Type = MetadataType.Secret },
+            new TenantMetadata { Key = "Region", Value = "WestEurope", Type = MetadataType.PlainText }));
+        _cache.Setup(x => x.GetByTenantIdAsync(TenantId, It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+            .ReturnsAsync(stored);
+
+        var result = await _service.GetTenantMetadata(TenantId);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(SecretValue, result.Data!.Single(m => m.Key == "OpenAiKey").Value);
+        Assert.Equal("WestEurope", result.Data!.Single(m => m.Key == "Region").Value);
+    }
+
+    [Fact]
+    public async Task GetTenantMetadata_WithoutMetadata_ReturnsEmptyList()
+    {
+        _cache.Setup(x => x.GetByTenantIdAsync(TenantId, It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+            .ReturnsAsync(CreateStoredTenant());
+
+        var result = await _service.GetTenantMetadata(TenantId);
+
+        Assert.True(result.IsSuccess);
+        Assert.Empty(result.Data!);
+    }
+
+    [Fact]
+    public async Task GetTenantMetadata_UnknownTenant_ReturnsNotFound()
+    {
+        _cache.Setup(x => x.GetByTenantIdAsync(TenantId, It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+            .ReturnsAsync((Tenant?)null);
+
+        var result = await _service.GetTenantMetadata(TenantId);
+
+        Assert.Equal(StatusCode.NotFound, result.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetTenantMetadata_ForUnauthorizedTenant_ReturnsForbidden()
+    {
+        _context.Setup(x => x.AuthorizedTenantIds).Returns(new List<string>());
+
+        var result = await _service.GetTenantMetadata(TenantId);
+
+        Assert.Equal(StatusCode.Forbidden, result.StatusCode);
+        _cache.Verify(x => x.GetByTenantIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()), Times.Never);
+    }
+
+    // ---------- GetTenantMetadataByKey ----------
+
+    [Fact]
+    public async Task GetTenantMetadataByKey_IsCaseInsensitive_AndDecrypts()
+    {
+        var stored = CreateStoredTenant(EncryptedMetadata(
+            new TenantMetadata { Key = "OpenAiKey", Value = SecretValue, Type = MetadataType.Secret }));
+        _cache.Setup(x => x.GetByTenantIdAsync(TenantId, It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+            .ReturnsAsync(stored);
+
+        var result = await _service.GetTenantMetadataByKey(TenantId, "openaikey");
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("OpenAiKey", result.Data!.Key);
+        Assert.Equal(SecretValue, result.Data.Value);
+    }
+
+    [Fact]
+    public async Task GetTenantMetadataByKey_UnknownKey_ReturnsNotFound()
+    {
+        _cache.Setup(x => x.GetByTenantIdAsync(TenantId, It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+            .ReturnsAsync(CreateStoredTenant());
+
+        var result = await _service.GetTenantMetadataByKey(TenantId, "missing");
+
+        Assert.Equal(StatusCode.NotFound, result.StatusCode);
+    }
+
+    // ---------- UpsertTenantMetadata ----------
+
+    [Fact]
+    public async Task UpsertTenantMetadata_AddsNewEntry_EncryptedAtRest()
+    {
+        var stored = CreateStoredTenant();
+        _repo.Setup(x => x.GetByTenantIdAsync(TenantId)).ReturnsAsync(stored);
+        Tenant? persisted = null;
+        _repo.Setup(x => x.UpdateAsync(stored.Id, It.IsAny<Tenant>()))
+            .Callback<string, Tenant>((_, t) => persisted = t)
+            .ReturnsAsync(true);
+
+        var result = await _service.UpsertTenantMetadata(TenantId, "OpenAiKey",
+            new UpsertTenantMetadataRequest { Value = SecretValue, Type = MetadataType.Secret });
+
+        Assert.True(result.IsSuccess);
+        // Response echoes the plaintext entry (metadata endpoints are the decrypted surface)
+        Assert.Equal(SecretValue, result.Data!.Value);
+        // Persisted value is ciphertext
+        Assert.NotEqual(SecretValue, persisted!.Metadata!.Single().Value);
+    }
+
+    [Fact]
+    public async Task UpsertTenantMetadata_ReplacesExistingKey_CaseInsensitive()
+    {
+        var stored = CreateStoredTenant(new List<TenantMetadata>
+        {
+            new() { Key = "Region", Value = "WestEurope", Type = MetadataType.PlainText }
+        });
+        _repo.Setup(x => x.GetByTenantIdAsync(TenantId)).ReturnsAsync(stored);
+        Tenant? persisted = null;
+        _repo.Setup(x => x.UpdateAsync(stored.Id, It.IsAny<Tenant>()))
+            .Callback<string, Tenant>((_, t) => persisted = t)
+            .ReturnsAsync(true);
+
+        var result = await _service.UpsertTenantMetadata(TenantId, "region",
+            new UpsertTenantMetadataRequest { Value = "NorthEurope" });
+
+        Assert.True(result.IsSuccess);
+        Assert.Single(persisted!.Metadata!);
+        Assert.Equal("NorthEurope", persisted.Metadata![0].Value);
+    }
+
+    [Fact]
+    public async Task UpsertTenantMetadata_WithInvalidKey_ReturnsBadRequest_WithoutPersisting()
+    {
+        var stored = CreateStoredTenant();
+        _repo.Setup(x => x.GetByTenantIdAsync(TenantId)).ReturnsAsync(stored);
+
+        var result = await _service.UpsertTenantMetadata(TenantId, "bad key!",
+            new UpsertTenantMetadataRequest { Value = "v" });
+
+        Assert.Equal(StatusCode.BadRequest, result.StatusCode);
+        _repo.Verify(x => x.UpdateAsync(It.IsAny<string>(), It.IsAny<Tenant>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpsertTenantMetadata_UnknownTenant_ReturnsNotFound()
+    {
+        _repo.Setup(x => x.GetByTenantIdAsync(TenantId)).ReturnsAsync((Tenant?)null);
+
+        var result = await _service.UpsertTenantMetadata(TenantId, "OpenAiKey",
+            new UpsertTenantMetadataRequest { Value = "v" });
+
+        Assert.Equal(StatusCode.NotFound, result.StatusCode);
+    }
+
+    // ---------- DeleteTenantMetadata ----------
+
+    [Fact]
+    public async Task DeleteTenantMetadata_RemovesEntry_CaseInsensitive_AndPreservesOthers()
+    {
+        var stored = CreateStoredTenant(new List<TenantMetadata>
+        {
+            new() { Key = "OpenAiKey", Value = "cipher", Type = MetadataType.Secret },
+            new() { Key = "Region", Value = "WestEurope", Type = MetadataType.PlainText }
+        });
+        _repo.Setup(x => x.GetByTenantIdAsync(TenantId)).ReturnsAsync(stored);
+        Tenant? persisted = null;
+        _repo.Setup(x => x.UpdateAsync(stored.Id, It.IsAny<Tenant>()))
+            .Callback<string, Tenant>((_, t) => persisted = t)
+            .ReturnsAsync(true);
+
+        var result = await _service.DeleteTenantMetadata(TenantId, "openaikey");
+
+        Assert.True(result.IsSuccess);
+        Assert.Single(persisted!.Metadata!);
+        Assert.Equal("Region", persisted.Metadata![0].Key);
+    }
+
+    [Fact]
+    public async Task DeleteTenantMetadata_UnknownKey_ReturnsNotFound_WithoutPersisting()
+    {
+        _repo.Setup(x => x.GetByTenantIdAsync(TenantId)).ReturnsAsync(CreateStoredTenant());
+
+        var result = await _service.DeleteTenantMetadata(TenantId, "missing");
+
+        Assert.Equal(StatusCode.NotFound, result.StatusCode);
+        _repo.Verify(x => x.UpdateAsync(It.IsAny<string>(), It.IsAny<Tenant>()), Times.Never);
+    }
+}


### PR DESCRIPTION
Add an optional metadata list (key/value/type) to the Tenant collection with encrypted-at-rest secret values, fully backward compatible with existing documents and API contracts.

- Add TenantMetadata model and MetadataType enum (PlainText, Secret) to the Tenant document, with validation, duplicate-key rejection, and deep-copy/sanitize wiring
- Add TenantMetadataProtector, reusing the existing AES-256-GCM SecureEncryptionService (EncryptionKeys:BaseSecret) with the immutable TenantId as the per-tenant unique secret; no new keys or config
- Encrypt Secret values on create/update; DB and cache only ever hold ciphertext, and general tenant payloads never expose decrypted values
- Add SysAdmin-only AdminApi endpoints as the sole decrypted surface:
  GET    /api/v1/admin/tenants/{tenantId}/metadata
  GET    /api/v1/admin/tenants/{tenantId}/metadata/{key}
  PUT    /api/v1/admin/tenants/{tenantId}/metadata/{key}
  DELETE /api/v1/admin/tenants/{tenantId}/metadata/{key}
- Accept optional metadata in create (POST) and update (PUT/PATCH)
  tenant requests; omitted metadata preserves stored entries untouched
- Add 47 unit tests (protector, model, service, repository/DB) and 15
  integration tests; legacy documents without metadata deserialize
  unchanged