### PR TITLE
feat(api): add error count to log stream summary

### DIFF
--- a/XiansAi.Server.Src/Features/AdminApi/Endpoints/AdminLogsService.md
+++ b/XiansAi.Server.Src/Features/AdminApi/Endpoints/AdminLogsService.md
@@ -132,7 +132,8 @@ Lists distinct log streams (a stream = a unique `workflow_id`) for a tenant, sor
       "firstLogAt": "2025-01-25T10:00:00Z",
       "logCount": 42,
       "lastLogLevel": "Information",
-      "lastLogMessage": "Task processing completed"
+      "lastLogMessage": "Task processing completed",
+      "errorCount": 3
     }
   ],
   "totalCount": 35,
@@ -141,6 +142,13 @@ Lists distinct log streams (a stream = a unique `workflow_id`) for a tenant, sor
   "totalPages": 2
 }
 ```
+
+**Stream Object Fields:**
+- `workflowId`, `workflowType`, `workflowRunId`, `agent`, `activation`, `participantId`: Identity of the stream (taken from the most recent log in the group).
+- `lastLogAt` / `firstLogAt`: Time range covered by the stream.
+- `logCount`: Total number of logs in the stream (after filters are applied).
+- `lastLogLevel` / `lastLogMessage`: Level and message of the most recent log.
+- `errorCount`: Number of `Error` + `Critical` level logs in the stream. Lets clients flag streams that contain errors anywhere in their history, even when the latest log is not an error. `0` means the stream has no errors.
 
 ### Implementation Details
 

--- a/XiansAi.Server.Src/Features/WebApi/Repositories/LogRepository.cs
+++ b/XiansAi.Server.Src/Features/WebApi/Repositories/LogRepository.cs
@@ -74,6 +74,13 @@ public class LogStreamSummary
     public required long LogCount { get; set; }
     public required LogLevel LastLogLevel { get; set; }
     public required string LastLogMessage { get; set; }
+
+    /// <summary>
+    /// Number of Error/Critical level logs in this stream. Lets the UI flag streams
+    /// that contain errors anywhere in their history - not only when the latest log
+    /// happens to be an error.
+    /// </summary>
+    public required long ErrorCount { get; set; }
 }
 
 public class LogRepository : ILogRepository
@@ -418,7 +425,10 @@ public class LogRepository : ILogRepository
                 FirstLogAt = g.Last().CreatedAt,
                 LogCount = g.LongCount(),
                 LastLogLevel = g.First().Level,
-                LastLogMessage = g.First().Message
+                LastLogMessage = g.First().Message,
+                // Count Error + Critical logs so streams with any errors can be flagged
+                // for attention, independent of what the most recent log level is.
+                ErrorCount = g.Sum(x => x.Level == LogLevel.Error || x.Level == LogLevel.Critical ? 1L : 0L)
             });
 
         // Count distinct streams for pagination metadata before applying skip/limit.

--- a/XiansAi.Server.Src/Shared/Services/AdminLogsService.cs
+++ b/XiansAi.Server.Src/Shared/Services/AdminLogsService.cs
@@ -33,6 +33,12 @@ public class AdminLogStream
     public required long LogCount { get; set; }
     public required LogLevel LastLogLevel { get; set; }
     public required string LastLogMessage { get; set; }
+
+    /// <summary>
+    /// Number of Error/Critical level logs in this stream. Allows clients to mark
+    /// streams that contain errors for attention, even when the latest log is not an error.
+    /// </summary>
+    public required long ErrorCount { get; set; }
 }
 
 /// <summary>
@@ -291,6 +297,7 @@ public class AdminLogsService : IAdminLogsService
         FirstLogAt = s.FirstLogAt,
         LogCount = s.LogCount,
         LastLogLevel = s.LastLogLevel,
-        LastLogMessage = s.LastLogMessage
+        LastLogMessage = s.LastLogMessage,
+        ErrorCount = s.ErrorCount
     };
 }


### PR DESCRIPTION
- Enhanced the log stream summary to include an `ErrorCount` field, which counts the number of `Error` and `Critical` level logs in a stream. This allows clients to identify streams with any errors in their history, improving error management.
- Updated the `AdminLogsService`, `LogRepository`, and documentation to reflect this new field and its purpose.

These changes enhance the API's usability by providing more detailed log stream information.