### PR TITLE
Fix Cosmos tenant creation and enforce lowercase tenant IDs

### DIFF
--- a/XiansAi.Server.Src/Features/AdminApi/Services/BootstrapService.cs
+++ b/XiansAi.Server.Src/Features/AdminApi/Services/BootstrapService.cs
@@ -191,11 +191,15 @@ public class BootstrapService : IBootstrapService
                 return ServiceResult<Tenant>.Success(existingTenant);
             }
 
+            // Only newly created ids have to be lowercase; the lookup above still finds tenants
+            // created before that rule whatever their casing.
+            var newTenantId = Tenant.SanitizeAndValidateNewTenantId(sanitizedTenantId);
+
             var tenant = new Tenant
             {
                 Id = ObjectId.GenerateNewId().ToString(),
-                TenantId = sanitizedTenantId,
-                Name = sanitizedTenantId,
+                TenantId = newTenantId,
+                Name = newTenantId,
                 Enabled = true,
                 CreatedBy = SystemCreator,
                 CreatedAt = DateTime.UtcNow,

--- a/XiansAi.Server.Src/Features/WebApi/Scripts/SeedData.cs
+++ b/XiansAi.Server.Src/Features/WebApi/Scripts/SeedData.cs
@@ -4,6 +4,7 @@ using Shared.Data;
 using Shared.Data.Models;
 using Shared.Configuration;
 using Shared.Repositories;
+using System.ComponentModel.DataAnnotations;
 
 namespace Features.WebApi.Scripts;
 
@@ -71,12 +72,25 @@ public class SeedData
             }
             
             logger.LogInformation("No tenants found, creating default tenant...");
-            
+
+            // Seeding is configuration driven, so a tenant ID that breaks the lowercase rule is
+            // reported as a misconfiguration instead of being silently normalized.
+            string defaultTenantId;
+            try
+            {
+                defaultTenantId = Tenant.SanitizeAndValidateNewTenantId(tenantSettings.TenantId);
+            }
+            catch (ValidationException ex)
+            {
+                logger.LogError(ex, "Default tenant not seeded: configured tenant ID is invalid");
+                return;
+            }
+
             // Create default tenant using configuration settings
             var defaultTenant = new Tenant
             {
                 Id = ObjectId.GenerateNewId().ToString(),
-                TenantId = tenantSettings.TenantId,
+                TenantId = defaultTenantId,
                 Name = tenantSettings.Name,
                 Domain = tenantSettings.Domain,
                 Enabled = tenantSettings.Enabled,

--- a/XiansAi.Server.Src/Shared/Data/Models/Tenant.cs
+++ b/XiansAi.Server.Src/Shared/Data/Models/Tenant.cs
@@ -240,6 +240,30 @@ public class Tenant : ModelValidatorBase<Tenant>
 
         return sanitizedTenantId;
     }
+
+    /// <summary>
+    /// Validates and sanitizes the tenant ID of a tenant that is about to be created.
+    ///
+    /// Tenant IDs are unique ignoring case, so new ones must be lowercase. The caller is rejected
+    /// rather than silently given a lowercased ID, because every tenant lookup other than creation
+    /// matches the stored ID exactly: a caller that kept using its own casing would then fail to
+    /// resolve its tenant. Tenants created before this rule keep their casing, which is why only
+    /// creation applies the stricter check.
+    /// </summary>
+    /// <exception cref="ValidationException">Thrown when the ID is invalid or not lowercase</exception>
+    public static string SanitizeAndValidateNewTenantId(string tenantId)
+    {
+        var sanitizedTenantId = SanitizeAndValidateTenantId(tenantId);
+
+        var lowercaseTenantId = sanitizedTenantId.ToLowerInvariant();
+        if (!string.Equals(sanitizedTenantId, lowercaseTenantId, StringComparison.Ordinal))
+        {
+            throw new ValidationException(
+                $"Tenant ID must be lowercase. Use '{lowercaseTenantId}' instead of '{sanitizedTenantId}'.");
+        }
+
+        return sanitizedTenantId;
+    }
 }
 
 public class Logo : ModelValidatorBase<Logo>

