### PR TITLE
feat(api): implement case-insensitive tenant ID handling

### DIFF
--- a/XiansAi.Server.Src/Features/AdminApi/Services/BootstrapService.cs
+++ b/XiansAi.Server.Src/Features/AdminApi/Services/BootstrapService.cs
@@ -94,11 +94,14 @@ public class BootstrapService : IBootstrapService
 
             // 4. Ensure an enabled tenant exists
             var tenantResult = await EnsureEnabledTenantAsync(resolvedTenantId, email);
-            if (!tenantResult.IsSuccess)
+            if (!tenantResult.IsSuccess || tenantResult.Data == null)
             {
                 return ServiceResult<BootstrapResponse>.Failure(
                     tenantResult.ErrorMessage ?? "Failed to ensure tenant", tenantResult.StatusCode);
             }
+
+            // Use the stored tenant id: an existing tenant may match the requested id with different casing.
+            resolvedTenantId = tenantResult.Data.TenantId;
 
             // 5. Create the SysAdmin user (CreateNewUser sets IsSysAdmin = true because no users exist)
             var createUserResult = await _userManagementService.CreateNewUser(new UserDto
@@ -175,7 +178,9 @@ public class BootstrapService : IBootstrapService
                 return ServiceResult<Tenant>.BadRequest(ex.Message);
             }
 
-            var existingTenant = await _tenantRepository.GetByTenantIdAsync(sanitizedTenantId);
+            // Case-insensitive lookup so bootstrap reuses e.g. "default" when asked for "Default"
+            // instead of creating a duplicate tenant that differs only in case.
+            var existingTenant = await _tenantRepository.GetByTenantIdCaseInsensitiveAsync(sanitizedTenantId);
             if (existingTenant != null)
             {
                 if (!existingTenant.Enabled)

--- a/XiansAi.Server.Src/Shared/Repositories/TenantRepository.cs
+++ b/XiansAi.Server.Src/Shared/Repositories/TenantRepository.cs
@@ -10,6 +10,7 @@ public interface ITenantRepository
 {
     Task<Tenant> GetByIdAsync(string id, CancellationToken cancellationToken = default);
     Task<Tenant> GetByTenantIdAsync(string tenantId, CancellationToken cancellationToken = default);
+    Task<Tenant> GetByTenantIdCaseInsensitiveAsync(string tenantId, CancellationToken cancellationToken = default);
     Task<Tenant> GetByDomainAsync(string domain, CancellationToken cancellationToken = default);
     Task<List<Tenant>> GetByDomainListAsync(string domain, CancellationToken cancellationToken = default);
     Task<List<Tenant>> GetByTenantIdsAsync(IEnumerable<string> tenantIds, CancellationToken cancellationToken = default);
@@ -58,6 +59,24 @@ public class TenantRepository : ITenantRepository
         {
             return await _collection.Find(tenant => tenant.TenantId == tenantId).FirstOrDefaultAsync(cancellationToken);
         }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "GetByTenantId");
+    }
+
+    /// <summary>
+    /// Finds a tenant whose tenant_id matches the given value ignoring case
+    /// (e.g. "MyTenant" matches an existing "mytenant"). Used to enforce
+    /// case-insensitive uniqueness of tenant ids at creation time.
+    /// </summary>
+    public async Task<Tenant> GetByTenantIdCaseInsensitiveAsync(string tenantId, CancellationToken cancellationToken = default)
+    {
+        return await MongoRetryHelper.ExecuteWithRetryAsync(async () =>
+        {
+            var filter = Builders<Tenant>.Filter.Eq(t => t.TenantId, tenantId);
+            var options = new FindOptions
+            {
+                Collation = new Collation("en", strength: CollationStrength.Secondary)
+            };
+            return await _collection.Find(filter, options).FirstOrDefaultAsync(cancellationToken);
+        }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "GetByTenantIdCaseInsensitive");
     }
 
     public async Task<Tenant> GetByDomainAsync(string domain, CancellationToken cancellationToken = default)