--- a/XiansAi.Server.Src/Shared/Repositories/TenantRepository.cs
+++ b/XiansAi.Server.Src/Shared/Repositories/TenantRepository.cs
@@ -10,7 +10,7 @@ public interface ITenantRepository
 {
     Task<Tenant> GetByIdAsync(string id, CancellationToken cancellationToken = default);
     Task<Tenant?> GetByTenantIdAsync(string tenantId, CancellationToken cancellationToken = default);
-    Task<Tenant> GetByTenantIdCaseInsensitiveAsync(string tenantId, CancellationToken cancellationToken = default);
+    Task<Tenant?> GetByTenantIdCaseInsensitiveAsync(string tenantId, CancellationToken cancellationToken = default);
     Task<Tenant> GetByDomainAsync(string domain, CancellationToken cancellationToken = default);
     Task<List<Tenant>> GetByDomainListAsync(string domain, CancellationToken cancellationToken = default);
     Task<List<Tenant>> GetByTenantIdsAsync(IEnumerable<string> tenantIds, CancellationToken cancellationToken = default);
@@ -65,18 +65,43 @@ public class TenantRepository : ITenantRepository
     /// Finds a tenant whose tenant_id matches the given value ignoring case
     /// (e.g. "MyTenant" matches an existing "mytenant"). Used to enforce
     /// case-insensitive uniqueness of tenant ids at creation time.
+    ///
+    /// Matched with an anchored case-insensitive regex instead of a collation because
+    /// Azure Cosmos DB's MongoDB API rejects collation on find ("collation is not
+    /// supported in the find command yet"). The exact match is tried first so the common
+    /// case still uses the unique tenant_id index.
     /// </summary>
-    public async Task<Tenant> GetByTenantIdCaseInsensitiveAsync(string tenantId, CancellationToken cancellationToken = default)
+    public async Task<Tenant?> GetByTenantIdCaseInsensitiveAsync(string tenantId, CancellationToken cancellationToken = default)
     {
+        if (string.IsNullOrWhiteSpace(tenantId))
+        {
+            throw new ArgumentException("Tenant ID is required", nameof(tenantId));
+        }
+
         return await MongoRetryHelper.ExecuteWithRetryAsync(async () =>
         {
-            var filter = Builders<Tenant>.Filter.Eq(t => t.TenantId, tenantId);
-            var options = new FindOptions
+            var exactMatch = await _collection
+                .Find(tenant => tenant.TenantId == tenantId)
+                .FirstOrDefaultAsync(cancellationToken);
+            if (exactMatch != null)
             {
-                Collation = new Collation("en", strength: CollationStrength.Secondary)
-            };
-            return await _collection.Find(filter, options).FirstOrDefaultAsync(cancellationToken);
+                return exactMatch;
+            }
+
+            return await _collection
+                .Find(BuildCaseInsensitiveTenantIdFilter(tenantId))
+                .FirstOrDefaultAsync(cancellationToken);
         }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "GetByTenantIdCaseInsensitive");
+    }
+
+    /// <summary>
+    /// Builds a filter that matches tenant_id in full (not as a substring) ignoring case.
+    /// The value is regex-escaped so characters such as '.' in a tenant id are matched literally.
+    /// </summary>
+    private static FilterDefinition<Tenant> BuildCaseInsensitiveTenantIdFilter(string tenantId)
+    {
+        var pattern = "^" + System.Text.RegularExpressions.Regex.Escape(tenantId) + "$";
+        return Builders<Tenant>.Filter.Regex(t => t.TenantId, new BsonRegularExpression(pattern, "i"));
     }
 
     public async Task<Tenant> GetByDomainAsync(string domain, CancellationToken cancellationToken = default)

--- a/XiansAi.Server.Src/Shared/Services/TenantService.cs
+++ b/XiansAi.Server.Src/Shared/Services/TenantService.cs
@@ -616,10 +616,12 @@ public class TenantService : ITenantService
             var finalCreatedBy = request.CreatedBy ?? createdBy ?? _tenantContext.LoggedInUser ?? throw new InvalidOperationException("Logged in user is not set");
             _logger.LogInformation("Final CreatedBy value determined: {FinalCreatedBy}", LogSanitizer.Sanitize(finalCreatedBy));
 