--- a/XiansAi.Server.Src/Shared/Services/TenantService.cs
+++ b/XiansAi.Server.Src/Shared/Services/TenantService.cs
@@ -637,6 +637,16 @@ public class TenantService : ITenantService
             var validatedTenant = tenant.SanitizeAndValidate();
             _logger.LogInformation("After sanitization, CreatedBy: {CreatedBy}", LogSanitizer.Sanitize(validatedTenant.CreatedBy));
 
+            // Tenant ids are unique ignoring case: reject "MyTenant" when "mytenant" already exists.
+            // The unique index on tenant_id remains the backstop for exact-case duplicates under races.
+            var duplicateTenant = await _tenantRepository.GetByTenantIdCaseInsensitiveAsync(validatedTenant.TenantId);
+            if (duplicateTenant != null)
+            {
+                _logger.LogWarning("Tenant ID {TenantId} already exists (case-insensitive match with {ExistingTenantId})",
+                    LogSanitizer.Sanitize(validatedTenant.TenantId), LogSanitizer.Sanitize(duplicateTenant.TenantId));
+                return ServiceResult<TenantCreatedResult>.BadRequest("A tenant with this ID already exists.");
+            }
+
             // Persist with Secret metadata values encrypted.
             validatedTenant.Metadata = _metadataProtector.Protect(validatedTenant.Metadata, validatedTenant.TenantId);
 

--- a/XiansAi.Server.Tests/IntegrationTests/AdminApi/AdminTenantEndpointsTests.cs
+++ b/XiansAi.Server.Tests/IntegrationTests/AdminApi/AdminTenantEndpointsTests.cs
@@ -208,6 +208,39 @@ public class AdminTenantEndpointsTests : AdminApiIntegrationTestBase
     }
 
     [Fact]
+    public async Task CreateTenant_WithSameTenantIdInDifferentCase_ReturnsBadRequest()
+    {
+        // Arrange
+        var tenantId = $"test-tenant-{Guid.NewGuid()}";
+        await ConfigureAdminApiClientAsync(tenantId);
+        await CreateTestTenantAsync(tenantId); // Required: X-Tenant-Id header must reference an existing tenant for auth validation
+
+        var newTenantId = $"new-tenant-{Guid.NewGuid()}";
+        var createRequest = new
+        {
+            tenantId = newTenantId,
+            name = "Original Tenant",
+            domain = $"{newTenantId}.test.com"
+        };
+        var createResponse = await PostAsJsonAsync("/api/v1/admin/tenants", createRequest);
+        Assert.Equal(HttpStatusCode.OK, createResponse.StatusCode);
+
+        // Act - attempt to create the same tenant id with different casing
+        var duplicateRequest = new
+        {
+            tenantId = newTenantId.ToUpperInvariant(),
+            name = "Duplicate Tenant",
+            domain = $"other-{Guid.NewGuid()}.test.com"
+        };
+        var duplicateResponse = await PostAsJsonAsync("/api/v1/admin/tenants", duplicateRequest);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, duplicateResponse.StatusCode);
+        var content = await duplicateResponse.Content.ReadAsStringAsync();
+        Assert.Contains("already exists", content);
+    }
+
+    [Fact]
     public async Task UpdateTenant_WithValidRequest_UpdatesTenant()
     {
         // Arrange


### PR DESCRIPTION
- Enhanced tenant creation and lookup processes to ensure tenant IDs are unique regardless of casing, preventing duplicates.
- Updated `BootstrapService` to use the resolved tenant ID from the result of the tenant existence check.
- Modified `TenantService` to reject tenant creation requests with duplicate IDs that differ only in case, improving data integrity.
- Added integration test to verify that creating a tenant with a duplicate ID in different casing returns a BadRequest response.

These changes improve the robustness of tenant management in the Admin API.