+            var newTenantId = Tenant.SanitizeAndValidateNewTenantId(request.TenantId);
+
             var tenant = new Tenant
             {
                 Id = ObjectId.GenerateNewId().ToString(),
-                TenantId = request.TenantId,
+                TenantId = newTenantId,
                 Name = request.Name,
                 Domain = request.Domain,
                 Description = request.Description,

--- a/XiansAi.Server.Src/wwwroot/api-docs/tenant-management-admin-api.yaml
+++ b/XiansAi.Server.Src/wwwroot/api-docs/tenant-management-admin-api.yaml
@@ -12,6 +12,7 @@ info:
     - Tenant updates and deletions require SysAdmin role
     - Tenant queries require admin permissions (TenantAdmin or SysAdmin)
     - Tenants are created with `enabled = false` by default
+    - New tenant IDs must be lowercase; tenant IDs are unique ignoring case
   version: 1.0.0
   contact:
     name: API Support
@@ -362,8 +363,11 @@ components:
       properties:
         tenantId:
           type: string
-          description: Unique tenant identifier (business ID)
-          pattern: '^[a-zA-Z0-9._@-]+$'
+          description: |
+            Unique tenant identifier (business ID). Must be lowercase: tenant IDs are unique
+            ignoring case, and a request with uppercase characters is rejected with 400 rather
+            than being lowercased, so the ID stays exactly as the caller sends it later.
+          pattern: '^[a-z0-9._@-]+$'
           minLength: 1
           maxLength: 50
           example: "acme-corp"

--- a/XiansAi.Server.Tests/IntegrationTests/AdminApi/AdminTenantEndpointsTests.cs
+++ b/XiansAi.Server.Tests/IntegrationTests/AdminApi/AdminTenantEndpointsTests.cs
@@ -208,35 +208,56 @@ public class AdminTenantEndpointsTests : AdminApiIntegrationTestBase
     }
 
     [Fact]
-    public async Task CreateTenant_WithSameTenantIdInDifferentCase_ReturnsBadRequest()
+    public async Task CreateTenant_WithUppercaseTenantId_ReturnsBadRequest()
     {
         // Arrange
         var tenantId = $"test-tenant-{Guid.NewGuid()}";
         await ConfigureAdminApiClientAsync(tenantId);
         await CreateTestTenantAsync(tenantId); // Required: X-Tenant-Id header must reference an existing tenant for auth validation
 
-        var newTenantId = $"new-tenant-{Guid.NewGuid()}";
-        var createRequest = new
+        var newTenantId = $"New-Tenant-{Guid.NewGuid()}";
+        var request = new
         {
             tenantId = newTenantId,
-            name = "Original Tenant",
-            domain = $"{newTenantId}.test.com"
+            name = "Uppercase Tenant",
+            domain = $"uppercase-{Guid.NewGuid()}.test.com"
         };
-        var createResponse = await PostAsJsonAsync("/api/v1/admin/tenants", createRequest);
-        Assert.Equal(HttpStatusCode.OK, createResponse.StatusCode);
 
-        // Act - attempt to create the same tenant id with different casing
-        var duplicateRequest = new
+        // Act
+        var response = await PostAsJsonAsync("/api/v1/admin/tenants", request);
+
+        // Assert - rejected rather than silently lowercased, and told what to send instead
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.Contains("must be lowercase", content);
+        Assert.Contains(newTenantId.ToLowerInvariant(), content);
+    }
+
+    [Fact]
+    public async Task CreateTenant_WhenAnExistingTenantDiffersOnlyByCase_ReturnsBadRequest()
+    {
+        // Arrange
+        var tenantId = $"test-tenant-{Guid.NewGuid()}";
+        await ConfigureAdminApiClientAsync(tenantId);
+        await CreateTestTenantAsync(tenantId); // Required: X-Tenant-Id header must reference an existing tenant for auth validation
+
+        // Seeded directly to represent a tenant created before new ids had to be lowercase.
+        var legacyTenantId = $"Legacy-Tenant-{Guid.NewGuid()}";
+        await CreateTestTenantAsync(legacyTenantId);
+
+        var request = new
         {
-            tenantId = newTenantId.ToUpperInvariant(),
+            tenantId = legacyTenantId.ToLowerInvariant(),
             name = "Duplicate Tenant",
             domain = $"other-{Guid.NewGuid()}.test.com"
         };
-        var duplicateResponse = await PostAsJsonAsync("/api/v1/admin/tenants", duplicateRequest);
+
+        // Act
+        var response = await PostAsJsonAsync("/api/v1/admin/tenants", request);
 
         // Assert
-        Assert.Equal(HttpStatusCode.BadRequest, duplicateResponse.StatusCode);
-        var content = await duplicateResponse.Content.ReadAsStringAsync();
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var content = await response.Content.ReadAsStringAsync();
         Assert.Contains("already exists", content);
     }
 

--- a/XiansAi.Server.Tests/UnitTests/Shared/Data/Models/TenantIdValidationTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Shared/Data/Models/TenantIdValidationTests.cs
@@ -1,0 +1,47 @@
+using System.ComponentModel.DataAnnotations;
+using Shared.Data.Models;
+using Xunit;
+
+namespace Tests.UnitTests.Shared.Data.Models;
+
+/// <summary>
+/// Tests for tenant ID validation, in particular the lowercase rule that applies only when a
+/// tenant is created. Lookups must stay permissive so tenants created before the rule, which may
+/// contain uppercase characters, remain reachable.
+/// </summary>
+public class TenantIdValidationTests
+{
+    [Theory]
+    [InlineData("acme-corp")]
+    [InlineData("parkly.no")]
+    [InlineData("tenant-99")]
+    public void SanitizeAndValidateNewTenantId_AcceptsLowercaseIds(string tenantId)
+    {
+        Assert.Equal(tenantId, Tenant.SanitizeAndValidateNewTenantId(tenantId));
+    }
+
+    [Theory]
+    [InlineData("Acme-Corp")]
+    [InlineData("ACME")]
+    [InlineData("parkly.NO")]
+    public void SanitizeAndValidateNewTenantId_RejectsIdsContainingUppercase(string tenantId)
+    {
+        var exception = Assert.Throws<ValidationException>(
+            () => Tenant.SanitizeAndValidateNewTenantId(tenantId));
+
+        // The message names the accepted form so the caller can correct the request directly.
+        Assert.Contains(tenantId.ToLowerInvariant(), exception.Message);
+    }
+
+    [Fact]
+    public void SanitizeAndValidateNewTenantId_RejectsBlankId()
+    {
+        Assert.Throws<ValidationException>(() => Tenant.SanitizeAndValidateNewTenantId("   "));
+    }
+
+    [Fact]
+    public void SanitizeAndValidateTenantId_StillAcceptsUppercase_SoLegacyTenantsStayReachable()
+    {
+        Assert.Equal("Acme-Corp", Tenant.SanitizeAndValidateTenantId("Acme-Corp"));
+    }
+}

--- a/XiansAi.Server.Tests/UnitTests/Shared/Repositories/TenantRepositoryLookupTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Shared/Repositories/TenantRepositoryLookupTests.cs
@@ -1,0 +1,102 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Moq;
+using Shared.Data;
+using Shared.Data.Models;
+using Shared.Repositories;
+using Tests.TestUtils;
+using Xunit;
+
+namespace Tests.UnitTests.Shared.Repositories;
+
+/// <summary>
+/// DB-level tests for the case-insensitive tenant lookup used to enforce unique tenant ids.
+/// Runs against a real MongoDB (ephemeral fixture) so the query itself is exercised, not mocked.
+/// </summary>
+public class TenantRepositoryLookupTests : IClassFixture<MongoDbFixture>
+{
+    private readonly TenantRepository _repository;
+
+    public TenantRepositoryLookupTests(MongoDbFixture fixture)
+    {
+        var collection = fixture.Database.GetCollection<Tenant>("tenants");
+
+        var clientService = new Mock<IMongoDbClientService>();
+        clientService.Setup(x => x.GetCollection<Tenant>("tenants")).Returns(collection);
+        _repository = new TenantRepository(clientService.Object, NullLogger<TenantRepository>.Instance);
+    }
+
+    private static Tenant NewTenant(string tenantId)
+    {
+        return new Tenant
+        {
+            Id = ObjectId.GenerateNewId().ToString(),
+            TenantId = tenantId,
+            Name = $"Tenant {tenantId}",
+            Domain = $"{tenantId}.test.com",
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = "db-test"
+        };
+    }
+
+    [Fact]
+    public async Task GetByTenantIdCaseInsensitive_FindsTenant_WhenCasingMatchesExactly()
+    {
+        var tenantId = $"db-lookup-{Guid.NewGuid()}";
+        await _repository.CreateAsync(NewTenant(tenantId));
+
+        var found = await _repository.GetByTenantIdCaseInsensitiveAsync(tenantId);
+
+        Assert.Equal(tenantId, found?.TenantId);
+    }
+
+    [Fact]
+    public async Task GetByTenantIdCaseInsensitive_FindsTenant_AndReturnsTheStoredCasing()
+    {
+        var tenantId = $"DB-Lookup-Mixed-{Guid.NewGuid()}";
+        await _repository.CreateAsync(NewTenant(tenantId));
+
+        var found = await _repository.GetByTenantIdCaseInsensitiveAsync(tenantId.ToLowerInvariant());
+
+        Assert.Equal(tenantId, found?.TenantId);
+    }
+
+    [Fact]
+    public async Task GetByTenantIdCaseInsensitive_ReturnsNull_WhenNoTenantMatches()
+    {
+        var found = await _repository.GetByTenantIdCaseInsensitiveAsync($"db-missing-{Guid.NewGuid()}");
+
+        Assert.Null(found);
+    }
+
+    [Fact]
+    public async Task GetByTenantIdCaseInsensitive_DoesNotMatchOnPartialTenantId()
+    {
+        var tenantId = $"db-prefix-{Guid.NewGuid()}";
+        await _repository.CreateAsync(NewTenant(tenantId + "-suffix"));
+
+        var found = await _repository.GetByTenantIdCaseInsensitiveAsync(tenantId);
+
+        Assert.Null(found);
+    }
+
+    [Fact]
+    public async Task GetByTenantIdCaseInsensitive_TreatsRegexCharactersLiterally()
+    {
+        var unique = Guid.NewGuid().ToString("N");
+        // A '.' must not behave as a regex wildcard: "db.dot-x" must not match "dbXdot-x".
+        await _repository.CreateAsync(NewTenant($"db{unique}dot"));
+
+        var found = await _repository.GetByTenantIdCaseInsensitiveAsync($"db.{unique.Substring(1)}dot");
+
+        Assert.Null(found);
+    }
+
+    [Fact]
+    public async Task GetByTenantIdCaseInsensitive_Throws_WhenTenantIdIsBlank()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => _repository.GetByTenantIdCaseInsensitiveAsync("  "));
+    }
+}


### PR DESCRIPTION
## Summary
- Fix tenant creation on Azure Cosmos DB by replacing MongoDB collation in `GetByTenantIdCaseInsensitiveAsync` with an exact-match lookup followed by an anchored, regex-escaped case-insensitive query (Cosmos rejects collation on `find`)
- Require new tenant IDs to be lowercase at creation time (`SanitizeAndValidateNewTenantId`), returning 400 with the accepted form instead of silently normalizing, so later exact-match lookups stay consistent
- Apply the lowercase rule across admin create, bootstrap, and seed paths; update admin API docs and add unit/integration tests for the lookup and validation behavior

## Test plan
- [x] `dotnet test XiansAi.Server.Tests --filter "FullyQualifiedName~Tenant|FullyQualifiedName~Bootstrap|FullyQualifiedName~Seed"`
- [x] Full test suite (`623` tests passing)
- [ ] Create a tenant via `POST /api/v1/admin/tenants` on Cosmos with a lowercase ID (e.g. `parkly.no`) and confirm 200
- [ ] Retry with an uppercase ID and confirm 400 with a message naming the lowercase form
- [ ] Confirm bootstrap still reuses an existing tenant when casing differs (e.g. request `Default`, existing `default`)


Made with [Cursor](https://cursor.com)