### PR TITLE
Feat/user authority resolution

### DIFF
--- a/XiansAi.Server.Src/Features/AdminApi/Auth/AdminEndpointAuthenticationHandler.cs
+++ b/XiansAi.Server.Src/Features/AdminApi/Auth/AdminEndpointAuthenticationHandler.cs
@@ -144,10 +144,12 @@ namespace Features.AdminApi.Auth
 
                         var finalTenantId = resolutionResult.FinalTenantId!;
                         var userRoles = resolutionResult.UserRoles!;
+                        // Prefer the canonical user_id when the key owner was stored as an email.
+                        var resolvedUserId = resolutionResult.ResolvedUserId ?? apiKey.CreatedBy;
 
                         _logger.LogDebug("Setting tenant context with user ID: {userId}, user type: {userType}, and roles: {roles}", 
-                            apiKey.CreatedBy, UserType.UserApiKey, string.Join(", ", userRoles));
-                        _tenantContext.LoggedInUser = apiKey.CreatedBy;
+                            resolvedUserId, UserType.UserApiKey, string.Join(", ", userRoles));
+                        _tenantContext.LoggedInUser = resolvedUserId;
                         _tenantContext.UserType = UserType.UserApiKey;
                         _tenantContext.TenantId = finalTenantId;
                         _tenantContext.UserRoles = userRoles.ToArray();
@@ -156,7 +158,7 @@ namespace Features.AdminApi.Auth
 
                         var claims = new List<Claim>
                         {
-                            new Claim(ClaimTypes.NameIdentifier, apiKey.CreatedBy),
+                            new Claim(ClaimTypes.NameIdentifier, resolvedUserId),
                             new Claim("TenantId", finalTenantId)
                         };
 
@@ -164,7 +166,7 @@ namespace Features.AdminApi.Auth
                         var principal = new ClaimsPrincipal(identity);
                         var ticket = new AuthenticationTicket(principal, Scheme.Name);
                         _logger.LogInformation("Successfully authenticated AdminApi connection: User={UserId}, Tenant={TenantId}, Roles={Roles}", 
-                            LogSanitizer.Sanitize(apiKey.CreatedBy), LogSanitizer.Sanitize(finalTenantId), LogSanitizer.Sanitize(string.Join(", ", userRoles)));
+                            LogSanitizer.Sanitize(resolvedUserId), LogSanitizer.Sanitize(finalTenantId), LogSanitizer.Sanitize(string.Join(", ", userRoles)));
 
                         return AuthenticateResult.Success(ticket);
                     }

--- a/XiansAi.Server.Src/Features/AdminApi/Auth/AdminRoleTenantResolver.cs
+++ b/XiansAi.Server.Src/Features/AdminApi/Auth/AdminRoleTenantResolver.cs
@@ -1,6 +1,7 @@
 using Shared.Auth;
 using Shared.Data.Models;
 using Shared.Exceptions;
+using Shared.Repositories;
 using Shared.Services;
 using Shared.Utils;
 
@@ -8,12 +9,15 @@ namespace Features.AdminApi.Auth;
 
 /// <summary>
 /// Result of resolving admin roles and tenant context.
+/// <paramref name="ResolvedUserId"/> is the canonical user_id after resolving the API key owner
+/// (which may be stored as a user id or as an email). Null when not applicable.
 /// </summary>
 public sealed record AdminRoleTenantResolutionResult(
     bool Success,
     string? FinalTenantId,
     string[]? UserRoles,
-    string? ErrorMessage);
+    string? ErrorMessage,
+    string? ResolvedUserId = null);
 
 /// <summary>
 /// Resolves user roles and target tenant for Admin API requests.
@@ -26,8 +30,14 @@ public interface IAdminRoleTenantResolver
     /// Resolves the final tenant ID and user roles based on API key and request context.
     /// Throws TenantNotFoundException when SysAdmin specifies a non-existent tenant.
     /// </summary>
+    /// <param name="userIdOrEmail">
+    /// API key owner identity: normally <see cref="User.UserId"/>, but some keys store the email.
+    /// </param>
+    /// <param name="apiKey">The authenticated API key.</param>
+    /// <param name="tenantIdFromRequest">Optional tenant override from query, route, or header.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     Task<AdminRoleTenantResolutionResult> ResolveAsync(
-        string userId,
+        string userIdOrEmail,
         ApiKey apiKey,
         string tenantIdFromRequest,
         CancellationToken cancellationToken = default);
@@ -41,27 +51,39 @@ public interface IAdminRoleTenantResolver
 /// </summary>
 public sealed class AdminRoleTenantResolver : IAdminRoleTenantResolver
 {
+    private readonly IUserRepository _userRepository;
     private readonly IRoleCacheService _roleCacheService;
     private readonly ITenantCacheService _tenantCacheService;
     private readonly ILogger<AdminRoleTenantResolver> _logger;
 
     public AdminRoleTenantResolver(
+        IUserRepository userRepository,
         IRoleCacheService roleCacheService,
         ITenantCacheService tenantCacheService,
         ILogger<AdminRoleTenantResolver> logger)
     {
+        _userRepository = userRepository;
         _roleCacheService = roleCacheService;
         _tenantCacheService = tenantCacheService;
         _logger = logger;
     }
 
     public async Task<AdminRoleTenantResolutionResult> ResolveAsync(
-        string userId,
+        string userIdOrEmail,
         ApiKey apiKey,
         string tenantIdFromRequest,
         CancellationToken cancellationToken = default)
     {
-        var userRoles = await _roleCacheService.GetUserRolesAsync(userId, apiKey.TenantId);
+        // Only an email owner needs a database round-trip to find the canonical user_id. This runs on
+        // every Admin API authentication and authorization pass, so the user id path skips the lookup.
+        var resolvedUserId = userIdOrEmail;
+        if (userIdOrEmail.Contains('@'))
+        {
+            var user = await _userRepository.GetByUserEmailAsync(userIdOrEmail);
+            resolvedUserId = user?.UserId ?? userIdOrEmail;
+        }
+
+        var userRoles = await _roleCacheService.GetUserRolesAsync(resolvedUserId, apiKey.TenantId);
 
         var hasSysAdmin = userRoles.Contains(SystemRoles.SysAdmin);
         var hasTenantAdmin = userRoles.Contains(SystemRoles.TenantAdmin);
@@ -70,11 +92,12 @@ public sealed class AdminRoleTenantResolver : IAdminRoleTenantResolver
         {
             _logger.LogWarning(
                 "User {UserId} does not have SysAdmin or TenantAdmin role. Roles: {Roles}",
-                LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(string.Join(", ", userRoles)));
+                LogSanitizer.Sanitize(resolvedUserId), LogSanitizer.Sanitize(string.Join(", ", userRoles)));
             return new AdminRoleTenantResolutionResult(
                 Success: false,
                 null, null,
-                "User does not have required admin role");
+                "User does not have required admin role",
+                ResolvedUserId: resolvedUserId);
         }
 
         string finalTenantId;
@@ -87,20 +110,20 @@ public sealed class AdminRoleTenantResolver : IAdminRoleTenantResolver
                 {
                     _logger.LogWarning(
                         "SysAdmin user {UserId} requested non-existent tenant: {TenantId}",
-                        LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(tenantIdFromRequest));
+                        LogSanitizer.Sanitize(resolvedUserId), LogSanitizer.Sanitize(tenantIdFromRequest));
                     throw new TenantNotFoundException(tenantIdFromRequest);
                 }
                 finalTenantId = tenantIdFromRequest;
                 _logger.LogDebug(
                     "SysAdmin user {UserId} using provided tenantId: {TenantId}",
-                    LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(finalTenantId));
+                    LogSanitizer.Sanitize(resolvedUserId), LogSanitizer.Sanitize(finalTenantId));
             }
             else
             {
                 finalTenantId = apiKey.TenantId;
                 _logger.LogDebug(
                     "SysAdmin user {UserId} using API key tenantId: {TenantId}",
-                    LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(finalTenantId));
+                    LogSanitizer.Sanitize(resolvedUserId), LogSanitizer.Sanitize(finalTenantId));
             }
         }
         else
@@ -111,23 +134,24 @@ public sealed class AdminRoleTenantResolver : IAdminRoleTenantResolver
                 {
                     _logger.LogWarning(
                         "TenantAdmin user {UserId} provided tenantId {ProvidedTenantId} that does not match API key tenantId {ApiKeyTenantId}",
-                        LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(tenantIdFromRequest), LogSanitizer.Sanitize(apiKey.TenantId));
+                        LogSanitizer.Sanitize(resolvedUserId), LogSanitizer.Sanitize(tenantIdFromRequest), LogSanitizer.Sanitize(apiKey.TenantId));
                     return new AdminRoleTenantResolutionResult(
                         Success: false,
                         null, null,
-                        "Tenant ID does not match API key tenant");
+                        "Tenant ID does not match API key tenant",
+                        ResolvedUserId: resolvedUserId);
                 }
                 finalTenantId = tenantIdFromRequest;
                 _logger.LogDebug(
                     "TenantAdmin user {UserId} validated tenantId: {TenantId}",
-                    LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(finalTenantId));
+                    LogSanitizer.Sanitize(resolvedUserId), LogSanitizer.Sanitize(finalTenantId));
             }
             else
             {
                 finalTenantId = apiKey.TenantId;
                 _logger.LogDebug(
                     "TenantAdmin user {UserId} using API key tenantId: {TenantId}",
-                    LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(finalTenantId));
+                    LogSanitizer.Sanitize(resolvedUserId), LogSanitizer.Sanitize(finalTenantId));
             }
         }
 
@@ -135,6 +159,7 @@ public sealed class AdminRoleTenantResolver : IAdminRoleTenantResolver
             Success: true,
             finalTenantId,
             userRoles.ToArray(),
-            null);
+            null,
+            ResolvedUserId: resolvedUserId);
     }
 }

--- a/XiansAi.Server.Src/Features/AdminApi/Auth/AdminRoleTenantResolver.cs
+++ b/XiansAi.Server.Src/Features/AdminApi/Auth/AdminRoleTenantResolver.cs
@@ -77,14 +77,25 @@ public sealed class AdminRoleTenantResolver : IAdminRoleTenantResolver
         // Modern keys already store the canonical user id; only legacy email CreatedBy values
         // need a DB round-trip. This runs on every Admin API auth and authorization pass, so
         // skipping the user-id path avoids an uncached lookup per request.
-        var resolvedUserId = userIdOrEmail;
+        //
+        // An address can answer to more than one account, and the key records no more than the
+        // address, so the accounts are combined rather than one being picked. The roles come back
+        // with the identity and are not read from the cache, which is keyed per account.
+        string resolvedUserId;
+        List<string> userRoles;
         if (userIdOrEmail.Contains('@'))
         {
-            var user = await _userRepository.GetByUserEmailAsync(userIdOrEmail);
-            resolvedUserId = user?.UserId ?? userIdOrEmail;
+            var identity = await _userRepository.ResolveEmailIdentityAsync(userIdOrEmail, apiKey.TenantId);
+            resolvedUserId = identity?.PrimaryUserId ?? userIdOrEmail;
+            userRoles = identity == null
+                ? new List<string>()
+                : SystemRoles.ExcludingParticipantRoles(identity.Roles);
         }
-
-        var userRoles = await _roleCacheService.GetUserRolesAsync(resolvedUserId, apiKey.TenantId);
+        else
+        {
+            resolvedUserId = userIdOrEmail;
+            userRoles = await _roleCacheService.GetUserRolesAsync(resolvedUserId, apiKey.TenantId);
+        }
 
         var hasSysAdmin = userRoles.Contains(SystemRoles.SysAdmin);
         var hasTenantAdmin = userRoles.Contains(SystemRoles.TenantAdmin);

--- a/XiansAi.Server.Src/Features/AdminApi/Auth/ValidAdminEndpointAccessHandler.cs
+++ b/XiansAi.Server.Src/Features/AdminApi/Auth/ValidAdminEndpointAccessHandler.cs
@@ -138,10 +138,11 @@ namespace Features.AdminApi.Auth
 
                 var finalTenantId = resolutionResult.FinalTenantId!;
                 var userRoles = resolutionResult.UserRoles!;
+                var resolvedUserId = resolutionResult.ResolvedUserId ?? loggedInUser;
 
                 _logger.LogDebug("Setting tenant context with user ID: {userId}, user type: {userType}, and roles: {roles}", 
-                    loggedInUser, UserType.UserApiKey, string.Join(", ", userRoles));
-                _tenantContext.LoggedInUser = loggedInUser;
+                    resolvedUserId, UserType.UserApiKey, string.Join(", ", userRoles));
+                _tenantContext.LoggedInUser = resolvedUserId;
                 _tenantContext.UserType = UserType.UserApiKey;
                 _tenantContext.TenantId = finalTenantId;
                 _tenantContext.UserRoles = userRoles.ToArray();
@@ -149,7 +150,7 @@ namespace Features.AdminApi.Auth
                 _tenantContext.Authorization = accessToken;
 
                 _logger.LogInformation("Successfully authorized AdminApi Endpoint Connection: User={UserId}, Tenant={TenantId}, Roles={Roles}", 
-                    LogSanitizer.Sanitize(loggedInUser), LogSanitizer.Sanitize(finalTenantId), LogSanitizer.Sanitize(string.Join(", ", userRoles)));
+                    LogSanitizer.Sanitize(resolvedUserId), LogSanitizer.Sanitize(finalTenantId), LogSanitizer.Sanitize(string.Join(", ", userRoles)));
                 context.Succeed(requirement);
             }
             catch (TenantNotFoundException)

--- a/XiansAi.Server.Src/Features/AdminApi/Endpoints/AdminOwnershipEndpoints.cs
+++ b/XiansAi.Server.Src/Features/AdminApi/Endpoints/AdminOwnershipEndpoints.cs
@@ -134,10 +134,8 @@ public static class AdminOwnershipEndpoints
                     return Results.Forbid();
                 }
 
-                // Get new admin user to validate they exist
-                // Try by userId first, then by email
-                var newAdminUser = await userRepository.GetByUserIdAsync(request.NewAdminId) ??
-                                   await userRepository.GetByUserEmailAsync(request.NewAdminId);
+                // Get new admin user to validate they exist (by user id or email)
+                var newAdminUser = await userRepository.GetByUserIdOrEmailAsync(request.NewAdminId);
 
                 if (newAdminUser == null)
                 {

--- a/XiansAi.Server.Src/Features/AdminApi/Endpoints/AdminOwnershipEndpoints.cs
+++ b/XiansAi.Server.Src/Features/AdminApi/Endpoints/AdminOwnershipEndpoints.cs
@@ -20,9 +20,14 @@ public static class AdminOwnershipEndpoints
     /// </summary>
     public class TransferOwnershipRequest
     {
+        /// <summary>
+        /// The <see cref="User.UserId"/> of the account to hand ownership to. Addresses are not
+        /// accepted: one can answer to more than one account, and this API knows the user id —
+        /// every endpoint that returns a user returns it.
+        /// </summary>
         [Required]
         [StringLength(200, MinimumLength = 1)]
-        public required string NewAdminId { get; set; }  // User identifier (userId, email, username, etc.)
+        public required string NewAdminId { get; set; }
     }
 
     /// <summary>
@@ -136,29 +141,21 @@ public static class AdminOwnershipEndpoints
                     return Results.Forbid();
                 }
 
-                // Get new admin user to validate they exist (by user id or email)
-                var newAdminUser = await userRepository.GetByUserIdAsync(request.NewAdminId);
-
-                if (newAdminUser == null && request.NewAdminId.Contains('@'))
+                // Ownership names exactly one account, and an address does not: two providers can
+                // each hold a record for the same one. Resolving an address here would hand the
+                // agent to whichever record was found rather than the one the caller meant.
+                if (request.NewAdminId.Contains('@'))
                 {
-                    // Ownership names exactly one account, so an address that answers to several
-                    // is refused rather than resolved to whichever record came back first.
-                    var owners = await userRepository.GetAllByUserEmailAsync(request.NewAdminId);
-                    if (owners.Count > 1)
+                    logger.LogWarning("Ownership transfer refused: {Email} is an address, not a user id",
+                        LogSanitizer.RedactEmail(request.NewAdminId));
+                    return Results.BadRequest(new
                     {
-                        logger.LogWarning(
-                            "Ownership transfer refused: {Email} matches {Count} accounts",
-                            LogSanitizer.RedactEmail(request.NewAdminId), owners.Count);
-                        return Results.Conflict(new
-                        {
-                            error = $"'{request.NewAdminId}' matches more than one account. " +
-                                    "Use the user id of the intended account."
-                        });
-                    }
-
-                    newAdminUser = owners.FirstOrDefault();
+                        error = "newAdminId must be a user id, not an email address. " +
+                                "An address can answer to more than one account."
+                    });
                 }
 
+                var newAdminUser = await userRepository.GetByUserIdAsync(request.NewAdminId);
                 if (newAdminUser == null)
                 {
                     return Results.BadRequest(new { error = $"User '{request.NewAdminId}' not found" });

--- a/XiansAi.Server.Src/Features/AdminApi/Endpoints/AdminOwnershipEndpoints.cs
+++ b/XiansAi.Server.Src/Features/AdminApi/Endpoints/AdminOwnershipEndpoints.cs
@@ -6,6 +6,7 @@ using Features.AdminApi.Utils;
 using Features.AdminApi.Auth;
 using Shared.Data.Models;
 using Shared.Services;
+using Shared.Utils;
 
 namespace Features.AdminApi.Endpoints;
 
@@ -97,7 +98,8 @@ public static class AdminOwnershipEndpoints
             [FromServices] IAgentRepository agentRepository,
             [FromServices] IUserRepository userRepository,
             [FromServices] IWebhookEventPublisher webhookEventPublisher,
-            [FromServices] ITenantContext tenantContext) =>
+            [FromServices] ITenantContext tenantContext,
+            [FromServices] ILogger<IUserRepository> logger) =>
         {
             try
             {
@@ -135,7 +137,27 @@ public static class AdminOwnershipEndpoints
                 }
 
                 // Get new admin user to validate they exist (by user id or email)
-                var newAdminUser = await userRepository.GetByUserIdOrEmailAsync(request.NewAdminId);
+                var newAdminUser = await userRepository.GetByUserIdAsync(request.NewAdminId);
+
+                if (newAdminUser == null && request.NewAdminId.Contains('@'))
+                {
+                    // Ownership names exactly one account, so an address that answers to several
+                    // is refused rather than resolved to whichever record came back first.
+                    var owners = await userRepository.GetAllByUserEmailAsync(request.NewAdminId);
+                    if (owners.Count > 1)
+                    {
+                        logger.LogWarning(
+                            "Ownership transfer refused: {Email} matches {Count} accounts",
+                            LogSanitizer.RedactEmail(request.NewAdminId), owners.Count);
+                        return Results.Conflict(new
+                        {
+                            error = $"'{request.NewAdminId}' matches more than one account. " +
+                                    "Use the user id of the intended account."
+                        });
+                    }
+
+                    newAdminUser = owners.FirstOrDefault();
+                }
 
                 if (newAdminUser == null)
                 {

--- a/XiansAi.Server.Src/Features/AdminApi/Endpoints/AdminOwnershipEndpoints.cs
+++ b/XiansAi.Server.Src/Features/AdminApi/Endpoints/AdminOwnershipEndpoints.cs
@@ -161,6 +161,32 @@ public static class AdminOwnershipEndpoints
                     return Results.BadRequest(new { error = $"User '{request.NewAdminId}' not found" });
                 }
 
+                // A disabled account cannot sign in, so handing it the agent would leave that agent
+                // with an owner nobody can act as.
+                if (newAdminUser.IsLockedOut)
+                {
+                    logger.LogWarning("Ownership transfer refused: {UserId} is disabled",
+                        LogSanitizer.RedactUserId(newAdminUser.UserId));
+                    return Results.Conflict(new
+                    {
+                        error = "This account is disabled, so it cannot own an agent. Enable it first."
+                    });
+                }
+
+                // The lookup above is not tenant-scoped, so without this any account in the
+                // deployment could be made owner of this tenant's agent. A system administrator
+                // reaches every tenant already, and is the one account that need not be a member.
+                if (!newAdminUser.IsSysAdmin && !IsApprovedMemberOf(newAdminUser, parsedTenant))
+                {
+                    logger.LogWarning(
+                        "Ownership transfer refused: {UserId} is not a member of tenant {TenantId}",
+                        LogSanitizer.RedactUserId(newAdminUser.UserId), LogSanitizer.Sanitize(parsedTenant));
+                    return Results.BadRequest(new
+                    {
+                        error = $"User '{request.NewAdminId}' is not an approved member of tenant '{parsedTenant}'"
+                    });
+                }
+
                 // Determine the identifier to use (prefer userId)
                 var newAdminUserId = newAdminUser.UserId;
 
@@ -215,6 +241,15 @@ public static class AdminOwnershipEndpoints
         .WithName("TransferOwnership")
         ;
     }
+
+    /// <summary>
+    /// Whether the account holds an approved membership of the tenant. A pending one is not enough:
+    /// its roles do not count anywhere else either, so it names someone who cannot yet act here.
+    /// </summary>
+    private static bool IsApprovedMemberOf(User user, string tenantId) =>
+        user.TenantRoles.Any(membership =>
+            string.Equals(membership.Tenant, tenantId, StringComparison.OrdinalIgnoreCase)
+            && membership.IsApproved);
 }
 
 

--- a/XiansAi.Server.Src/Features/AdminApi/Endpoints/AdminParticipantsEndpoints.cs
+++ b/XiansAi.Server.Src/Features/AdminApi/Endpoints/AdminParticipantsEndpoints.cs
@@ -98,8 +98,21 @@ public static class AdminParticipantsEndpoints
                 }
                 email = validatedEmail;
 
-                // Get user by email
-                var user = await userRepository.GetByUserEmailAsync(email);
+                // Get user by email. The reply describes one participant's memberships, so an
+                // address that answers to several accounts is refused rather than answered from
+                // whichever record came back first.
+                var owners = await userRepository.GetAllByUserEmailAsync(email);
+                if (owners.Count > 1)
+                {
+                    logger.LogWarning("Participant lookup refused: {EmailRedacted} matches {Count} accounts",
+                        LogSanitizer.RedactEmail(email), owners.Count);
+                    return Results.Problem(
+                        detail: "This email matches more than one account, so participant details " +
+                                "cannot be resolved from it.",
+                        statusCode: StatusCodes.Status409Conflict);
+                }
+
+                var user = owners.FirstOrDefault();
 
                 // Reject locked-out users
                 if (user?.IsLockedOut == true)

--- a/XiansAi.Server.Src/Features/AdminApi/Endpoints/AdminUserEndpoints.cs
+++ b/XiansAi.Server.Src/Features/AdminApi/Endpoints/AdminUserEndpoints.cs
@@ -19,13 +19,30 @@ namespace Features.AdminApi.Endpoints;
 /// </summary>
 public static class AdminUserEndpoints
 {
+    /// <summary>
+    /// Either names an existing account with <see cref="UserId"/>, or supplies
+    /// <see cref="Email"/> and <see cref="Name"/> to create one.
+    /// </summary>
     public sealed class CreateTenantParticipantUserRequest
     {
+        /// <summary>
+        /// The account to give the role to. Takes precedence: when it is set, the address and name
+        /// are ignored. Settles which account is meant when an address is held by more than one,
+        /// which matters because the role granted here may be TenantAdmin.
+        /// </summary>
+        [JsonPropertyName("userId")]
+        public string? UserId { get; init; }
+
+        /// <summary>
+        /// Names the single account holding it, or creates one when none does. Refused when more
+        /// than one account holds it, since then it names nobody in particular — supply
+        /// <see cref="UserId"/> instead.
+        /// </summary>
         [JsonPropertyName("email")]
-        public required string Email { get; init; }
+        public string? Email { get; init; }
 
         [JsonPropertyName("name")]
-        public required string Name { get; init; }
+        public string? Name { get; init; }
 
         /// <summary>Any tenant role: TenantAdmin, TenantUser, TenantParticipant, or TenantParticipantAdmin.</summary>
         [JsonPropertyName("role")]
@@ -97,7 +114,7 @@ public static class AdminUserEndpoints
             if (!TenantRouteMatchesContext(tenantContext, tenantId, loggerFactory, out var forbid))
                 return forbid;
 
-            var result = await service.CreateAsync(tenantId, body.Email, body.Name, body.Role);
+            var result = await service.CreateAsync(tenantId, body.Email, body.Name, body.Role, body.UserId);
             if (result.IsSuccess && result.Data != null)
             {
                 var location = AdminApiConstants.BuildVersionedPath(

--- a/XiansAi.Server.Src/Features/AgentApi/Auth/CertificateAuthenticationHandler.cs
+++ b/XiansAi.Server.Src/Features/AgentApi/Auth/CertificateAuthenticationHandler.cs
@@ -228,34 +228,57 @@ public class CertificateAuthenticationHandler : AuthenticationHandler<Certificat
         // The certificate's OU may carry either the canonical user id or the user's email,
         // depending on which UI issued the certificate. Resolve by user id first, then
         // fall back to email so certificates issued by either path authenticate correctly.
-        var user = await _userRepository.GetByUserIdOrEmailAsync(subjectUser);
-        if (user == null)
+        // Both paths refuse a locked-out account and only count an approved membership.
+        var user = await _userRepository.GetByUserIdAsync(subjectUser);
+        if (user != null)
         {
-            return (false, "Invalid user ID", new CachedCertificateValidation { IsValid = false });
+            var (error, identity) = CertificateUserAccess.Resolve(user, tenantId, _logger);
+            if (identity == null)
+            {
+                _logger.LogWarning(
+                    "Certificate authentication denied for {UserId}: {Reason}",
+                    LogSanitizer.RedactUserId(user.UserId), error);
+                return (false, error, new CachedCertificateValidation { IsValid = false });
+            }
+
+            // Always use the canonical user id for the authenticated context, regardless of
+            // whether the certificate identified the user by id or by email.
+            var userId = string.IsNullOrEmpty(identity.PrimaryUserId) ? subjectUser : identity.PrimaryUserId;
+            return (true, null, BuildValidation(
+                tenantId, userId, identity.Roles.ToList(), identity.IsSysAdmin));
         }
 
-        // Always use the canonical user id for the authenticated context, regardless of
-        // whether the certificate identified the user by id or by email.
-        var userId = string.IsNullOrEmpty(user.UserId) ? subjectUser : user.UserId;
+        // An address can answer to more than one account, and the certificate records no more than
+        // the address, so the accounts are combined rather than one being picked arbitrarily.
+        if (subjectUser.Contains('@'))
+        {
+            var identity = await _userRepository.ResolveEmailIdentityAsync(subjectUser, tenantId);
+            if (identity != null)
+            {
+                return (true, null, BuildValidation(
+                    tenantId, identity.PrimaryUserId, identity.Roles.ToList(), identity.IsSysAdmin));
+            }
+        }
 
-        var roles = user.TenantRoles
-            .FirstOrDefault(tr => tr.Tenant == tenantId)?.Roles?.ToList() ?? new List<string>();
+        return (false, "Invalid user ID", new CachedCertificateValidation { IsValid = false });
+    }
 
-        if (user.IsSysAdmin && !roles.Contains(SystemRoles.SysAdmin))
+    private static CachedCertificateValidation BuildValidation(
+        string tenantId, string userId, List<string> roles, bool isSysAdmin)
+    {
+        if (isSysAdmin && !roles.Contains(SystemRoles.SysAdmin))
         {
             roles.Add(SystemRoles.SysAdmin);
         }
 
-        var validation = new CachedCertificateValidation
+        return new CachedCertificateValidation
         {
             IsValid = true,
             TenantId = tenantId,
             UserId = userId,
             Roles = roles.ToArray(), // Use array for immutability (matches default Array.Empty<string>())
-            IsSysAdmin = user.IsSysAdmin
+            IsSysAdmin = isSysAdmin
         };
-
-        return (true, null, validation);
     }
 
     private Task<AuthenticateResult> CreateAuthenticationTicket(X509Certificate2 cert, CachedCertificateValidation validation)

--- a/XiansAi.Server.Src/Features/AgentApi/Auth/CertificateAuthenticationHandler.cs
+++ b/XiansAi.Server.Src/Features/AgentApi/Auth/CertificateAuthenticationHandler.cs
@@ -228,8 +228,7 @@ public class CertificateAuthenticationHandler : AuthenticationHandler<Certificat
         // The certificate's OU may carry either the canonical user id or the user's email,
         // depending on which UI issued the certificate. Resolve by user id first, then
         // fall back to email so certificates issued by either path authenticate correctly.
-        var user = await _userRepository.GetByUserIdAsync(subjectUser)
-            ?? await _userRepository.GetByUserEmailAsync(subjectUser);
+        var user = await _userRepository.GetByUserIdOrEmailAsync(subjectUser);
         if (user == null)
         {
             return (false, "Invalid user ID", new CachedCertificateValidation { IsValid = false });

--- a/XiansAi.Server.Src/Features/AgentApi/Auth/CertificateUserAccess.cs
+++ b/XiansAi.Server.Src/Features/AgentApi/Auth/CertificateUserAccess.cs
@@ -1,0 +1,36 @@
+using Shared.Data.Models;
+using Shared.Repositories;
+
+namespace Features.AgentApi.Auth;
+
+/// <summary>
+/// What a certificate naming one user account acts as. Delegates to
+/// <see cref="EmailIdentityResolution"/> so the user-id path and the email path cannot
+/// drift: a locked-out account is unusable, and only an approved membership of the
+/// certificate's tenant contributes roles.
+/// </summary>
+public static class CertificateUserAccess
+{
+    public const string LockedOutError = "User account is locked out";
+    public const string InvalidUserError = "Invalid user ID";
+
+    /// <summary>
+    /// The identity this one account authenticates as, or an error when it cannot.
+    /// </summary>
+    public static (string? Error, EmailIdentityResolution? Identity) Resolve(
+        User user, string tenantId, ILogger logger)
+    {
+        var identity = EmailIdentityResolution.From(
+            string.IsNullOrWhiteSpace(user.Email) ? user.UserId : user.Email,
+            new[] { user },
+            tenantId,
+            logger);
+
+        if (identity != null)
+        {
+            return (null, identity);
+        }
+
+        return (user.IsLockedOut ? LockedOutError : InvalidUserError, null);
+    }
+}

--- a/XiansAi.Server.Src/Features/AgentApi/Auth/ICertificateValidationCache.cs
+++ b/XiansAi.Server.Src/Features/AgentApi/Auth/ICertificateValidationCache.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Caching.Memory;
 using System;
 using System.Collections.Generic;
+using Shared.Services;
 using Shared.Utils;
 
 namespace Features.AgentApi.Auth;
@@ -46,6 +47,7 @@ public interface ICertificateValidationCache
 public class MemoryCertificateValidationCache : ICertificateValidationCache
 {
     private readonly IMemoryCache _cache;
+    private readonly IUserCacheIndex _userCacheIndex;
     private readonly ILogger<MemoryCertificateValidationCache> _logger;
     private readonly TimeSpan _cacheDuration;
     private readonly TimeSpan _cacheMaxDuration;
@@ -53,20 +55,24 @@ public class MemoryCertificateValidationCache : ICertificateValidationCache
 
     public MemoryCertificateValidationCache(
         IMemoryCache cache,
+        IUserCacheIndex userCacheIndex,
         ILogger<MemoryCertificateValidationCache> logger,
         IConfiguration configuration)
     {
         _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _userCacheIndex = userCacheIndex ?? throw new ArgumentNullException(nameof(userCacheIndex));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         
         // Idle window: an agent that keeps calling within this window never revalidates.
         _cacheDuration = TimeSpan.FromMinutes(
-            configuration.GetValue<double>("AgentApi:CertificateValidationCacheDurationMinutes", 10));
+            configuration.GetValue<double>("AgentApi:CertificateValidationCacheDurationMinutes", 2));
 
-        // Hard ceiling regardless of activity. Revocation and deletion evict the entry directly,
-        // so this only bounds staleness when the eviction happened on another server instance.
+        // Hard ceiling regardless of activity. Revoking a certificate and disabling the account
+        // both evict the entry directly, so this only bounds staleness on the server instances
+        // that did not handle that request. Matched to the token and role caches, so that every
+        // cached authorization decision has the same worst case on the instances it did not reach.
         _cacheMaxDuration = TimeSpan.FromMinutes(
-            configuration.GetValue<double>("AgentApi:CertificateValidationCacheMaxDurationMinutes", 30));
+            configuration.GetValue<double>("AgentApi:CertificateValidationCacheMaxDurationMinutes", 5));
 
         if (_cacheMaxDuration < _cacheDuration)
         {
@@ -127,9 +133,17 @@ public class MemoryCertificateValidationCache : ICertificateValidationCache
             .SetSlidingExpiration(_cacheDuration)
             .SetAbsoluteExpiration(_cacheMaxDuration)
             .SetPriority(CacheItemPriority.Normal)
-            .SetSize(_cacheEntrySize);
+            .SetSize(_cacheEntrySize)
+            .RegisterPostEvictionCallback(
+                (key, _, _, _) => _userCacheIndex.Forget(validation.UserId, key.ToString() ?? string.Empty));
         
         _cache.Set(cacheKey, validation, cacheOptions);
+
+        // Tracked against the account the certificate resolved to, so that disabling that account
+        // stops its agents rather than leaving them running until the entry ages out. The entry
+        // holds the roles and the SysAdmin flag, so a cache hit never revisits the record.
+        _userCacheIndex.Track(validation.UserId, cacheKey);
+
         _logger.LogDebug("Cached successful certificate validation for thumbprint: {Thumbprint}", thumbprint);
     }
 

--- a/XiansAi.Server.Src/Features/UserApi/Auth/AuthorizedTenantResolver.cs
+++ b/XiansAi.Server.Src/Features/UserApi/Auth/AuthorizedTenantResolver.cs
@@ -77,6 +77,7 @@ public class AuthorizedTenantResolver : IAuthorizedTenantResolver
 
     private readonly IUserTenantService _userTenantService;
     private readonly IMemoryCache _cache;
+    private readonly OidcValidationPolicy _policy;
     private readonly ILogger<AuthorizedTenantResolver> _logger;
     private readonly TimeSpan _cacheDuration;
 
@@ -84,10 +85,12 @@ public class AuthorizedTenantResolver : IAuthorizedTenantResolver
         IUserTenantService userTenantService,
         IMemoryCache cache,
         IConfiguration configuration,
+        OidcValidationPolicy policy,
         ILogger<AuthorizedTenantResolver> logger)
     {
         _userTenantService = userTenantService;
         _cache = cache;
+        _policy = policy;
         _logger = logger;
         _cacheDuration = TimeSpan.FromSeconds(
             configuration.GetValue<double>("Auth:ApprovedTenantCacheDurationSeconds", 30));
@@ -171,17 +174,41 @@ public class AuthorizedTenantResolver : IAuthorizedTenantResolver
             return cachedAccess;
         }
 
-        // The requested tenant is passed through so a user who is not a member of it is registered
-        // as pending there and becomes visible to its admins. It does not widen what comes back:
-        // the result is still only the tenants they are approved for.
+        // The address is recorded whether or not the provider vouched for it, because a record with
+        // no address cannot be matched to a person at all. Whether it may decide *identity* is a
+        // separate question the stored EmailVerified flag answers: an unverified claim is only
+        // display and contact, or someone able to assert an arbitrary email at their IdP could claim
+        // a victim's address. See OidcTokenInspector.IsEmailVerified.
         //
-        // Email is unique and used to decide account identity (CreateNewUser, ParticipantId, email
-        // lookups). An unverified claim must not participate in that — only display/contact — or an
-        // attacker who can assert an arbitrary email at their IdP can claim a victim's address
-        // (provisioning lockout / conversation-namespace squatting). See OidcTokenInspector.IsEmailVerified.
-        var emailForLinking = validation.EmailVerified ? validation.Email : null;
+        // The membership is created approved when the token was checked against the audiences this
+        // tenant declared, because that is what makes holding one the tenant's own statement that
+        // this person belongs to it — unlike the WebAPI console, which validates against the
+        // deployment-wide provider and therefore still requires an admin to approve.
+        //
+        // A provider that declares no audience accepts anything its issuer signed, including a
+        // token minted for an unrelated application there, so holding one says nothing about this
+        // tenant. Those fall back to a pending membership for an admin to approve, which is where
+        // they sat before automatic approval existed. Declaring an audience is what earns it.
+        if (!validation.AudienceValidated)
+        {
+            _policy.WarnAboutConfiguration("approval:" + requestedTenantId,
+                "Not auto-approving membership of tenant {TenantId}: its OIDC provider declares no " +
+                "expectedAudience, so this token was accepted on its issuer's signature alone. New " +
+                "members wait for an admin until expectedAudience is set on the provider.",
+                LogSanitizer.Sanitize(requestedTenantId));
+        }
+
         var result = await _userTenantService.EnsureUserAndGetApprovedTenants(
-            providerUserId, emailForLinking, validation.Name, providerAuthority, requestedTenantId);
+            new SignInIdentity
+            {
+                UserId = providerUserId,
+                Email = validation.Email,
+                EmailVerified = validation.EmailVerified,
+                Name = validation.Name,
+                ProviderAuthority = providerAuthority
+            },
+            requestedTenantId,
+            approveNewMembership: validation.AudienceValidated);
 
         if (!result.IsSuccess || result.Data == null)
         {

--- a/XiansAi.Server.Src/Features/UserApi/Auth/AuthorizedTenantResolver.cs
+++ b/XiansAi.Server.Src/Features/UserApi/Auth/AuthorizedTenantResolver.cs
@@ -86,6 +86,7 @@ public class AuthorizedTenantResolver : IAuthorizedTenantResolver
 
     private readonly IUserTenantService _userTenantService;
     private readonly IMemoryCache _cache;
+    private readonly IUserCacheIndex _userCacheIndex;
     private readonly OidcValidationPolicy _policy;
     private readonly ILogger<AuthorizedTenantResolver> _logger;
     private readonly TimeSpan _cacheDuration;
@@ -93,12 +94,14 @@ public class AuthorizedTenantResolver : IAuthorizedTenantResolver
     public AuthorizedTenantResolver(
         IUserTenantService userTenantService,
         IMemoryCache cache,
+        IUserCacheIndex userCacheIndex,
         IConfiguration configuration,
         OidcValidationPolicy policy,
         ILogger<AuthorizedTenantResolver> logger)
     {
         _userTenantService = userTenantService;
         _cache = cache;
+        _userCacheIndex = userCacheIndex;
         _policy = policy;
         _logger = logger;
         _cacheDuration = TimeSpan.FromSeconds(
@@ -185,11 +188,10 @@ public class AuthorizedTenantResolver : IAuthorizedTenantResolver
             return cachedAccess;
         }
 
-        // The address is recorded whether or not the provider vouched for it, because a record with
-        // no address cannot be matched to a person at all. Whether it may decide *identity* is a
-        // separate question the stored EmailVerified flag answers: an unverified claim is only
-        // display and contact, or someone able to assert an arbitrary email at their IdP could claim
-        // a victim's address. See OidcTokenInspector.IsEmailVerified.
+        // The address is recorded whatever it is worth, because a record with no address cannot be
+        // matched to a person at all. It never decides identity on its own: the record is keyed on
+        // the provider subject, and an address held by more than one account resolves through
+        // EmailIdentityResolution rather than naming one of them.
         //
         // The membership is created approved when the token was checked against the audiences this
         // tenant declared, because that is what makes holding one the tenant's own statement that
@@ -214,7 +216,6 @@ public class AuthorizedTenantResolver : IAuthorizedTenantResolver
             {
                 UserId = providerUserId,
                 Email = validation.Email,
-                EmailVerified = validation.EmailVerified,
                 Name = validation.Name,
                 ProviderAuthority = providerAuthority
             },
@@ -239,8 +240,15 @@ public class AuthorizedTenantResolver : IAuthorizedTenantResolver
 
         var cacheOptions = new MemoryCacheEntryOptions()
             .SetAbsoluteExpiration(_cacheDuration)
-            .SetSize(1);
+            .SetSize(1)
+            .RegisterPostEvictionCallback(
+                (key, _, _, _) => _userCacheIndex.Forget(access.AccountUserId, key.ToString() ?? string.Empty));
         _cache.Set(cacheKey, access, cacheOptions);
+
+        // Tracked against the account rather than the key, which is built from what the token
+        // presented and cannot be reconstructed when an administrator disables the account. The
+        // entry carries the approved tenants, so a hit skips the lockout check entirely.
+        _userCacheIndex.Track(access.AccountUserId, cacheKey);
 
         return access;
     }

--- a/XiansAi.Server.Src/Features/UserApi/Auth/AuthorizedTenantResolver.cs
+++ b/XiansAi.Server.Src/Features/UserApi/Auth/AuthorizedTenantResolver.cs
@@ -28,9 +28,16 @@ public class AuthorizedTenantResolution
     public string? AccountUserId { get; private init; }
 
     /// <summary>
-    /// The account's stored email when present. Null when unauthorized or the account has no email.
+    /// The address that may namespace this account's message threads. Null when unauthorized, when
+    /// the account has no email, or when another account holds the same one.
     /// </summary>
-    public string? Email { get; private init; }
+    public string? ConversationEmail { get; private init; }
+
+    /// <summary>
+    /// The address stored on the account, which identifies the caller but namespaces nothing. Null
+    /// when unauthorized or the account has no email.
+    /// </summary>
+    public string? AccountEmail { get; private init; }
 
     public static AuthorizedTenantResolution Denied() => new();
 
@@ -38,14 +45,16 @@ public class AuthorizedTenantResolution
         string matchedTenantId,
         List<string> authorizedTenantIds,
         string accountUserId,
-        string? email = null) =>
+        string? conversationEmail = null,
+        string? accountEmail = null) =>
         new()
         {
             IsAuthorized = true,
             MatchedTenantId = matchedTenantId,
             AuthorizedTenantIds = authorizedTenantIds,
             AccountUserId = accountUserId,
-            Email = email
+            ConversationEmail = conversationEmail,
+            AccountEmail = accountEmail
         };
 }
 
@@ -127,7 +136,8 @@ public class AuthorizedTenantResolver : IAuthorizedTenantResolver
 
         // Copied because the source list may be a shared cache entry.
         return AuthorizedTenantResolution.Authorized(
-            matchedTenantId, access.TenantIds.ToList(), access.AccountUserId, access.Email);
+            matchedTenantId, access.TenantIds.ToList(), access.AccountUserId,
+            access.ConversationEmail, access.AccountEmail);
     }
 
     /// <summary>The account a token resolves to and the tenants it is approved for.</summary>
@@ -135,7 +145,8 @@ public class AuthorizedTenantResolver : IAuthorizedTenantResolver
     {
         public required string AccountUserId { get; init; }
         public required IReadOnlyList<string> TenantIds { get; init; }
-        public string? Email { get; init; }
+        public string? ConversationEmail { get; init; }
+        public string? AccountEmail { get; init; }
     }
 
     /// <summary>
@@ -222,7 +233,8 @@ public class AuthorizedTenantResolver : IAuthorizedTenantResolver
         {
             AccountUserId = result.Data.UserId,
             TenantIds = result.Data.Tenants.Select(t => t.TenantId).ToArray(),
-            Email = result.Data.Email
+            ConversationEmail = result.Data.ConversationEmail,
+            AccountEmail = result.Data.AccountEmail
         };
 
         var cacheOptions = new MemoryCacheEntryOptions()

--- a/XiansAi.Server.Src/Features/UserApi/Auth/UserApiCredentialAuthenticator.cs
+++ b/XiansAi.Server.Src/Features/UserApi/Auth/UserApiCredentialAuthenticator.cs
@@ -298,15 +298,14 @@ public class UserApiCredentialAuthenticator : IUserApiCredentialAuthenticator
         // Records written by this path are attributed to the canonical `provider|subject` id.
         var canonicalUserId = validation.CanonicalUserId!;
 
-        // Conversation identity prefers the account's stored email when present so clients that
-        // still pass email as participantId (and historical threads keyed by email) keep working
-        // while the account remains the provider subject. Falls back to the token subject when the
-        // account has no email.
-        var accountEmail = string.IsNullOrWhiteSpace(resolution.Email)
-            ? null
-            : resolution.Email.Trim().ToLowerInvariant();
+        // Two addresses with different jobs. The conversation one namespaces message threads, so it
+        // is only present when it names a single account; the token subject stands in otherwise.
+        // The account one merely identifies the caller, so it is set either way and lets someone
+        // whose address is shared still be recognised when they name themselves by it.
+        var conversationEmail = Normalize(resolution.ConversationEmail);
+        var accountEmail = Normalize(resolution.AccountEmail);
         var providerSubject = validation.ProviderUserId;
-        var participantId = accountEmail ?? providerSubject;
+        var participantId = conversationEmail ?? providerSubject;
 
         _tenantContext.LoggedInUser = canonicalUserId;
         _tenantContext.UserType = UserType.UserToken;
@@ -350,6 +349,11 @@ public class UserApiCredentialAuthenticator : IUserApiCredentialAuthenticator
         }
 
         return Succeed(claims, schemeName);
+    }
+
+    private static string? Normalize(string? email)
+    {
+        return string.IsNullOrWhiteSpace(email) ? null : email.Trim().ToLowerInvariant();
     }
 
     private AuthenticateResult SucceedAsApiKey(ApiKey apiKey, string schemeName)

--- a/XiansAi.Server.Src/Features/UserApi/Utils/ParticipantIdResolver.cs
+++ b/XiansAi.Server.Src/Features/UserApi/Utils/ParticipantIdResolver.cs
@@ -15,8 +15,14 @@ public readonly record struct ResolvedParticipant(string ParticipantId, string? 
 public static class ParticipantIdResolver
 {
     /// <summary>
-    /// Resolves the participant id for a request. An explicitly supplied id wins; otherwise the
-    /// caller's own participant id from the authenticated token is used.
+    /// Resolves the participant id for a request. An id naming someone else wins; naming yourself,
+    /// by any of the identifiers you answer to, is the same as naming no one and yields your own
+    /// participant id.
+    ///
+    /// That equivalence is what lets a client keep sending an email address whose owner is not
+    /// unique. The address cannot namespace threads — two accounts hold it, and one namespace would
+    /// merge their conversations — but it still identifies the caller, so it resolves to the id
+    /// they were actually issued rather than being refused.
     ///
     /// Ids are lowercased because participant ids are frequently email addresses, and callers are
     /// inconsistent about casing.
@@ -34,9 +40,13 @@ public static class ParticipantIdResolver
         var ownParticipantId = (tenantContext.ParticipantId ?? string.Empty).ToLowerInvariant();
         var canonicalLoginId = (tenantContext.LoggedInUser ?? string.Empty).ToLowerInvariant();
 
-        var participantId = string.IsNullOrEmpty(requestedParticipantId)
-            ? ownParticipantId
-            : requestedParticipantId.ToLowerInvariant();
+        var namesSomeoneElse =
+            !string.IsNullOrEmpty(requestedParticipantId) &&
+            !NamesSelf(requestedParticipantId, tenantContext);
+
+        var participantId = namesSomeoneElse
+            ? requestedParticipantId!.ToLowerInvariant()
+            : ownParticipantId;
 
         // The fallback is only meaningful for the caller's own threads, and only when the two ids
         // actually differ.
@@ -74,8 +84,7 @@ public static class ParticipantIdResolver
     ///
     /// API keys are tenant-scoped service credentials held by trusted callers that legitimately act
     /// on behalf of many end users, so they may name any participant. A token holder may only name
-    /// themselves: their conversation participant id, canonical login id, account email, or raw
-    /// provider subject — clients pass any of these depending on era and client code.
+    /// themselves.
     /// </summary>
     public static bool CanActAs(string? participantId, ITenantContext tenantContext)
     {
@@ -84,11 +93,16 @@ public static class ParticipantIdResolver
             return true;
         }
 
-        if (string.IsNullOrEmpty(participantId))
-        {
-            return false;
-        }
+        return !string.IsNullOrEmpty(participantId) && NamesSelf(participantId, tenantContext);
+    }
 
+    /// <summary>
+    /// Whether the id is one the caller answers to: their conversation participant id, canonical
+    /// login id, account email, or raw provider subject — clients pass any of these depending on
+    /// era and client code.
+    /// </summary>
+    private static bool NamesSelf(string participantId, ITenantContext tenantContext)
+    {
         return MatchesOwnId(participantId, tenantContext.ParticipantId) ||
                MatchesOwnId(participantId, tenantContext.LoggedInUser) ||
                MatchesOwnId(participantId, tenantContext.Email) ||

--- a/XiansAi.Server.Src/Features/WebApi/Services/RoleManagementService.cs
+++ b/XiansAi.Server.Src/Features/WebApi/Services/RoleManagementService.cs
@@ -86,6 +86,10 @@ namespace Features.WebApi.Services
                 if (user == null)
                     return ServiceResult<bool>.NotFound("User not found");
 
+                var sharedEmail = await FindSharedEmailConflictAsync(user);
+                if (sharedEmail != null)
+                    return sharedEmail;
+
                 user.IsSysAdmin = true;
                 var result = await _userRepository.UpdateAsync(_tenantContext.LoggedInUser, user);
                 _roleCacheService.InvalidateUserRoles(_tenantContext.LoggedInUser, _tenantContext.TenantId);
@@ -116,6 +120,10 @@ namespace Features.WebApi.Services
                 if (user == null)
                     return ServiceResult<bool>.NotFound("User not found");
 
+                var sharedEmail = await FindSharedEmailConflictAsync(user);
+                if (sharedEmail != null)
+                    return sharedEmail;
+
                 user.IsSysAdmin = true;
 
                 var result = await _userRepository.UpdateAsync(userId, user);
@@ -129,6 +137,32 @@ namespace Features.WebApi.Services
                 _logger.LogError(ex, "Error assigning roles to user {UserId}", LogSanitizer.Sanitize(userId));
                 return ServiceResult<bool>.InternalServerError("Error assigning roles");
             }
+        }
+
+        /// <summary>
+        /// Refuses a promotion whose address is held by more than one account, or null when it may
+        /// go ahead.
+        ///
+        /// Granting the role to one of several accounts sharing an address changes what that
+        /// address resolves to for all of them, so it is not a decision this endpoint should make
+        /// as a side effect of ordinary role management. The global user endpoint is the one place
+        /// that accepts it, where the operator is looking at every account holding the address.
+        /// </summary>
+        private async Task<ServiceResult<bool>?> FindSharedEmailConflictAsync(User user)
+        {
+            if (string.IsNullOrWhiteSpace(user.Email))
+                return null;
+
+            if (!await _userRepository.IsEmailSharedAsync(user.Email, user.UserId))
+                return null;
+
+            _logger.LogWarning(
+                "Refusing to grant SysAdmin to {UserId}: another account holds the same email",
+                LogSanitizer.Sanitize(user.UserId));
+            return ServiceResult<bool>.Conflict(
+                "More than one account holds this email address, so the system administrator role " +
+                "cannot be granted from here. Use the global user administration endpoint, which " +
+                "shows every account holding the address.");
         }
 
         public async Task<ServiceResult<bool>> RemoveSysAdminRolesToUserAsync(string userId)

--- a/XiansAi.Server.Src/Shared/Auth/DynamicOidcValidator.cs
+++ b/XiansAi.Server.Src/Shared/Auth/DynamicOidcValidator.cs
@@ -169,7 +169,11 @@ public class DynamicOidcValidator : IDynamicOidcValidator
                 OidcTokenInspector.GetEmail(jwt),
                 OidcTokenInspector.GetName(jwt),
                 OidcTokenInspector.ExpiresAt(jwt),
-                OidcTokenInspector.IsEmailVerified(jwt));
+                OidcTokenInspector.IsEmailVerified(jwt),
+                // The parameters record whether the provider declared any audience to check
+                // against, so callers can tell an audience-checked token from one accepted on its
+                // issuer's signature alone.
+                parameters.ValidateAudience);
         }
         catch (SecurityTokenException ex)
         {

--- a/XiansAi.Server.Src/Shared/Auth/DynamicOidcValidator.cs
+++ b/XiansAi.Server.Src/Shared/Auth/DynamicOidcValidator.cs
@@ -169,7 +169,6 @@ public class DynamicOidcValidator : IDynamicOidcValidator
                 OidcTokenInspector.GetEmail(jwt),
                 OidcTokenInspector.GetName(jwt),
                 OidcTokenInspector.ExpiresAt(jwt),
-                OidcTokenInspector.IsEmailVerified(jwt),
                 // The parameters record whether the provider declared any audience to check
                 // against, so callers can tell an audience-checked token from one accepted on its
                 // issuer's signature alone.

--- a/XiansAi.Server.Src/Shared/Auth/OidcTokenInspector.cs
+++ b/XiansAi.Server.Src/Shared/Auth/OidcTokenInspector.cs
@@ -143,8 +143,7 @@ public static class OidcTokenInspector
     }
 
     /// <summary>
-    /// The address to record for display and contact, which is a looser question than who the caller
-    /// is — see <see cref="IsEmailVerified"/> for that.
+    /// The address to record for display and contact.
     ///
     /// <c>emails</c> is Azure AD B2C's array spelling. Some B2C user flows (including custom
     /// policies) instead issue a single <c>emailAddress</c> string — without that spelling a B2C
@@ -158,41 +157,6 @@ public static class OidcTokenInspector
 
     public static string? GetName(JsonWebToken jwt) =>
         FirstPresent(jwt, ["name", ClaimTypes.Name, "preferred_username"]).Value;
-
-    /// <summary>
-    /// Whether the provider states that the holder actually owns the address in the token, which is
-    /// the only basis on which an email may be used to decide *who someone is* rather than merely how
-    /// to display or contact them.
-    ///
-    /// Deliberately stricter than <see cref="GetEmail"/>. That method falls back to
-    /// <c>preferred_username</c> and <c>upn</c>, which are frequently not addresses at all and are
-    /// editable by the user at many providers, and to B2C's <c>emails</c>, which carries no
-    /// verification signal — a B2C address may come from a social account the directory never
-    /// checked. Only a genuine <c>email</c> claim backed by one of the verification claims below
-    /// counts here, so a B2C sign-in is never verified on the token's own evidence.
-    ///
-    /// <c>xms_edov</c> is accepted alongside the standard <c>email_verified</c> because Entra ID does
-    /// not issue the latter — it publishes <c>xms_edov</c> to say the email's domain was verified by
-    /// its owner. Without one of the two, an Entra <c>email</c> is settable by any tenant
-    /// administrator to any string, which is the nOAuth account-takeover pattern.
-    /// </summary>
-    public static bool IsEmailVerified(JsonWebToken jwt)
-    {
-        var email = FirstPresent(jwt, ["email", ClaimTypes.Email]).Value;
-        if (string.IsNullOrWhiteSpace(email))
-        {
-            return false;
-        }
-
-        return IsTrueClaim(jwt, "email_verified") || IsTrueClaim(jwt, "xms_edov");
-    }
-
-    /// <summary>
-    /// Reads a boolean claim. Providers serialize these as both JSON booleans and strings, and the
-    /// two arrive here as "True" and "true" respectively, so the comparison ignores case.
-    /// </summary>
-    private static bool IsTrueClaim(JsonWebToken jwt, string claimType) =>
-        string.Equals(GetExactClaim(jwt, claimType), "true", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Checks that the token carries every scope the provider requires, or returns null when the

--- a/XiansAi.Server.Src/Shared/Auth/OidcValidationResult.cs
+++ b/XiansAi.Server.Src/Shared/Auth/OidcValidationResult.cs
@@ -34,6 +34,17 @@ public class OidcValidationResult
     /// </summary>
     public bool EmailVerified { get; init; }
 
+    /// <summary>
+    /// Whether the token was checked against the audiences the provider declared, rather than being
+    /// accepted on its issuer's signature alone.
+    ///
+    /// False means only that the issuer signed it — it may have been minted for an entirely
+    /// different application at that same identity provider. Anything that treats holding a token
+    /// as the tenant's own statement about the caller needs this to be true, because that is what
+    /// the audience says and the signature does not.
+    /// </summary>
+    public bool AudienceValidated { get; init; }
+
     public string? Name { get; init; }
     public string? Error { get; init; }
 
@@ -53,7 +64,8 @@ public class OidcValidationResult
         string? email,
         string? name,
         DateTimeOffset? tokenExpiresAt = null,
-        bool emailVerified = false) =>
+        bool emailVerified = false,
+        bool audienceValidated = false) =>
         new()
         {
             Success = true,
@@ -62,6 +74,7 @@ public class OidcValidationResult
             ProviderAuthority = providerAuthority,
             Email = email,
             EmailVerified = emailVerified,
+            AudienceValidated = audienceValidated,
             Name = name,
             TokenExpiresAt = tokenExpiresAt
         };

--- a/XiansAi.Server.Src/Shared/Auth/OidcValidationResult.cs
+++ b/XiansAi.Server.Src/Shared/Auth/OidcValidationResult.cs
@@ -29,12 +29,6 @@ public class OidcValidationResult
     public string? Email { get; init; }
 
     /// <summary>
-    /// Whether the provider states the holder owns <see cref="Email"/>. Only this justifies using the
-    /// address to decide which account the caller is; an unverified one is for display and contact.
-    /// </summary>
-    public bool EmailVerified { get; init; }
-
-    /// <summary>
     /// Whether the token was checked against the audiences the provider declared, rather than being
     /// accepted on its issuer's signature alone.
     ///
@@ -64,7 +58,6 @@ public class OidcValidationResult
         string? email,
         string? name,
         DateTimeOffset? tokenExpiresAt = null,
-        bool emailVerified = false,
         bool audienceValidated = false) =>
         new()
         {
@@ -73,7 +66,6 @@ public class OidcValidationResult
             ProviderUserId = providerUserId,
             ProviderAuthority = providerAuthority,
             Email = email,
-            EmailVerified = emailVerified,
             AudienceValidated = audienceValidated,
             Name = name,
             TokenExpiresAt = tokenExpiresAt

--- a/XiansAi.Server.Src/Shared/Auth/SystemRoles.cs
+++ b/XiansAi.Server.Src/Shared/Auth/SystemRoles.cs
@@ -5,6 +5,14 @@ public static class SystemRoles
     public const string TenantParticipant = "TenantParticipant";
     public const string TenantParticipantAdmin = "TenantParticipantAdmin";
     public const string TenantUser = "TenantUser";
+
+    /// <summary>
+    /// Drops the participant roles from the set an authenticated caller acts with. A participant is
+    /// someone an agent can hold a conversation with rather than someone who signs in, so the role
+    /// exists to be queried through the Admin API, not to carry access on a request.
+    /// </summary>
+    public static List<string> ExcludingParticipantRoles(IEnumerable<string> roles) =>
+        roles.Where(role => role != TenantParticipant && role != TenantParticipantAdmin).ToList();
 }
 
 public static class Policies

--- a/XiansAi.Server.Src/Shared/Auth/TenantContext.cs
+++ b/XiansAi.Server.Src/Shared/Auth/TenantContext.cs
@@ -28,8 +28,11 @@ namespace Shared.Auth;
         string ParticipantId { get; set; }
 
         /// <summary>
-        /// The account's stored email when known. A token holder may name this as
-        /// <see cref="ParticipantId"/> even when the account is keyed by a provider subject.
+        /// The account's stored email when known. A token holder may name themselves by it, which
+        /// resolves to their <see cref="ParticipantId"/>.
+        ///
+        /// It identifies the caller but must not namespace anything: another account can hold the
+        /// same address, in which case <see cref="ParticipantId"/> is deliberately something else.
         /// </summary>
         string? Email { get; set; }
 

--- a/XiansAi.Server.Src/Shared/Configuration/SharedConfiguration.cs
+++ b/XiansAi.Server.Src/Shared/Configuration/SharedConfiguration.cs
@@ -84,6 +84,11 @@ public static class SharedConfiguration
         // Register HttpClient for token services
         builder.Services.AddHttpClient();
 
+        // Which cache entries belong to which user, so that disabling an account can drop them.
+        // Singleton because the caches that populate it are scoped, and an index that went out of
+        // scope with the request that wrote the entry could never evict it later.
+        builder.Services.AddSingleton<IUserCacheIndex, UserCacheIndex>();
+
         // Register token validation cache
         builder.Services.AddScoped<ITokenValidationCache, MemoryTokenValidationCache>();
 
@@ -233,6 +238,7 @@ public static class SharedConfiguration
         builder.Services.AddHttpClient();              
         builder.Services.AddScoped<IApiKeyService, ApiKeyService>();
         builder.Services.AddScoped<IRoleCacheService, RoleCacheService>();
+        builder.Services.AddScoped<IUserAuthorizationInvalidator, UserAuthorizationInvalidator>();
         builder.Services.AddSingleton<ITenantCacheService, TenantCacheService>();
         builder.Services.AddScoped<IUserTenantService, UserTenantService>();
         builder.Services.AddScoped<IUserManagementService, UserManagementService>();

--- a/XiansAi.Server.Src/Shared/Data/Models/User.cs
+++ b/XiansAi.Server.Src/Shared/Data/Models/User.cs
@@ -27,20 +27,6 @@ public class User
         set => _email = value.ToLowerInvariant();
     }
 
-    /// <summary>
-    /// Whether the provider stated that the holder owns <see cref="Email"/>, rather than merely
-    /// asserting it. Only a verified address may decide *who someone is* — the uniqueness check that
-    /// stops a new sign-in from taking over an existing account turns on this. An unverified address
-    /// is still stored, because display and contact do not need that proof, and because refusing to
-    /// store one leaves the record with no address at all.
-    ///
-    /// False on records created before this existed, so treat it as "not known to be verified"
-    /// rather than "known to be unverified".
-    /// </summary>
-    [BsonElement("email_verified")]
-    [JsonPropertyName("emailVerified")]
-    public bool EmailVerified { get; set; }
-
     [BsonElement("name")]
     [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;

--- a/XiansAi.Server.Src/Shared/Data/Models/User.cs
+++ b/XiansAi.Server.Src/Shared/Data/Models/User.cs
@@ -4,6 +4,8 @@ using System.Text.Json.Serialization;
 
 namespace Shared.Data.Models;
 
+// Documents may carry fields written by newer server versions; ignoring them keeps reads working.
+[BsonIgnoreExtraElements]
 public class User
 {
     [BsonId]
@@ -62,6 +64,7 @@ public class User
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 }
 
+[BsonIgnoreExtraElements]
 public class TenantRole
 {
     [BsonElement("tenant")]

--- a/XiansAi.Server.Src/Shared/Data/Models/User.cs
+++ b/XiansAi.Server.Src/Shared/Data/Models/User.cs
@@ -27,6 +27,20 @@ public class User
         set => _email = value.ToLowerInvariant();
     }
 
+    /// <summary>
+    /// Whether the provider stated that the holder owns <see cref="Email"/>, rather than merely
+    /// asserting it. Only a verified address may decide *who someone is* — the uniqueness check that
+    /// stops a new sign-in from taking over an existing account turns on this. An unverified address
+    /// is still stored, because display and contact do not need that proof, and because refusing to
+    /// store one leaves the record with no address at all.
+    ///
+    /// False on records created before this existed, so treat it as "not known to be verified"
+    /// rather than "known to be unverified".
+    /// </summary>
+    [BsonElement("email_verified")]
+    [JsonPropertyName("emailVerified")]
+    public bool EmailVerified { get; set; }
+
     [BsonElement("name")]
     [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;

--- a/XiansAi.Server.Src/Shared/Data/MongoIndexSynchronizer.cs
+++ b/XiansAi.Server.Src/Shared/Data/MongoIndexSynchronizer.cs
@@ -20,6 +20,53 @@ public class MongoIndexDefinition
     public bool? Sparse { get; init; }
     public bool? Background { get; init; }
     public TimeSpan? ExpireAfter { get; init; }
+
+    /// <summary>
+    /// Returns true when an index already present in MongoDB still matches this definition.
+    /// Only the options this definition can express are compared, so unrelated server-side
+    /// metadata is never mistaken for drift. "background" is excluded because MongoDB has
+    /// ignored and stopped reporting it since 4.2.
+    /// </summary>
+    public bool MatchesExistingIndex(BsonDocument existingIndex)
+    {
+        if (existingIndex == null)
+            return false;
+
+        return KeysMatch(existingIndex)
+            && existingIndex.GetValue("unique", false).ToBoolean() == (Unique ?? false)
+            && existingIndex.GetValue("sparse", false).ToBoolean() == (Sparse ?? false)
+            && ExpiryMatches(existingIndex);
+    }
+
+    private bool KeysMatch(BsonDocument existingIndex)
+    {
+        if (!existingIndex.TryGetValue("key", out var keyValue) || keyValue is not BsonDocument existingKeys)
+            return false;
+
+        if (existingKeys.ElementCount != Keys.Count)
+            return false;
+
+        return existingKeys
+            .Zip(Keys, (existing, expected) =>
+                existing.Name == expected.Key
+                && existing.Value.IsNumeric
+                && existing.Value.ToInt32() == DirectionValue(expected.Value))
+            .All(keyMatches => keyMatches);
+    }
+
+    private static int DirectionValue(string direction) =>
+        string.Equals(direction, "desc", StringComparison.OrdinalIgnoreCase) ? -1 : 1;
+
+    private bool ExpiryMatches(BsonDocument existingIndex)
+    {
+        if (!existingIndex.TryGetValue("expireAfterSeconds", out var existingExpiry))
+            return !ExpireAfter.HasValue;
+
+        if (!ExpireAfter.HasValue || !existingExpiry.IsNumeric)
+            return false;
+
+        return Math.Abs(existingExpiry.ToDouble() - ExpireAfter.Value.TotalSeconds) < 1;
+    }
 }
 
 public class MongoIndexSynchronizer(
@@ -37,8 +84,11 @@ public class MongoIndexSynchronizer(
         var collectionsCursor = await database.ListCollectionNamesAsync();
         var collections = await collectionsCursor.ToListAsync();
 
-        var expectedIndexes = await GetExpectedIndexesAsync();
-        foreach (var (collectionName, indexes) in expectedIndexes)
+        // Detect if we're using Cosmos DB by checking connection string or error patterns
+        var isCosmosDb = await IsCosmosDbAsync(database);
+
+        var expectedIndexes = await GetIndexDefinitionsAsync();
+        foreach (var (collectionName, definitions) in expectedIndexes.OrderBy(kvp => kvp.Key))
         {
             try
             {
@@ -50,64 +100,7 @@ public class MongoIndexSynchronizer(
                 }
 
                 var collection = database.GetCollection<object>(collectionName);
-                
-                // Get existing indexes
-                var existingIndexes = await (await collection.Indexes.ListAsync()).ToListAsync();
-                var existingIndexNames = existingIndexes.Select(i => i["name"].AsString).ToHashSet();
-                var expectedIndexNames = indexes.Select(i => i.Options.Name).ToHashSet();
-
-                // Detect if we're using Cosmos DB by checking connection string or error patterns
-                var isCosmosDb = await IsCosmosDbAsync(database);
-
-                if (!isCosmosDb)
-                {
-                    // For regular MongoDB, drop unused indexes (except _id_)
-                    foreach (var index in existingIndexes)
-                    {
-                        var indexName = index["name"].AsString;
-                        if (indexName != "_id_" && !expectedIndexNames.Contains(indexName))
-                        {
-                            logger.LogInformation("Dropping unused index {IndexName} from collection {CollectionName}", 
-                                indexName, collectionName);
-                            try
-                            {
-                                await collection.Indexes.DropOneAsync(indexName);
-                            }
-                            catch (Exception dropEx)
-                            {
-                                logger.LogWarning(dropEx, "Failed to drop index {IndexName} from collection {CollectionName}, continuing", 
-                                    indexName, collectionName);
-                            }
-                        }
-                    }
-                }
-                else
-                {
-                    logger.LogInformation("Detected Cosmos DB - skipping index drops for collection {CollectionName}", collectionName);
-                }
-
-                // Create missing indexes with Cosmos DB error handling
-                var indexesToCreate = indexes
-                    .Where(i => !existingIndexNames.Contains(i.Options.Name))
-                    .ToList();
-
-                if (indexesToCreate.Count != 0)
-                {
-                    logger.LogInformation("Creating {Count} indexes for collection {CollectionName}", 
-                        indexesToCreate.Count, collectionName);
-                    
-                    try
-                    {
-                        await collection.Indexes.CreateManyAsync(indexesToCreate);
-                    }
-                    catch (MongoCommandException ex) when (IsCosmosDbUniqueIndexError(ex))
-                    {
-                        logger.LogWarning("Cosmos DB unique index restriction encountered for collection {CollectionName}. " +
-                                        "Indexes may already exist with different constraints. Continuing without recreating indexes. " +
-                                        "Error: {Message}", collectionName, ex.Message);
-                        // Continue execution - don't let index creation failures stop the app
-                    }
-                }
+                await SyncCollectionIndexesAsync(collection, collectionName, definitions, isCosmosDb);
             }
             catch (MongoCommandException ex) when (IsCosmosDbUniqueIndexError(ex))
             {
@@ -130,6 +123,148 @@ public class MongoIndexSynchronizer(
         }
         
         logger.LogInformation("Index synchronization completed");
+    }
+
+    private async Task SyncCollectionIndexesAsync(
+        IMongoCollection<object> collection,
+        string collectionName,
+        List<MongoIndexDefinition> definitions,
+        bool isCosmosDb)
+    {
+        var existingIndexes = await (await collection.Indexes.ListAsync()).ToListAsync();
+        var existingIndexesByName = existingIndexes.ToDictionary(index => index["name"].AsString);
+        var expectedIndexNames = definitions.Select(definition => definition.Name).ToHashSet();
+
+        if (!isCosmosDb)
+        {
+            await DropUnusedIndexesAsync(collection, collectionName, existingIndexes, expectedIndexNames);
+            await DropMismatchedIndexesAsync(collection, collectionName, definitions, existingIndexesByName);
+        }
+        else
+        {
+            logger.LogInformation("Detected Cosmos DB - skipping index drops for collection {CollectionName}", collectionName);
+            LogMismatchedIndexes(collectionName, definitions, existingIndexesByName);
+        }
+
+        // Create missing indexes with Cosmos DB error handling
+        var indexesToCreate = definitions
+            .Where(definition => !existingIndexesByName.ContainsKey(definition.Name))
+            .Select(BuildIndexModel)
+            .ToList();
+
+        if (indexesToCreate.Count == 0)
+        {
+            return;
+        }
+
+        logger.LogInformation("Creating {Count} indexes for collection {CollectionName}", 
+            indexesToCreate.Count, collectionName);
+
+        try
+        {
+            await collection.Indexes.CreateManyAsync(indexesToCreate);
+        }
+        catch (MongoCommandException ex) when (IsCosmosDbUniqueIndexError(ex))
+        {
+            logger.LogWarning("Cosmos DB unique index restriction encountered for collection {CollectionName}. " +
+                            "Indexes may already exist with different constraints. Continuing without recreating indexes. " +
+                            "Error: {Message}", collectionName, ex.Message);
+            // Continue execution - don't let index creation failures stop the app
+        }
+    }
+
+    private async Task DropUnusedIndexesAsync(
+        IMongoCollection<object> collection,
+        string collectionName,
+        List<BsonDocument> existingIndexes,
+        HashSet<string> expectedIndexNames)
+    {
+        foreach (var index in existingIndexes)
+        {
+            var indexName = index["name"].AsString;
+            if (indexName == "_id_" || expectedIndexNames.Contains(indexName))
+            {
+                continue;
+            }
+
+            logger.LogInformation("Dropping unused index {IndexName} from collection {CollectionName}", 
+                indexName, collectionName);
+            try
+            {
+                await collection.Indexes.DropOneAsync(indexName);
+            }
+            catch (Exception dropEx)
+            {
+                logger.LogWarning(dropEx, "Failed to drop index {IndexName} from collection {CollectionName}, continuing", 
+                    indexName, collectionName);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns the indexes that already exist but whose options no longer match their definition.
+    /// </summary>
+    private static List<(MongoIndexDefinition Definition, BsonDocument ExistingIndex)> FindMismatchedIndexes(
+        List<MongoIndexDefinition> definitions,
+        Dictionary<string, BsonDocument> existingIndexesByName)
+    {
+        return definitions
+            .Where(definition => existingIndexesByName.ContainsKey(definition.Name)
+                && !definition.MatchesExistingIndex(existingIndexesByName[definition.Name]))
+            .Select(definition => (definition, existingIndexesByName[definition.Name]))
+            .ToList();
+    }
+
+    /// <summary>
+    /// Drops indexes whose options no longer match their definition, so the create step rebuilds them.
+    /// MongoDB cannot change options such as "unique" in place, and matching on name alone would let a
+    /// stale constraint outlive the definition that created it.
+    /// Successfully dropped names are removed from <paramref name="existingIndexesByName"/> so the
+    /// caller recreates them.
+    /// </summary>
+    private async Task DropMismatchedIndexesAsync(
+        IMongoCollection<object> collection,
+        string collectionName,
+        List<MongoIndexDefinition> definitions,
+        Dictionary<string, BsonDocument> existingIndexesByName)
+    {
+        foreach (var (definition, existingIndex) in FindMismatchedIndexes(definitions, existingIndexesByName))
+        {
+            logger.LogWarning("Index {IndexName} on collection {CollectionName} no longer matches its definition " +
+                            "and will be recreated. Existing definition: {ExistingIndex}",
+                definition.Name, collectionName, existingIndex.ToJson());
+
+            try
+            {
+                await collection.Indexes.DropOneAsync(definition.Name);
+                existingIndexesByName.Remove(definition.Name);
+            }
+            catch (Exception dropEx)
+            {
+                logger.LogError(dropEx, "Failed to drop mismatched index {IndexName} from collection {CollectionName}. " +
+                                "It keeps its current options until the drop succeeds",
+                    definition.Name, collectionName);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reports mismatched indexes without touching them. Cosmos DB refuses to modify a unique index,
+    /// so correcting one there means recreating the collection with the intended index set; surfacing
+    /// the drift is all the synchronizer can do.
+    /// </summary>
+    private void LogMismatchedIndexes(
+        string collectionName,
+        List<MongoIndexDefinition> definitions,
+        Dictionary<string, BsonDocument> existingIndexesByName)
+    {
+        foreach (var (definition, existingIndex) in FindMismatchedIndexes(definitions, existingIndexesByName))
+        {
+            logger.LogWarning("Index {IndexName} on collection {CollectionName} does not match its definition and " +
+                            "cannot be corrected automatically on Cosmos DB. Recreate the collection with the " +
+                            "intended indexes to clear this. Existing definition: {ExistingIndex}",
+                definition.Name, collectionName, existingIndex.ToJson());
+        }
     }
 
     /// <summary>
@@ -171,30 +306,22 @@ public class MongoIndexSynchronizer(
                 ex.Message.Contains("The unique index cannot be modified"));
     }
 
-    private async Task<Dictionary<string, List<CreateIndexModel<object>>>> GetExpectedIndexesAsync()
+    private static CreateIndexModel<object> BuildIndexModel(MongoIndexDefinition def)
     {
-        var indexDefinitions = await GetIndexDefinitionsAsync();
-
-        return indexDefinitions.OrderBy(kvp => kvp.Key).ToDictionary(
-            kvp => kvp.Key,
-            kvp => kvp.Value.Select(def =>
-            {
-                var indexKeysBuilder = new IndexKeysDefinitionBuilder<object>();
-                var indexKeys = indexKeysBuilder.Combine(
-                    def.Keys.Select(k => k.Value == "asc"
-                        ? indexKeysBuilder.Ascending(k.Key)
-                        : indexKeysBuilder.Descending(k.Key))
-                );
-
-                var options = new CreateIndexOptions { Name = def.Name };
-                if (def.Unique.HasValue) options.Unique = def.Unique.Value;
-                if (def.Sparse.HasValue) options.Sparse = def.Sparse.Value;
-                if (def.Background.HasValue) options.Background = def.Background.Value;
-                if (def.ExpireAfter.HasValue) options.ExpireAfter = def.ExpireAfter;
-
-                return new CreateIndexModel<object>(indexKeys, options);
-            }).ToList()
+        var indexKeysBuilder = new IndexKeysDefinitionBuilder<object>();
+        var indexKeys = indexKeysBuilder.Combine(
+            def.Keys.Select(k => k.Value == "asc"
+                ? indexKeysBuilder.Ascending(k.Key)
+                : indexKeysBuilder.Descending(k.Key))
         );
+
+        var options = new CreateIndexOptions { Name = def.Name };
+        if (def.Unique.HasValue) options.Unique = def.Unique.Value;
+        if (def.Sparse.HasValue) options.Sparse = def.Sparse.Value;
+        if (def.Background.HasValue) options.Background = def.Background.Value;
+        if (def.ExpireAfter.HasValue) options.ExpireAfter = def.ExpireAfter;
+
+        return new CreateIndexModel<object>(indexKeys, options);
     }
 
     private async Task<Dictionary<string, List<MongoIndexDefinition>>> GetIndexDefinitionsAsync()

--- a/XiansAi.Server.Src/Shared/Providers/Auth/TokenValidationCache.cs
+++ b/XiansAi.Server.Src/Shared/Providers/Auth/TokenValidationCache.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.Caching.Memory;
 using System.Security.Cryptography;
 using System.Text;
-using System.Collections.Concurrent;
+using Shared.Services;
 using Shared.Utils;
 
 namespace Shared.Providers.Auth;
@@ -42,18 +42,21 @@ public class MemoryTokenValidationCache : ITokenValidationCache
     private readonly TimeSpan _absoluteExpiration;
     private readonly TimeSpan _slidingExpiration;
     private readonly long _cacheEntrySizeLimit;
-    
-    // Reverse index to track tokens by user ID for invalidation
-    // Using ConcurrentDictionary for thread-safe operations without explicit locking
-    // Key: userId, Value: ConcurrentBag of token cache keys
-    private readonly ConcurrentDictionary<string, ConcurrentBag<string>> _userTokens = new();
+
+    // Which tokens belong to which user, so that locking an account can drop them. Held by the
+    // shared singleton rather than by this instance: this cache is registered scoped, so an index
+    // of its own would be discarded with the request that cached the token, leaving the request
+    // that locks the account with nothing to evict.
+    private readonly IUserCacheIndex _userCacheIndex;
 
     public MemoryTokenValidationCache(
         IMemoryCache cache,
+        IUserCacheIndex userCacheIndex,
         ILogger<MemoryTokenValidationCache> logger,
         IConfiguration configuration)
     {
         _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _userCacheIndex = userCacheIndex ?? throw new ArgumentNullException(nameof(userCacheIndex));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
         // Default to 5 minutes absolute expiration if not configured
@@ -122,16 +125,8 @@ public class MemoryTokenValidationCache : ITokenValidationCache
             .SetSize(_cacheEntrySizeLimit)
             .RegisterPostEvictionCallback((key, value, reason, state) =>
             {
-                // Clean up reverse index when cache entry is evicted
-                // This ensures the reverse index doesn't grow unbounded
-                if (value is CachedValidation cachedVal && !string.IsNullOrEmpty(cachedVal.UserId))
-                {
-                    // Note: We don't try to remove individual items from ConcurrentBag as it's not efficient
-                    // The bag will be cleaned up when the user is invalidated or naturally as entries expire
-                    // This is a trade-off: slight memory overhead vs. expensive item removal operations
-                    _logger.LogTrace("Cache entry evicted for user {UserId}, reason: {Reason}", 
-                        cachedVal.UserId, reason);
-                }
+                // Keeps the index from growing without bound as tokens expire on their own.
+                _userCacheIndex.Forget(userId, key.ToString() ?? string.Empty);
             });
 
         var cachedValidation = new CachedValidation
@@ -142,11 +137,7 @@ public class MemoryTokenValidationCache : ITokenValidationCache
         };
 
         _cache.Set(cacheKey, cachedValidation, cacheOptions);
-
-        // Update reverse index to track this token for the user
-        // ConcurrentDictionary.GetOrAdd is thread-safe and atomic
-        var tokens = _userTokens.GetOrAdd(userId, _ => new ConcurrentBag<string>());
-        tokens.Add(cacheKey);
+        _userCacheIndex.Track(userId, cacheKey);
 
         _logger.LogDebug("Cached successful token validation result for user {UserId}", LogSanitizer.Sanitize(userId));
         return Task.CompletedTask;
@@ -171,13 +162,10 @@ public class MemoryTokenValidationCache : ITokenValidationCache
             return Task.CompletedTask;
         }
 
-        var cacheKey = GetCacheKey(token);
-        
-        // Remove from cache - the eviction callback will handle reverse index cleanup if needed
-        // We don't try to manually clean the reverse index here to avoid race conditions
-        // and because ConcurrentBag doesn't support efficient item removal
-        _cache.Remove(cacheKey);
-        
+        // Removing the entry runs the post-eviction callback, which drops it from the index.
+        _cache.Remove(GetCacheKey(token));
+
+
         _logger.LogDebug("Removed token validation cache entry");
         return Task.CompletedTask;
     }
@@ -191,32 +179,7 @@ public class MemoryTokenValidationCache : ITokenValidationCache
             return Task.CompletedTask;
         }
 
-        // Try to remove and get the token bag for this user atomically
-        if (!_userTokens.TryRemove(userId, out var tokenBag))
-        {
-            _logger.LogDebug("No cached tokens found for user {UserId}", LogSanitizer.Sanitize(userId));
-            return Task.CompletedTask;
-        }
-
-        // Convert to array to get count and avoid multiple enumeration
-        var tokenKeys = tokenBag.ToArray();
-        
-        // Remove all cached tokens for this user
-        // Using Parallel.ForEach for better performance when there are many tokens
-        if (tokenKeys.Length > 10)
-        {
-            Parallel.ForEach(tokenKeys, tokenKey => _cache.Remove(tokenKey));
-        }
-        else
-        {
-            // For small numbers, simple loop is more efficient
-            foreach (var tokenKey in tokenKeys)
-            {
-                _cache.Remove(tokenKey);
-            }
-        }
-
-        _logger.LogInformation("Invalidated {Count} cached tokens for user {UserId}", tokenKeys.Length, LogSanitizer.Sanitize(userId));
+        _userCacheIndex.Invalidate(userId);
         return Task.CompletedTask;
     }
 

--- a/XiansAi.Server.Src/Shared/Repositories/EmailAccountLookup.cs
+++ b/XiansAi.Server.Src/Shared/Repositories/EmailAccountLookup.cs
@@ -1,0 +1,35 @@
+using Shared.Data.Models;
+
+namespace Shared.Repositories;
+
+/// <summary>
+/// The one account an address names, for operations that act on a single account rather than on the
+/// combined identity <see cref="EmailIdentityResolution"/> produces.
+///
+/// Granting a membership or a role names one person, and an address does not always name one
+/// account: two providers can each hold a record for the same address. Resolving to whichever
+/// record a collection scan returned first would put a different account in the tenant than the
+/// operator meant, so an ambiguous address is refused and the operator is asked for a user id.
+/// </summary>
+/// <param name="Account">The single record holding the address, or null when it is not exactly one.</param>
+/// <param name="MatchCount">How many records hold it, including disabled ones.</param>
+public sealed record EmailAccountLookup(User? Account, int MatchCount)
+{
+    /// <summary>More than one record holds the address, so it does not name a single account.</summary>
+    public bool IsAmbiguous => MatchCount > 1;
+
+    /// <summary>
+    /// Shared wording so that every refusal points at the same way through. Disabled records are
+    /// counted, so an address awaiting a system administrator review is ambiguous here even though
+    /// the fold resolves it without difficulty.
+    /// </summary>
+    public const string AmbiguousError =
+        "More than one account holds this email address, so it does not name a single person. " +
+        "Use the user id of the intended account.";
+
+    public static EmailAccountLookup From(IReadOnlyList<User>? records)
+    {
+        var owners = records ?? (IReadOnlyList<User>)Array.Empty<User>();
+        return new EmailAccountLookup(owners.Count == 1 ? owners[0] : null, owners.Count);
+    }
+}

--- a/XiansAi.Server.Src/Shared/Repositories/EmailIdentityResolution.cs
+++ b/XiansAi.Server.Src/Shared/Repositories/EmailIdentityResolution.cs
@@ -1,0 +1,130 @@
+using Shared.Data.Models;
+using Shared.Utils;
+
+namespace Shared.Repositories;
+
+/// <summary>
+/// The single identity a credential that names an email address acts as, folded from every user
+/// record holding that address.
+///
+/// Duplicates are legitimate: a record is keyed on the provider subject, so two identity providers
+/// can each hold an account for the same person. Credentials that carry only an address — legacy
+/// API keys storing an email in <c>CreatedBy</c>, certificates whose OU is an email — have no way
+/// to say which of those accounts they meant, so the records are combined rather than one being
+/// picked arbitrarily.
+/// </summary>
+/// <param name="PrimaryUserId">
+/// The account the request acts as, chosen deterministically so it does not vary between requests.
+/// Data scoping and ownership still resolve to this one id.
+/// </param>
+/// <param name="CandidateUserIds">Every record that contributed, oldest first.</param>
+/// <param name="Roles">
+/// The union of the contributing records' roles for the requested tenant, including
+/// <see cref="SystemRoles.SysAdmin"/> when <paramref name="IsSysAdmin"/> holds.
+/// </param>
+/// <param name="IsSysAdmin">
+/// True only when every contributing record holds the role, so it can never be assembled out of one
+/// record that has it and one that does not.
+/// </param>
+/// <param name="IsAmbiguous">True when more than one record contributed.</param>
+public sealed record EmailIdentityResolution(
+    string PrimaryUserId,
+    IReadOnlyList<string> CandidateUserIds,
+    IReadOnlyList<string> Roles,
+    bool IsSysAdmin,
+    bool IsAmbiguous)
+{
+    /// <summary>
+    /// Folds the records holding an address into the one identity to act as, or null when none of
+    /// them is usable.
+    /// </summary>
+    /// <param name="email">The address being resolved, used only for logging.</param>
+    /// <param name="records">Every user record holding the address, in any order.</param>
+    /// <param name="tenantId">The tenant whose roles are being resolved.</param>
+    /// <param name="logger">
+    /// Records an ambiguous address, and a set that does not agree on SysAdmin.
+    /// </param>
+    public static EmailIdentityResolution? From(
+        string email, IReadOnlyList<User> records, string tenantId, ILogger logger)
+    {
+        // Ordered so the identity a credential acts as does not change between requests. Unordered
+        // this is whatever the collection scan returned first, which is how the same credential
+        // could resolve to a different account on a later call.
+        var candidates = records
+            .Where(user => !user.IsLockedOut)
+            .OrderBy(user => user.CreatedAt)
+            .ThenBy(user => user.UserId, StringComparer.Ordinal)
+            .ToList();
+
+        if (candidates.Count == 0)
+        {
+            return null;
+        }
+
+        // Only approved memberships contribute, so reaching a tenant this way still requires an
+        // admin of that tenant to have granted the membership.
+        var roles = candidates
+            .SelectMany(user => user.TenantRoles)
+            .Where(tenantRole => tenantRole.Tenant == tenantId && tenantRole.IsApproved)
+            .SelectMany(tenantRole => tenantRole.Roles)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        var isSysAdmin = ResolveSysAdmin(email, candidates, logger);
+        if (isSysAdmin && !roles.Contains(SystemRoles.SysAdmin))
+        {
+            roles.Add(SystemRoles.SysAdmin);
+        }
+
+        if (candidates.Count > 1)
+        {
+            logger.LogWarning(
+                "Email {Email} resolves to {Count} accounts [{UserIds}]; acting as {PrimaryUserId} " +
+                "with their combined roles for tenant {TenantId}",
+                LogSanitizer.RedactEmail(email), candidates.Count,
+                LogSanitizer.Sanitize(string.Join(", ", candidates.Select(user => user.UserId))),
+                LogSanitizer.RedactUserId(candidates[0].UserId), LogSanitizer.Sanitize(tenantId));
+        }
+
+        return new EmailIdentityResolution(
+            PrimaryUserId: candidates[0].UserId,
+            CandidateUserIds: candidates.Select(user => user.UserId).ToList(),
+            Roles: roles,
+            IsSysAdmin: isSysAdmin,
+            IsAmbiguous: candidates.Count > 1);
+    }
+
+    /// <summary>
+    /// SysAdmin is global and grants access to every tenant, so an address only carries it when
+    /// every record answering to that address holds it. One record short and the answer is no: a
+    /// second account at another provider is created for review and without the role, so a mixed
+    /// set means nobody has yet accepted that the two are the same person.
+    ///
+    /// The cost is that enabling such an account without also granting it the role takes SysAdmin
+    /// away from the account that had it, on the paths that name only an address. Completing the
+    /// grant restores it.
+    /// </summary>
+    private static bool ResolveSysAdmin(string email, IReadOnlyList<User> candidates, ILogger logger)
+    {
+        // Safe on the single-record case, which is the ordinary one: the record's own flag decides.
+        if (candidates.All(user => user.IsSysAdmin))
+        {
+            return true;
+        }
+
+        if (candidates.Any(user => user.IsSysAdmin))
+        {
+            logger.LogError(
+                "Refusing SysAdmin for {Email}: it is held by a system administrator and by {Others}, " +
+                "which have not been accepted as the same person. Grant the system administrator " +
+                "role to every account holding this address, or leave the others disabled; until " +
+                "then this address cannot authenticate as SysAdmin",
+                LogSanitizer.RedactEmail(email),
+                LogSanitizer.Sanitize(string.Join(", ", candidates
+                    .Where(user => !user.IsSysAdmin)
+                    .Select(user => user.UserId))));
+        }
+
+        return false;
+    }
+}

--- a/XiansAi.Server.Src/Shared/Repositories/UserRepository.cs
+++ b/XiansAi.Server.Src/Shared/Repositories/UserRepository.cs
@@ -413,11 +413,29 @@ public class UserRepository : IUserRepository
 
     public async Task<List<string>> GetUserRolesAsync(string userId, string tenantId)
     {
-        // Accept either the canonical user id or an email (legacy API-key CreatedBy values).
-        var user = await GetByUserIdOrEmailAsync(userId);
+        if (string.IsNullOrWhiteSpace(userId))
+            return new List<string>();
+
+        // The canonical id names one account and needs no folding. Checked first so a record whose
+        // UserId is itself an address — some providers issue one — still resolves to itself.
+        var user = await GetByUserIdAsync(userId);
 
         if (user == null)
+        {
+            // No record is keyed on this value, so an address here names whoever holds it, which
+            // can be more than one account. Fold rather than taking whichever the collection scan
+            // returned first: SysAdmin is global, and one record holding it while another does not
+            // means nobody has accepted the two as the same person. The fold also drops disabled
+            // records before choosing, where picking first could land on one and report no roles
+            // while a live account holds the same address.
+            if (userId.Contains('@'))
+            {
+                var identity = await ResolveEmailIdentityAsync(userId, tenantId);
+                return identity?.Roles.ToList() ?? new List<string>();
+            }
+
             return new List<string>();
+        }
 
         // A disabled account carries nothing, matching what an address resolves to through
         // EmailIdentityResolution. Without this a credential naming the id kept its roles after the

--- a/XiansAi.Server.Src/Shared/Repositories/UserRepository.cs
+++ b/XiansAi.Server.Src/Shared/Repositories/UserRepository.cs
@@ -18,6 +18,22 @@ public interface IUserRepository
     Task<User?> GetByIdAsync(string id);
     Task<User?> GetByUserEmailAsync(string email);
     /// <summary>
+    /// Every record holding this address. More than one is legitimate: two identity providers can
+    /// each hold an account for the same person, and the provider subject rather than the address
+    /// is what a record is keyed on.
+    /// </summary>
+    Task<List<User>> GetAllByUserEmailAsync(string email);
+    /// <summary>
+    /// Folds every record holding <paramref name="email"/> into the one identity a credential that
+    /// names an address acts as. Null when no usable record exists.
+    /// </summary>
+    Task<EmailIdentityResolution?> ResolveEmailIdentityAsync(string email, string tenantId);
+    /// <summary>
+    /// Whether any record other than <paramref name="excludingUserId"/> holds this address. Callers
+    /// use it to keep a SysAdmin's address unique, since SysAdmin cannot be resolved from a shared one.
+    /// </summary>
+    Task<bool> IsEmailSharedAsync(string email, string excludingUserId);
+    /// <summary>
     /// Resolves a user by <see cref="User.UserId"/> first, then by email when the value looks like an email.
     /// Needed because identity can arrive as the canonical user id or as an email (bootstrapped users
     /// and legacy API keys may store the email in place of the user id).
@@ -33,8 +49,14 @@ public interface IUserRepository
     Task<bool> UnlockUserAsync(string userId);
     Task<bool> IsLockedOutAsync(string userId);
     Task<bool> IsSysAdmin(string userId);
+    /// <summary>
+    /// Sets only the fields supplied, leaving the rest of the record untouched. Unlike
+    /// <see cref="UpdateAsync"/>, which replaces the whole document, this cannot undo a change
+    /// another request made in the meantime — a tenant membership appended in parallel, say.
+    /// </summary>
+    Task<bool> UpdateProfileFieldsAsync(string userId, string? email, bool? emailVerified, string? name);
     Task<string?> PinProviderAuthorityIfUnsetAsync(string userId, string providerAuthority);
-    Task<bool> AddPendingTenantRoleIfAbsentAsync(string userId, string tenantId);
+    Task<bool> AddTenantRoleIfAbsentAsync(string userId, string tenantId, bool isApproved, IReadOnlyList<string> roles);
     Task<bool> SetSysAdminAsync(string userId, bool isSysAdmin);
     Task<bool> DeleteUser(string userId, string? tenantId = null);
     Task<List<User>> SearchUsersAsync(string query, string? tenantId = null);
@@ -294,6 +316,38 @@ public class UserRepository : IUserRepository
         }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "GetByUserEmail");
     }
 
+    public async Task<List<User>> GetAllByUserEmailAsync(string email)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+        {
+            return new List<User>();
+        }
+
+        return await MongoRetryHelper.ExecuteWithRetryAsync(async () =>
+        {
+            // Normalize email to lowercase (emails are stored in lowercase in DB)
+            var normalizedEmail = email.ToLowerInvariant();
+            return await _users.Find(x => x.Email == normalizedEmail).ToListAsync();
+        }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "GetAllByUserEmail");
+    }
+
+    public async Task<EmailIdentityResolution?> ResolveEmailIdentityAsync(string email, string tenantId)
+    {
+        var records = await GetAllByUserEmailAsync(email);
+        return EmailIdentityResolution.From(email, records, tenantId, _logger);
+    }
+
+    public async Task<bool> IsEmailSharedAsync(string email, string excludingUserId)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+        {
+            return false;
+        }
+
+        var owners = await GetAllByUserEmailAsync(email);
+        return owners.Any(user => !string.Equals(user.UserId, excludingUserId, StringComparison.Ordinal));
+    }
+
     public async Task<User?> GetByUserIdOrEmailAsync(string userIdOrEmail)
     {
         if (string.IsNullOrWhiteSpace(userIdOrEmail))
@@ -365,9 +419,20 @@ public class UserRepository : IUserRepository
         if (user == null)
             return new List<string>();
 
-        // Only return roles for approved tenants
+        // A disabled account carries nothing, matching what an address resolves to through
+        // EmailIdentityResolution. Without this a credential naming the id kept its roles after the
+        // account was turned off.
+        if (user.IsLockedOut)
+        {
+            _logger.LogWarning("No roles for {UserId}: the account is disabled",
+                LogSanitizer.RedactUserId(user.UserId));
+            return new List<string>();
+        }
+
+        // Only return roles for approved tenants. Copied, because SysAdmin is appended below and
+        // the record's own list would otherwise grow a role nobody wrote.
         var tenantRole = user.TenantRoles.FirstOrDefault(tr => tr.Tenant == tenantId && tr.IsApproved);
-        var result = tenantRole?.Roles ?? new List<string>();
+        var result = tenantRole?.Roles.ToList() ?? new List<string>();
 
         if (user.IsSysAdmin)
         {
@@ -421,6 +486,42 @@ public class UserRepository : IUserRepository
             var result = await _users.ReplaceOneAsync(x => x.UserId == userId, user);
             return result.ModifiedCount > 0;
         }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "UpdateUser");
+    }
+
+    public async Task<bool> UpdateProfileFieldsAsync(
+        string userId, string? email, bool? emailVerified, string? name)
+    {
+        var updates = new List<UpdateDefinition<User>>();
+
+        if (email != null)
+        {
+            // Stored lowercase, matching the property setter on the model.
+            updates.Add(Builders<User>.Update.Set(x => x.Email, email.ToLowerInvariant()));
+        }
+
+        if (emailVerified.HasValue)
+        {
+            updates.Add(Builders<User>.Update.Set(x => x.EmailVerified, emailVerified.Value));
+        }
+
+        if (name != null)
+        {
+            updates.Add(Builders<User>.Update.Set(x => x.Name, name));
+        }
+
+        if (updates.Count == 0)
+        {
+            return false;
+        }
+
+        updates.Add(Builders<User>.Update.Set(x => x.UpdatedAt, DateTime.UtcNow));
+
+        return await MongoRetryHelper.ExecuteWithRetryAsync(async () =>
+        {
+            var result = await _users.UpdateOneAsync(
+                x => x.UserId == userId, Builders<User>.Update.Combine(updates));
+            return result.ModifiedCount > 0;
+        }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "UpdateUserProfileFields");
     }
 
     public async Task<bool> LockUserAsync(string userId, string reason, string lockedByUserId)
@@ -518,15 +619,19 @@ public class UserRepository : IUserRepository
     }
 
     /// <summary>
-    /// Records an unapproved membership of <paramref name="tenantId"/>, unless the user already has
-    /// some membership of it. Grants nothing on its own — it exists so the user shows up in the
+    /// Records a membership of <paramref name="tenantId"/>, unless the user already has some
+    /// membership of it. An existing row is never altered: it may carry roles an admin granted, or
+    /// an approval they deliberately withheld.
+    ///
+    /// An unapproved membership grants nothing on its own — it exists so the user shows up in the
     /// tenant's pending list for an admin to approve or ignore.
     ///
     /// Conditional on the server rather than read-then-write, because concurrent requests from the
     /// same newly provisioned user would otherwise each append their own row.
     /// </summary>
     /// <returns>True when this call added the membership.</returns>
-    public async Task<bool> AddPendingTenantRoleIfAbsentAsync(string userId, string tenantId)
+    public async Task<bool> AddTenantRoleIfAbsentAsync(
+        string userId, string tenantId, bool isApproved, IReadOnlyList<string> roles)
     {
         return await MongoRetryHelper.ExecuteWithRetryAsync(async () =>
         {
@@ -539,14 +644,14 @@ public class UserRepository : IUserRepository
                 .Push(u => u.TenantRoles, new TenantRole
                 {
                     Tenant = tenantId,
-                    Roles = new List<string>(),
-                    IsApproved = false
+                    Roles = roles.ToList(),
+                    IsApproved = isApproved
                 })
                 .Set(u => u.UpdatedAt, DateTime.UtcNow);
 
             var result = await _users.UpdateOneAsync(withoutTenant, update);
             return result.ModifiedCount > 0;
-        }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "AddPendingTenantRoleIfAbsent");
+        }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "AddTenantRoleIfAbsent");
     }
 
     public async Task<bool> SetSysAdminAsync(string userId, bool isSysAdmin)

--- a/XiansAi.Server.Src/Shared/Repositories/UserRepository.cs
+++ b/XiansAi.Server.Src/Shared/Repositories/UserRepository.cs
@@ -54,7 +54,7 @@ public interface IUserRepository
     /// <see cref="UpdateAsync"/>, which replaces the whole document, this cannot undo a change
     /// another request made in the meantime — a tenant membership appended in parallel, say.
     /// </summary>
-    Task<bool> UpdateProfileFieldsAsync(string userId, string? email, bool? emailVerified, string? name);
+    Task<bool> UpdateProfileFieldsAsync(string userId, string? email, string? name);
     Task<string?> PinProviderAuthorityIfUnsetAsync(string userId, string providerAuthority);
     Task<bool> AddTenantRoleIfAbsentAsync(string userId, string tenantId, bool isApproved, IReadOnlyList<string> roles);
     Task<bool> SetSysAdminAsync(string userId, bool isSysAdmin);
@@ -488,8 +488,7 @@ public class UserRepository : IUserRepository
         }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "UpdateUser");
     }
 
-    public async Task<bool> UpdateProfileFieldsAsync(
-        string userId, string? email, bool? emailVerified, string? name)
+    public async Task<bool> UpdateProfileFieldsAsync(string userId, string? email, string? name)
     {
         var updates = new List<UpdateDefinition<User>>();
 
@@ -497,11 +496,6 @@ public class UserRepository : IUserRepository
         {
             // Stored lowercase, matching the property setter on the model.
             updates.Add(Builders<User>.Update.Set(x => x.Email, email.ToLowerInvariant()));
-        }
-
-        if (emailVerified.HasValue)
-        {
-            updates.Add(Builders<User>.Update.Set(x => x.EmailVerified, emailVerified.Value));
         }
 
         if (name != null)

--- a/XiansAi.Server.Src/Shared/Repositories/UserRepository.cs
+++ b/XiansAi.Server.Src/Shared/Repositories/UserRepository.cs
@@ -17,6 +17,12 @@ public interface IUserRepository
     Task<User?> GetByUserIdAsync(string userId);
     Task<User?> GetByIdAsync(string id);
     Task<User?> GetByUserEmailAsync(string email);
+    /// <summary>
+    /// Resolves a user by <see cref="User.UserId"/> first, then by email when the value looks like an email.
+    /// Needed because a user's identity can reach the server either as the canonical user id or as an
+    /// email address (bootstrapped users and legacy API keys store the email in place of the user id).
+    /// </summary>
+    Task<User?> GetByUserIdOrEmailAsync(string userIdOrEmail);
     Task<List<TenantInfoDto>> GetUserTenantsAsync(string userId);
     Task<List<string>> GetUserRolesAsync(string userId, string tenantId);
     Task<User?> GetAnyUserAsync();
@@ -286,6 +292,21 @@ public class UserRepository : IUserRepository
         }, _logger, maxRetries: 3, baseDelayMs: 100, operationName: "GetByUserEmail");
     }
 
+    public async Task<User?> GetByUserIdOrEmailAsync(string userIdOrEmail)
+    {
+        if (string.IsNullOrWhiteSpace(userIdOrEmail))
+            return null;
+
+        var user = await GetByUserIdAsync(userIdOrEmail);
+        if (user != null)
+            return user;
+
+        if (userIdOrEmail.Contains('@'))
+            return await GetByUserEmailAsync(userIdOrEmail);
+
+        return null;
+    }
+
     public async Task<List<TenantInfoDto>> GetUserTenantsAsync(string userId)
     {
         var filter = Builders<User>.Filter.Eq(u => u.UserId, userId);
@@ -335,11 +356,9 @@ public class UserRepository : IUserRepository
 
     public async Task<List<string>> GetUserRolesAsync(string userId, string tenantId)
     {
-        var filter = Builders<User>.Filter.Eq(u => u.UserId, userId);
-
-        var user = await _users
-            .Find(filter)
-            .FirstOrDefaultAsync();
+        // Accept either the canonical user id or an email address, since callers such as the
+        // Admin API identify the user by whatever value was stored on their API key.
+        var user = await GetByUserIdOrEmailAsync(userId);
 
         if (user == null)
             return new List<string>();

--- a/XiansAi.Server.Src/Shared/Services/GlobalUserAdminService.cs
+++ b/XiansAi.Server.Src/Shared/Services/GlobalUserAdminService.cs
@@ -57,6 +57,13 @@ public class GlobalUserDetail
     public required bool IsSysAdmin { get; init; }
     [JsonPropertyName("isEnabled")]
     public required bool IsEnabled { get; init; }
+    /// <summary>
+    /// Why the account is disabled, for whoever has to decide whether to enable it. An account
+    /// created because its address is also a system administrator's says so here, along with what
+    /// enabling it on its own would cost — which is not otherwise visible from this record.
+    /// </summary>
+    [JsonPropertyName("disabledReason")]
+    public string? DisabledReason { get; init; }
     [JsonPropertyName("memberships")]
     public required List<GlobalUserMembership> Memberships { get; init; }
 }
@@ -256,6 +263,21 @@ public class GlobalUserAdminService : IGlobalUserAdminService
             if (user == null)
                 return ServiceResult<GlobalUserDetail>.NotFound("User not found");
 
+            // The one place that accepts a grant on an address several accounts hold. Making it
+            // here is the operator stating that those accounts are the same person, which is what
+            // lets the address authenticate as a system administrator again. Every other promotion
+            // path refuses, so this is the only record of that decision being taken.
+            if (isSysAdmin
+                && !string.IsNullOrWhiteSpace(user.Email)
+                && await _userRepository.IsEmailSharedAsync(user.Email, user.UserId))
+            {
+                _logger.LogWarning(
+                    "Granting SysAdmin to {UserId}, whose email other accounts also hold. That " +
+                    "address authenticates as a system administrator only once every enabled " +
+                    "account holding it has the role",
+                    LogSanitizer.Sanitize(userId));
+            }
+
             var updated = await _userRepository.SetSysAdminAsync(userId, isSysAdmin);
             if (!updated)
                 return ServiceResult<GlobalUserDetail>.InternalServerError("Update failed");
@@ -290,7 +312,11 @@ public class GlobalUserAdminService : IGlobalUserAdminService
             if (enabled)
             {
                 ok = await _userRepository.UnlockUserAsync(userId);
-                if (ok) user.IsLockedOut = false;
+                if (ok)
+                {
+                    user.IsLockedOut = false;
+                    await WarnIfEnablingDemotesASysAdminAsync(user);
+                }
             }
             else
             {
@@ -324,6 +350,36 @@ public class GlobalUserAdminService : IGlobalUserAdminService
             _logger.LogError(ex, "Error setting status for user {UserId}", LogSanitizer.Sanitize(userId));
             return ServiceResult<GlobalUserDetail>.InternalServerError("An error occurred while updating the user");
         }
+    }
+
+    /// <summary>
+    /// Records the case where enabling this account takes SysAdmin away from another one.
+    ///
+    /// An address only authenticates as a system administrator when every enabled account holding
+    /// it has the role, so enabling one that does not withdraws it — from a different account than
+    /// the one being enabled, on credentials that name only an email. Granting this account the
+    /// same role puts it back.
+    /// </summary>
+    private async Task WarnIfEnablingDemotesASysAdminAsync(User user)
+    {
+        if (user.IsSysAdmin || string.IsNullOrWhiteSpace(user.Email))
+            return;
+
+        var owners = await _userRepository.GetAllByUserEmailAsync(user.Email);
+        var affected = owners
+            .Where(owner => owner.IsSysAdmin && owner.UserId != user.UserId)
+            .Select(owner => owner.UserId)
+            .ToList();
+
+        if (affected.Count == 0)
+            return;
+
+        _logger.LogError(
+            "Enabled {UserId}, which holds the same email as system administrator(s) {Others} " +
+            "without holding that role. Until it is granted the same role, that address no longer " +
+            "authenticates as a system administrator on credentials naming only an email",
+            LogSanitizer.Sanitize(user.UserId),
+            LogSanitizer.Sanitize(string.Join(", ", affected)));
     }
 
     private static GlobalUserSummary ToSummary(User user)
@@ -361,6 +417,7 @@ public class GlobalUserAdminService : IGlobalUserAdminService
             Name = user.Name,
             IsSysAdmin = user.IsSysAdmin,
             IsEnabled = !user.IsLockedOut,
+            DisabledReason = user.IsLockedOut ? user.LockedOutReason : null,
             Memberships = memberships,
         };
     }

--- a/XiansAi.Server.Src/Shared/Services/GlobalUserAdminService.cs
+++ b/XiansAi.Server.Src/Shared/Services/GlobalUserAdminService.cs
@@ -112,23 +112,20 @@ public class GlobalUserAdminService : IGlobalUserAdminService
 
     private readonly IUserRepository _userRepository;
     private readonly ITenantCacheService _tenantCacheService;
-    private readonly IRoleCacheService _roleCacheService;
-    private readonly ITokenValidationCache _tokenCache;
+    private readonly IUserAuthorizationInvalidator _authorizationInvalidator;
     private readonly IWebhookEventPublisher _webhookEventPublisher;
     private readonly ILogger<GlobalUserAdminService> _logger;
 
     public GlobalUserAdminService(
         IUserRepository userRepository,
         ITenantCacheService tenantCacheService,
-        IRoleCacheService roleCacheService,
-        ITokenValidationCache tokenCache,
+        IUserAuthorizationInvalidator authorizationInvalidator,
         IWebhookEventPublisher webhookEventPublisher,
         ILogger<GlobalUserAdminService> logger)
     {
         _userRepository = userRepository;
         _tenantCacheService = tenantCacheService;
-        _roleCacheService = roleCacheService;
-        _tokenCache = tokenCache;
+        _authorizationInvalidator = authorizationInvalidator;
         _webhookEventPublisher = webhookEventPublisher;
         _logger = logger;
     }
@@ -424,8 +421,6 @@ public class GlobalUserAdminService : IGlobalUserAdminService
 
     private async Task InvalidateCachesAsync(User user)
     {
-        foreach (var tr in user.TenantRoles)
-            _roleCacheService.InvalidateUserRoles(user.UserId, tr.Tenant);
-        await _tokenCache.InvalidateUserTokens(user.UserId);
+        await _authorizationInvalidator.InvalidateAsync(user);
     }
 }

--- a/XiansAi.Server.Src/Shared/Services/RoleCacheService.cs
+++ b/XiansAi.Server.Src/Shared/Services/RoleCacheService.cs
@@ -30,14 +30,22 @@ namespace Shared.Services
 
         public async Task<List<string>> GetUserRolesAsync(string userId, string tenantId)
         {
+            // Entries are keyed on the value passed in, but every InvalidateUserRoles caller passes a
+            // canonical user id, so an entry keyed on an email would never be invalidated and would
+            // serve stale roles for the full cache duration. Callers resolve an email to an account
+            // before reaching here; this keeps a caller that forgets from creating such an entry.
+            if (userId.Contains('@'))
+            {
+                return SystemRoles.ExcludingParticipantRoles(
+                    await _userRepository.GetUserRolesAsync(userId, tenantId) ?? new List<string>());
+            }
+
             var cacheKey = $"{tenantId}:{userId}:roles";
             if (!_cache.TryGetValue(cacheKey, out List<string>? roles))
             {
                 var rawRoles = await _userRepository.GetUserRolesAsync(userId, tenantId);
                 // Filter before caching - participants cannot authenticate/login (exist for Admin API queries only)
-                roles = (rawRoles ?? new List<string>())
-                    .Where(r => r != SystemRoles.TenantParticipant && r != SystemRoles.TenantParticipantAdmin)
-                    .ToList();
+                roles = SystemRoles.ExcludingParticipantRoles(rawRoles ?? new List<string>());
                 var cacheOptions = new MemoryCacheEntryOptions()
                     .SetAbsoluteExpiration(_cacheDuration)
                     .SetSize(1);

--- a/XiansAi.Server.Src/Shared/Services/RoleCacheService.cs
+++ b/XiansAi.Server.Src/Shared/Services/RoleCacheService.cs
@@ -18,14 +18,17 @@ namespace Shared.Services
     {
         private readonly IMemoryCache _cache;
         private readonly IUserRepository _userRepository;
+        private readonly IUserCacheIndex _userCacheIndex;
         private readonly TimeSpan _cacheDuration = TimeSpan.FromMinutes(5);
 
         public RoleCacheService(
             IMemoryCache cache,
-            IUserRepository userRepository)
+            IUserRepository userRepository,
+            IUserCacheIndex userCacheIndex)
         {
             _cache = cache;
             _userRepository = userRepository;
+            _userCacheIndex = userCacheIndex;
         }
 
         public async Task<List<string>> GetUserRolesAsync(string userId, string tenantId)
@@ -48,8 +51,15 @@ namespace Shared.Services
                 roles = SystemRoles.ExcludingParticipantRoles(rawRoles ?? new List<string>());
                 var cacheOptions = new MemoryCacheEntryOptions()
                     .SetAbsoluteExpiration(_cacheDuration)
-                    .SetSize(1);
+                    .SetSize(1)
+                    .RegisterPostEvictionCallback(
+                        (key, _, _, _) => _userCacheIndex.Forget(userId, key.ToString() ?? string.Empty));
                 _cache.Set(cacheKey, roles, cacheOptions);
+
+                // Tracked so that disabling the account drops its roles in every tenant, including
+                // any this user is no longer a member of — those are absent from the record the
+                // caller would otherwise iterate to work out which keys to remove.
+                _userCacheIndex.Track(userId, cacheKey);
             }
 
             return roles ?? new List<string>();

--- a/XiansAi.Server.Src/Shared/Services/TenantOidcConfigService.cs
+++ b/XiansAi.Server.Src/Shared/Services/TenantOidcConfigService.cs
@@ -331,9 +331,11 @@ public class TenantOidcConfigService : ITenantOidcConfigService
     /// Rejects a configuration the validator would refuse or silently override at runtime, so that
     /// the administrator finds out while saving rather than when their users cannot sign in.
     ///
-    /// A missing audience is only warned about: existing configurations were never required to
-    /// declare one, and refusing here would block those tenants from making unrelated edits. It
-    /// becomes a hard failure at validation time once Auth:RequireOidcAudience is enabled.
+    /// A missing audience is refused outright, including on a provider that predates the rule and
+    /// on a save that does not touch it. Grandfathering it would leave the configurations that
+    /// actually matter unfixed forever, since nothing else ever forces them to be revisited. The
+    /// cost is that a tenant configured this way cannot save any OIDC change until it declares one;
+    /// sign-in is unaffected until Auth:RequireOidcAudience is enabled.
     ///
     /// A mutable <c>userIdClaim</c> is refused when newly introduced or changed. An unchanged
     /// pre-existing value is grandfathered with a warning so tenants already configured that way
@@ -368,10 +370,13 @@ public class TenantOidcConfigService : ITenantOidcConfigService
             if (provider.ExpectedAudience is not { Count: > 0 })
             {
                 _logger.LogWarning(
-                    "OIDC provider '{Provider}' for tenant {TenantId} was saved without an " +
-                    "expectedAudience, so it will accept any token its issuer signed — including " +
-                    "tokens minted for a different application.",
-                    LogSanitizer.Sanitize(name), LogSanitizer.Sanitize(tenantId));
+                    "Refused an OIDC save for tenant {TenantId}: provider '{Provider}' declares no " +
+                    "expectedAudience.",
+                    LogSanitizer.Sanitize(tenantId), LogSanitizer.Sanitize(name));
+                return $"Provider '{name}' declares no expectedAudience, so it would accept any " +
+                       "token its issuer signed — including one minted for a different application " +
+                       "at that same identity provider. Set expectedAudience to the client id (or " +
+                       "API identifier) this tenant's tokens are issued for.";
             }
         }
 

--- a/XiansAi.Server.Src/Shared/Services/TenantParticipantUserService.cs
+++ b/XiansAi.Server.Src/Shared/Services/TenantParticipantUserService.cs
@@ -52,7 +52,16 @@ public interface ITenantParticipantUserService
 {
     Task<ServiceResult<PagedParticipantResult>> ListAsync(string tenantId, int page, int pageSize, string? search, string? role = null);
     Task<ServiceResult<TenantParticipantUser>> GetAsync(string tenantId, string userId);
-    Task<ServiceResult<TenantParticipantUser>> CreateAsync(string tenantId, string email, string name, string role);
+    /// <summary>
+    /// Grants <paramref name="role"/> in the tenant to the account named by <paramref name="userId"/>,
+    /// or, when no user id is given, to the single account holding <paramref name="email"/> —
+    /// creating one from that address and <paramref name="name"/> if none does.
+    ///
+    /// An address held by more than one account settles nothing, and is refused; that is what
+    /// <paramref name="userId"/> is for.
+    /// </summary>
+    Task<ServiceResult<TenantParticipantUser>> CreateAsync(
+        string tenantId, string? email, string? name, string role, string? userId = null);
     Task<ServiceResult<TenantParticipantUser>> UpdateAsync(
         string tenantId, string userId, string? name, string? email, string? role, bool? isApproved,
         bool callerIsSysAdmin = false);
@@ -158,25 +167,34 @@ public class TenantParticipantUserService : ITenantParticipantUserService
         }
     }
 
-    public async Task<ServiceResult<TenantParticipantUser>> CreateAsync(string tenantId, string email, string name, string role)
+    public async Task<ServiceResult<TenantParticipantUser>> CreateAsync(
+        string tenantId, string? email, string? name, string role, string? userId = null)
     {
         var normalizedRole = NormalizeTenantRole(role);
         if (normalizedRole == null)
             return ServiceResult<TenantParticipantUser>.BadRequest(
                 $"Role must be one of: {string.Join(", ", AllowedTenantRoles)}");
 
-        var sanitizedEmail = ValidationHelpers.SanitizeAndValidateEmail(email);
+        // An existing account is named by its user id. An address is not an identifier here: it can
+        // answer to more than one account, and the role granted may be TenantAdmin, so resolving
+        // one would risk handing that role to a different account than the caller meant.
+        if (!string.IsNullOrWhiteSpace(userId))
+        {
+            return await AddRoleToNamedAccountAsync(userId.Trim(), tenantId, normalizedRole);
+        }
+
+        var sanitizedEmail = ValidationHelpers.SanitizeAndValidateEmail(email ?? string.Empty);
         if (sanitizedEmail == null)
-            return ServiceResult<TenantParticipantUser>.BadRequest("Invalid email address");
+            return ServiceResult<TenantParticipantUser>.BadRequest(
+                "Supply either a userId for an existing account, or a valid email to create a new one");
 
-        var sanitizedName = ValidationHelpers.SanitizeString(name);
-        if (string.IsNullOrWhiteSpace(sanitizedName))
-            return ServiceResult<TenantParticipantUser>.BadRequest("Name is required");
-
-        // If the user already exists, add them to the tenant instead of creating a new account.
-        // The role granted here can be TenantAdmin, so the address has to name one account: an
-        // address two records answer to is refused rather than resolved to whichever came back
-        // first, which would hand the role to a different account than the admin meant.
+        // An address exactly one account holds names it as surely as a user id does, so the
+        // membership is added rather than the caller being sent to look up something the address
+        // already settles. Refusing here would not make anything safer: an operator sent to find
+        // the user id would search by the same address and arrive at the same record.
+        //
+        // Several accounts is the case a user id exists to settle, and the role granted here can
+        // be TenantAdmin, so that one is refused rather than resolved to whichever came back first.
         var lookup = EmailAccountLookup.From(await _userRepository.GetAllByUserEmailAsync(sanitizedEmail));
         if (lookup.IsAmbiguous)
         {
@@ -189,6 +207,12 @@ public class TenantParticipantUserService : ITenantParticipantUserService
 
         if (lookup.Account != null)
             return await AddTenantToExistingUserAsync(lookup.Account, tenantId, normalizedRole);
+
+        // Only a new account needs a name; adding an existing one takes the name already on it.
+        var sanitizedName = ValidationHelpers.SanitizeString(name ?? string.Empty);
+        if (string.IsNullOrWhiteSpace(sanitizedName))
+            return ServiceResult<TenantParticipantUser>.BadRequest(
+                "Name is required to create a new account");
 
         var dto = new CreateNewUserDto
         {
@@ -225,6 +249,29 @@ public class TenantParticipantUserService : ITenantParticipantUserService
             Role = normalizedRole,
             IsApproved = !created.IsLockedOut && (tenantRole?.IsApproved ?? true),
         }, StatusCode.Created);
+    }
+
+    /// <summary>
+    /// Adds the role to the account the caller named by user id, which is the only identifier that
+    /// names exactly one account.
+    /// </summary>
+    private async Task<ServiceResult<TenantParticipantUser>> AddRoleToNamedAccountAsync(
+        string userId, string tenantId, string normalizedRole)
+    {
+        if (userId.Contains('@'))
+        {
+            return ServiceResult<TenantParticipantUser>.BadRequest(
+                "userId must be a user id, not an email address. Omit it and supply email and " +
+                "name to create a new account.");
+        }
+
+        var user = await _userRepository.GetByUserIdAsync(userId);
+        if (user == null)
+        {
+            return ServiceResult<TenantParticipantUser>.NotFound($"User '{userId}' not found");
+        }
+
+        return await AddTenantToExistingUserAsync(user, tenantId, normalizedRole);
     }
 
     private async Task<ServiceResult<TenantParticipantUser>> AddTenantToExistingUserAsync(

--- a/XiansAi.Server.Src/Shared/Services/TenantParticipantUserService.cs
+++ b/XiansAi.Server.Src/Shared/Services/TenantParticipantUserService.cs
@@ -1,5 +1,4 @@
 using System.Text.Json.Serialization;
-using Shared.Auth;
 using Shared.Data.Models;
 using Shared.Data.Models.Validation;
 using Shared.Providers.Auth;
@@ -175,9 +174,21 @@ public class TenantParticipantUserService : ITenantParticipantUserService
             return ServiceResult<TenantParticipantUser>.BadRequest("Name is required");
 
         // If the user already exists, add them to the tenant instead of creating a new account.
-        var existingUser = await _userRepository.GetByUserEmailAsync(sanitizedEmail);
-        if (existingUser != null)
-            return await AddTenantToExistingUserAsync(existingUser, tenantId, normalizedRole);
+        // The role granted here can be TenantAdmin, so the address has to name one account: an
+        // address two records answer to is refused rather than resolved to whichever came back
+        // first, which would hand the role to a different account than the admin meant.
+        var lookup = EmailAccountLookup.From(await _userRepository.GetAllByUserEmailAsync(sanitizedEmail));
+        if (lookup.IsAmbiguous)
+        {
+            _logger.LogWarning(
+                "Refusing to add {Email} to tenant {TenantId} as {Role}: it matches {Count} accounts",
+                LogSanitizer.RedactEmail(sanitizedEmail), LogSanitizer.Sanitize(tenantId),
+                normalizedRole, lookup.MatchCount);
+            return ServiceResult<TenantParticipantUser>.Conflict(EmailAccountLookup.AmbiguousError);
+        }
+
+        if (lookup.Account != null)
+            return await AddTenantToExistingUserAsync(lookup.Account, tenantId, normalizedRole);
 
         var dto = new CreateNewUserDto
         {
@@ -219,6 +230,18 @@ public class TenantParticipantUserService : ITenantParticipantUserService
     private async Task<ServiceResult<TenantParticipantUser>> AddTenantToExistingUserAsync(
         User user, string tenantId, string normalizedRole)
     {
+        // A disabled account cannot sign in, and the one kind most likely to be found by address is
+        // a record created disabled because it collides with a system administrator. Granting it a
+        // membership would leave that grant waiting on a decision nobody made here.
+        if (user.IsLockedOut)
+        {
+            _logger.LogWarning(
+                "Refusing to add disabled account {UserId} to tenant {TenantId}",
+                LogSanitizer.Sanitize(user.UserId), LogSanitizer.Sanitize(tenantId));
+            return ServiceResult<TenantParticipantUser>.Conflict(
+                "This account is disabled, so it cannot be added to a tenant. Enable it first.");
+        }
+
         var existingMembership = user.TenantRoles.FirstOrDefault(t => t.Tenant == tenantId);
         if (existingMembership != null)
         {

--- a/XiansAi.Server.Src/Shared/Services/TenantService.cs
+++ b/XiansAi.Server.Src/Shared/Services/TenantService.cs
@@ -437,7 +437,7 @@ public class TenantService : ITenantService
         }
         catch (MongoWriteException ex) when (ex.WriteError?.Code == 11000) // Duplicate key error
         {
-            var message = DescribeDuplicateTenant(ex.WriteError?.Message, request);
+            var message = DescribeDuplicateTenant(ex.WriteError?.Message, request.TenantId, request.Domain);
             _logger.LogWarning("Rejected duplicate tenant {TenantId}: {Message}. Write error: {WriteError}",
                 LogSanitizer.Sanitize(request.TenantId), message, LogSanitizer.Sanitize(ex.WriteError?.Message));
             return ServiceResult<TenantCreatedResult>.BadRequest(message);
@@ -450,26 +450,26 @@ public class TenantService : ITenantService
     }
 
     /// <summary>
-    /// Explains which value collided when MongoDB rejects a tenant insert as a duplicate.
+    /// Explains which value collided when MongoDB rejects a tenant write as a duplicate.
     /// The write error names the violated index, which is the only way to tell a tenant id
     /// clash apart from a domain clash.
     /// </summary>
-    private static string DescribeDuplicateTenant(string? writeErrorMessage, CreateTenantRequest request)
+    private static string DescribeDuplicateTenant(string? writeErrorMessage, string tenantId, string? domain)
     {
         var writeError = writeErrorMessage ?? string.Empty;
 
         if (writeError.Contains("tenant_id", StringComparison.OrdinalIgnoreCase))
         {
-            return $"A tenant with ID '{request.TenantId}' already exists.";
+            return $"A tenant with ID '{tenantId}' already exists.";
         }
 
         if (writeError.Contains("domain", StringComparison.OrdinalIgnoreCase))
         {
-            // A unique domain index also rejects a second tenant that leaves the domain empty,
-            // which reads as a false conflict unless the message spells it out.
-            return string.IsNullOrWhiteSpace(request.Domain)
+            // A unique domain index also rejects a tenant that leaves the domain empty when another
+            // one already has none, which reads as a false conflict unless the message spells it out.
+            return string.IsNullOrWhiteSpace(domain)
                 ? "This database requires every tenant to have a unique domain, and another tenant already has none. Provide a domain for this tenant."
-                : $"A tenant with domain '{request.Domain}' already exists.";
+                : $"A tenant with domain '{domain}' already exists.";
         }
 
         return "A tenant with this ID or domain already exists.";
@@ -630,7 +630,19 @@ public class TenantService : ITenantService
         existingTenant.UpdatedAt = DateTime.UtcNow;
         var validatedTenant = existingTenant.SanitizeAndValidate();
 
-        var success = await _tenantRepository.UpdateAsync(id, validatedTenant);
+        bool success;
+        try
+        {
+            success = await _tenantRepository.UpdateAsync(id, validatedTenant);
+        }
+        catch (MongoWriteException ex) when (ex.WriteError?.Code == 11000) // Duplicate key error
+        {
+            var message = DescribeDuplicateTenant(ex.WriteError?.Message, validatedTenant.TenantId, validatedTenant.Domain);
+            _logger.LogWarning("Rejected duplicate tenant update for {Id}: {Message}. Write error: {WriteError}",
+                LogSanitizer.Sanitize(id), message, LogSanitizer.Sanitize(ex.WriteError?.Message));
+            return ServiceResult<Tenant>.BadRequest(message);
+        }
+
         if (!success)
         {
             _logger.LogError("Failed to update tenant with ID {Id}", LogSanitizer.Sanitize(id));

--- a/XiansAi.Server.Src/Shared/Services/UserAuthorizationInvalidator.cs
+++ b/XiansAi.Server.Src/Shared/Services/UserAuthorizationInvalidator.cs
@@ -1,0 +1,88 @@
+using Shared.Data.Models;
+using Shared.Repositories;
+using Shared.Utils;
+
+namespace Shared.Services;
+
+/// <summary>
+/// Drops every cached authorization decision that depends on an account, for use when that
+/// account changes in a way that should take effect now rather than when the caches expire.
+///
+/// Disabling an account is checked when a decision is made, not when it is used, and each API
+/// caches the decision: the User API keeps the approved tenant list, the Agent API keeps the
+/// certificate's user and roles, the Admin API keeps the resolved roles, and validated tokens are
+/// kept for all of them. Without this, a disabled account keeps working for as long as the longest
+/// of those lifetimes.
+/// </summary>
+public interface IUserAuthorizationInvalidator
+{
+    Task InvalidateAsync(User user);
+    Task InvalidateAsync(string userId);
+}
+
+public class UserAuthorizationInvalidator : IUserAuthorizationInvalidator
+{
+    private readonly IUserCacheIndex _userCacheIndex;
+    private readonly IUserRepository _userRepository;
+    private readonly ILogger<UserAuthorizationInvalidator> _logger;
+
+    public UserAuthorizationInvalidator(
+        IUserCacheIndex userCacheIndex,
+        IUserRepository userRepository,
+        ILogger<UserAuthorizationInvalidator> logger)
+    {
+        _userCacheIndex = userCacheIndex;
+        _userRepository = userRepository;
+        _logger = logger;
+    }
+
+    public async Task InvalidateAsync(string userId)
+    {
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            return;
+        }
+
+        var user = await _userRepository.GetByUserIdAsync(userId);
+        if (user == null)
+        {
+            _userCacheIndex.Invalidate(userId);
+            return;
+        }
+
+        await InvalidateAsync(user);
+    }
+
+    public async Task InvalidateAsync(User user)
+    {
+        _userCacheIndex.Invalidate(user.UserId);
+
+        if (string.IsNullOrWhiteSpace(user.Email))
+        {
+            return;
+        }
+
+        // Credentials that carry only an address resolve through every account holding it, and the
+        // result changes when one of them does: a disabled account drops out of the combined roles
+        // and withdraws the administrator role from the rest. Those decisions are cached against a
+        // sibling's id, so they survive unless the siblings are invalidated too.
+        try
+        {
+            var siblings = await _userRepository.GetAllByUserEmailAsync(user.Email);
+            foreach (var sibling in siblings)
+            {
+                if (!string.Equals(sibling.UserId, user.UserId, StringComparison.Ordinal))
+                {
+                    _userCacheIndex.Invalidate(sibling.UserId);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            // The account's own entries are already gone, which is the part that matters most.
+            _logger.LogWarning(ex,
+                "Could not invalidate cached authorization for the accounts sharing {Email}",
+                LogSanitizer.RedactEmail(user.Email));
+        }
+    }
+}

--- a/XiansAi.Server.Src/Shared/Services/UserCacheIndex.cs
+++ b/XiansAi.Server.Src/Shared/Services/UserCacheIndex.cs
@@ -1,0 +1,116 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Caching.Memory;
+using Shared.Utils;
+
+namespace Shared.Services;
+
+/// <summary>
+/// Records which cache entries were written on behalf of which user, so that a change to an
+/// account can evict all of them at once.
+///
+/// The authorization caches are keyed on what the request presented — a hash of a token, a
+/// certificate thumbprint, a provider authority and subject — and none of those can be
+/// reconstructed from a user id. Without this index, disabling an account would leave every
+/// cached decision about it in place until it expired on its own, which is how long the account
+/// would keep working after being disabled.
+/// </summary>
+public interface IUserCacheIndex
+{
+    /// <summary>Associates a cache key with the user whose authorization it depends on.</summary>
+    void Track(string userId, string cacheKey);
+
+    /// <summary>
+    /// Drops the association, for entries the cache evicted on its own. Callers register this as a
+    /// post-eviction callback so the index does not grow without bound.
+    /// </summary>
+    void Forget(string userId, string cacheKey);
+
+    /// <summary>Evicts every entry tracked for the user. Returns how many were removed.</summary>
+    int Invalidate(string userId);
+}
+
+/// <summary>
+/// Must be registered as a singleton. The caches that populate it are scoped, so an index held by
+/// one of them would be discarded at the end of the request that wrote the entry and would be
+/// empty in the later request that needs to evict it.
+/// </summary>
+public class UserCacheIndex : IUserCacheIndex
+{
+    private readonly IMemoryCache _cache;
+    private readonly ILogger<UserCacheIndex> _logger;
+
+    // Compared without regard to case, because the same account reaches this under spellings that
+    // differ in case — an address is stored lowercase while a token may present it otherwise.
+    // Treating two spellings as one user can only evict more than was needed, which costs a cache
+    // miss, whereas treating them as two would leave an entry behind.
+    private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, byte>> _keysByUser =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public UserCacheIndex(IMemoryCache cache, ILogger<UserCacheIndex> logger)
+    {
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public void Track(string userId, string cacheKey)
+    {
+        if (string.IsNullOrWhiteSpace(userId) || string.IsNullOrWhiteSpace(cacheKey))
+        {
+            return;
+        }
+
+        var keys = _keysByUser.GetOrAdd(
+            userId, _ => new ConcurrentDictionary<string, byte>(StringComparer.Ordinal));
+        keys[cacheKey] = 0;
+    }
+
+    public void Forget(string userId, string cacheKey)
+    {
+        if (string.IsNullOrWhiteSpace(userId) || string.IsNullOrWhiteSpace(cacheKey))
+        {
+            return;
+        }
+
+        if (!_keysByUser.TryGetValue(userId, out var keys))
+        {
+            return;
+        }
+
+        keys.TryRemove(cacheKey, out _);
+
+        // A racing Track may have just added a key to this instance, so the removal is conditional
+        // on it still being empty. Losing that race only leaves an empty entry behind.
+        if (keys.IsEmpty)
+        {
+            _keysByUser.TryRemove(new KeyValuePair<string, ConcurrentDictionary<string, byte>>(userId, keys));
+        }
+    }
+
+    public int Invalidate(string userId)
+    {
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            return 0;
+        }
+
+        if (!_keysByUser.TryRemove(userId, out var keys))
+        {
+            return 0;
+        }
+
+        var cacheKeys = keys.Keys.ToArray();
+        foreach (var cacheKey in cacheKeys)
+        {
+            _cache.Remove(cacheKey);
+        }
+
+        if (cacheKeys.Length > 0)
+        {
+            _logger.LogInformation(
+                "Evicted {Count} cached authorization entries for {UserId}",
+                cacheKeys.Length, LogSanitizer.RedactUserId(userId));
+        }
+
+        return cacheKeys.Length;
+    }
+}

--- a/XiansAi.Server.Src/Shared/Services/UserManagementService.cs
+++ b/XiansAi.Server.Src/Shared/Services/UserManagementService.cs
@@ -20,13 +20,6 @@ public class UserDto
     public string Name { get; set; } = string.Empty;
 
     /// <summary>
-    /// Whether the provider stated that the holder owns <see cref="Email"/>. See
-    /// <see cref="User.EmailVerified"/>; only a verified address participates in deciding identity.
-    /// </summary>
-    [JsonPropertyName("emailVerified")]
-    public bool EmailVerified { get; set; }
-
-    /// <summary>
     /// OIDC authority the subject was authenticated by, pinned onto the new record. Null for
     /// provisioning paths that do not authenticate against a specific provider, such as operator
     /// bootstrap and admin-created users; those records are pinned on first sign-in instead.
@@ -171,6 +164,7 @@ public class UserManagementService : IUserManagementService
     private readonly IEmailService _emailService;
     private readonly IJwtClaimsExtractor _jwtClaimsExtractor;
     private readonly ITokenValidationCache _tokenCache;
+    private readonly IUserAuthorizationInvalidator _authorizationInvalidator;
 
     private const string EMAIL_SUBJECT = "Xians.ai - Invitation";
 
@@ -183,6 +177,7 @@ public class UserManagementService : IUserManagementService
         IEmailService emailService,
         IJwtClaimsExtractor jwtClaimsExtractor,
         ITokenValidationCache tokenCache,
+        IUserAuthorizationInvalidator authorizationInvalidator,
         ILogger<UserManagementService> logger)
     {
         _userRepository = userRepository;
@@ -194,6 +189,7 @@ public class UserManagementService : IUserManagementService
         _emailService = emailService;
         _jwtClaimsExtractor = jwtClaimsExtractor;
         _tokenCache = tokenCache;
+        _authorizationInvalidator = authorizationInvalidator;
     }
 
     public async Task<ServiceResult<bool>> LockUserAsync(string userId, string reason)
@@ -212,9 +208,10 @@ public class UserManagementService : IUserManagementService
                 return ServiceResult<bool>.NotFound("User not found");
             }
 
-            // Invalidate all cached tokens for this user to ensure locked users cannot access the system
-            await _tokenCache.InvalidateUserTokens(userId);
-            _logger.LogInformation("User {UserId} locked by {AdminUserId} and tokens invalidated", LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
+            // Every cached decision about this account, across all four APIs, so that the lock
+            // takes effect on the next request rather than when those entries expire.
+            await _authorizationInvalidator.InvalidateAsync(userId);
+            _logger.LogInformation("User {UserId} locked by {AdminUserId} and cached access invalidated", LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
             return ServiceResult<bool>.Success(true);
         }
         catch (Exception ex)
@@ -240,9 +237,9 @@ public class UserManagementService : IUserManagementService
                 return ServiceResult<bool>.NotFound("User not found");
             }
 
-            // Invalidate cached tokens so user needs to re-authenticate with fresh token
-            await _tokenCache.InvalidateUserTokens(userId);
-            _logger.LogInformation("User {UserId} unlocked by {AdminUserId} and tokens invalidated", LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
+            // Cached refusals are dropped too, so the account works again without a wait.
+            await _authorizationInvalidator.InvalidateAsync(userId);
+            _logger.LogInformation("User {UserId} unlocked by {AdminUserId} and cached access invalidated", LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(_tenantContext.LoggedInUser));
             return ServiceResult<bool>.Success(true);
         }
         catch (Exception ex)
@@ -338,7 +335,6 @@ public class UserManagementService : IUserManagementService
             {
                 UserId = userDto.UserId,
                 Email = userDto.Email,
-                EmailVerified = userDto.EmailVerified,
                 Name = userDto.Name,
                 ProviderAuthority = userDto.ProviderAuthority,
                 IsSysAdmin = isFirstUserBootstrap,

--- a/XiansAi.Server.Src/Shared/Services/UserManagementService.cs
+++ b/XiansAi.Server.Src/Shared/Services/UserManagementService.cs
@@ -20,6 +20,13 @@ public class UserDto
     public string Name { get; set; } = string.Empty;
 
     /// <summary>
+    /// Whether the provider stated that the holder owns <see cref="Email"/>. See
+    /// <see cref="User.EmailVerified"/>; only a verified address participates in deciding identity.
+    /// </summary>
+    [JsonPropertyName("emailVerified")]
+    public bool EmailVerified { get; set; }
+
+    /// <summary>
     /// OIDC authority the subject was authenticated by, pinned onto the new record. Null for
     /// provisioning paths that do not authenticate against a specific provider, such as operator
     /// bootstrap and admin-created users; those records are pinned on first sign-in instead.
@@ -293,23 +300,19 @@ public class UserManagementService : IUserManagementService
                 return ServiceResult<bool>.Conflict("User already exists");
             }
 
-            // Email is unique across the system. Several lookups resolve a person by email and take
-            // the first match — certificate authentication and ownership transfer both accept an
-            // email in place of a user id — so a second record sharing one makes those resolve to
-            // an arbitrary record. Every deliberate creation path already refuses this; enforcing it
-            // here means an implicit path cannot quietly reopen the hole.
+            // One person can legitimately hold an account at two identity providers, so an address
+            // shared across providers is allowed. Two records under the *same* provider are not:
+            // there the address really does name one account, so a second one is a duplicate.
             //
             // Records with no email cannot collide and are not compared, or they would all match
             // each other.
+            var admission = EmailAdmission.Allowed;
             if (!string.IsNullOrWhiteSpace(userDto.Email))
             {
-                var emailOwner = await _userRepository.GetByUserEmailAsync(userDto.Email);
-                if (emailOwner != null)
+                admission = await AdmitEmailAsync(userDto);
+                if (admission.Conflict != null)
                 {
-                    _logger.LogWarning(
-                        "Refusing to create {UserId}: its email already belongs to {ExistingUserId}",
-                        LogSanitizer.RedactUserId(userDto.UserId), LogSanitizer.RedactUserId(emailOwner.UserId));
-                    return ServiceResult<bool>.Conflict("A user with this email already exists");
+                    return admission.Conflict;
                 }
             }
             else
@@ -335,10 +338,15 @@ public class UserManagementService : IUserManagementService
             {
                 UserId = userDto.UserId,
                 Email = userDto.Email,
+                EmailVerified = userDto.EmailVerified,
                 Name = userDto.Name,
                 ProviderAuthority = userDto.ProviderAuthority,
                 IsSysAdmin = isFirstUserBootstrap,
-                IsLockedOut = false,
+                IsLockedOut = admission.NeedsReview,
+                LockedOutReason = admission.NeedsReview
+                    ? SharedWithSysAdminReason(admission.SysAdminOwnerId!)
+                    : null,
+                LockedOutAt = admission.NeedsReview ? DateTime.UtcNow : null,
                 CreatedAt = DateTime.UtcNow,
                 UpdatedAt = DateTime.UtcNow,
                 TenantRoles = new List<TenantRole>()
@@ -391,6 +399,108 @@ public class UserManagementService : IUserManagementService
             return ServiceResult<bool>.InternalServerError("An error occurred while creating the new user");
         }
     }
+
+    /// <summary>
+    /// Whether a record may be created for an address somebody already holds, and in what state.
+    /// </summary>
+    /// <param name="Conflict">The result to return instead of creating anything.</param>
+    /// <param name="SysAdminOwnerId">
+    /// The system administrator already holding the address, when the record is to be created
+    /// disabled so a person can decide whether the two are the same someone.
+    /// </param>
+    private sealed record EmailAdmission(ServiceResult<bool>? Conflict, string? SysAdminOwnerId)
+    {
+        public static readonly EmailAdmission Allowed = new(null, null);
+
+        public static EmailAdmission Refuse(ServiceResult<bool> conflict) => new(conflict, null);
+
+        public static EmailAdmission ForReview(string sysAdminOwnerId) => new(null, sysAdminOwnerId);
+
+        public bool NeedsReview => SysAdminOwnerId != null;
+    }
+
+    /// <summary>
+    /// Decides what to do about an address an existing record already holds.
+    ///
+    /// A second account at a *different* identity provider belongs to the same person arriving
+    /// through another door, so it is allowed — that is the case this exists for. Two records under
+    /// providers that cannot be told apart are refused: the same provider, where the address really
+    /// does name one account, and an unknown provider on either side, since a record that might
+    /// have come from the same provider has to be treated as the same account.
+    ///
+    /// An address a system administrator holds is neither allowed outright nor refused. Refusing it
+    /// leaves a real person in a second directory unable to sign in at all, with no way through
+    /// that does not involve deleting somebody's account. Allowing it outright would strip SysAdmin
+    /// from the account that has it, since the role is never resolved from an address whose records
+    /// do not all hold it. So the record is created disabled: inert, invisible to that resolution,
+    /// and waiting for an administrator to decide.
+    /// </summary>
+    private async Task<EmailAdmission> AdmitEmailAsync(UserDto userDto)
+    {
+        var owners = await _userRepository.GetAllByUserEmailAsync(userDto.Email);
+        if (owners.Count == 0)
+        {
+            return EmailAdmission.Allowed;
+        }
+
+        // Before the SysAdmin case, so that a duplicate under the same provider is refused for
+        // being a duplicate rather than queued for a review that should never happen.
+        var sameProviderOwner = owners.FirstOrDefault(
+            owner => !IsDifferentProvider(owner.ProviderAuthority, userDto.ProviderAuthority));
+        if (sameProviderOwner != null)
+        {
+            _logger.LogWarning(
+                "Refusing to create {UserId} from {Authority}: {ExistingUserId} already holds its email " +
+                "and cannot be told apart as a separate provider",
+                LogSanitizer.RedactUserId(userDto.UserId),
+                LogSanitizer.Sanitize(userDto.ProviderAuthority ?? "(unknown)"),
+                LogSanitizer.RedactUserId(sameProviderOwner.UserId));
+            return EmailAdmission.Refuse(ServiceResult<bool>.Conflict("A user with this email already exists"));
+        }
+
+        var sysAdminOwner = owners.FirstOrDefault(owner => owner.IsSysAdmin);
+        if (sysAdminOwner != null)
+        {
+            _logger.LogWarning(
+                "Creating {UserId} from {Authority} disabled: its email belongs to system administrator " +
+                "{ExistingUserId}. Until an administrator enables it and grants it the same role, it " +
+                "cannot sign in and does not affect what that address resolves to",
+                LogSanitizer.RedactUserId(userDto.UserId),
+                LogSanitizer.Sanitize(userDto.ProviderAuthority ?? "(unknown)"),
+                LogSanitizer.RedactUserId(sysAdminOwner.UserId));
+            return EmailAdmission.ForReview(sysAdminOwner.UserId);
+        }
+
+        _logger.LogInformation(
+            "Creating {UserId} from {Authority} with an email already held by {Count} account(s) at " +
+            "other providers; they resolve as one identity where a credential names only the address",
+            LogSanitizer.RedactUserId(userDto.UserId),
+            LogSanitizer.Sanitize(userDto.ProviderAuthority ?? "(unknown)"),
+            owners.Count);
+        return EmailAdmission.Allowed;
+    }
+
+    /// <summary>
+    /// Why the record is disabled, written for whoever finds it in the admin console and has to
+    /// decide. It states the consequence of enabling it on its own, because that consequence lands
+    /// on a different account than the one being enabled and is otherwise invisible from here.
+    /// </summary>
+    private static string SharedWithSysAdminReason(string sysAdminUserId) =>
+        $"Created disabled for review: this email is also held by system administrator {sysAdminUserId}. " +
+        "If both accounts belong to the same person, enable this one and grant it the system " +
+        "administrator role in the same sitting. Enabling it without the grant takes that role away " +
+        "from credentials that name only an email address — legacy API keys and certificates whose " +
+        "OU is an email — until the grant is made.";
+
+    /// <summary>
+    /// True only when both records name a provider and the two differ. An unknown provider on
+    /// either side reads as "cannot be told apart", because a record that might have come from the
+    /// same provider has to be treated as the same account.
+    /// </summary>
+    private static bool IsDifferentProvider(string? existingAuthority, string? incomingAuthority) =>
+        !string.IsNullOrEmpty(existingAuthority)
+        && !string.IsNullOrEmpty(incomingAuthority)
+        && !string.Equals(existingAuthority, incomingAuthority, StringComparison.OrdinalIgnoreCase);
 
     public async Task<ServiceResult<bool>> UpdateUser(EditUserDto user)
     {

--- a/XiansAi.Server.Src/Shared/Services/UserTenantService.cs
+++ b/XiansAi.Server.Src/Shared/Services/UserTenantService.cs
@@ -52,11 +52,18 @@ public class ResolvedUserAccess
     public required List<TenantInfoDto> Tenants { get; init; }
 
     /// <summary>
-    /// The account's stored email, when present. Used as an alternate conversation participant id so
-    /// clients may keep naming the person by email while the account remains keyed by the provider
-    /// subject.
+    /// The address that may name this account's message threads, or null when it may not because
+    /// another account holds it too. Threads are namespaced by this, so it has to name exactly one
+    /// account.
     /// </summary>
-    public string? Email { get; init; }
+    public string? ConversationEmail { get; init; }
+
+    /// <summary>
+    /// The address stored on the record, whether or not another account also holds it. It may
+    /// identify the caller — recognising them when they name themselves by email — but must never
+    /// namespace anything, which is what <see cref="ConversationEmail"/> is for.
+    /// </summary>
+    public string? AccountEmail { get; init; }
 }
 
 /// <summary>
@@ -304,7 +311,8 @@ public class UserTenantService : IUserTenantService
             {
                 UserId = userId,
                 Tenants = tenants.Data,
-                Email = await ConversationIdentityEmailAsync(user)
+                ConversationEmail = await ConversationIdentityEmailAsync(user),
+                AccountEmail = NormalizeEmail(user?.Email)
             });
     }
 
@@ -332,7 +340,12 @@ public class UserTenantService : IUserTenantService
             return null;
         }
 
-        return user.Email.Trim().ToLowerInvariant();
+        return NormalizeEmail(user.Email);
+    }
+
+    private static string? NormalizeEmail(string? email)
+    {
+        return string.IsNullOrWhiteSpace(email) ? null : email.Trim().ToLowerInvariant();
     }
 
     /// <summary>

--- a/XiansAi.Server.Src/Shared/Services/UserTenantService.cs
+++ b/XiansAi.Server.Src/Shared/Services/UserTenantService.cs
@@ -59,6 +59,31 @@ public class ResolvedUserAccess
     public string? Email { get; init; }
 }
 
+/// <summary>
+/// What a validated token says about the person signing in, as far as provisioning needs it.
+/// </summary>
+public sealed class SignInIdentity
+{
+    /// <summary>The raw provider subject, which is the form the users collection is keyed on.</summary>
+    public required string UserId { get; init; }
+
+    public string? Email { get; init; }
+
+    /// <summary>
+    /// Whether the provider stated the holder owns <see cref="Email"/>. An unverified address is
+    /// still stored for display and contact, but only a verified one may decide identity.
+    /// </summary>
+    public bool EmailVerified { get; init; }
+
+    public string? Name { get; init; }
+
+    /// <summary>
+    /// The authority whose signing keys authenticated the subject. A subject is only unique within
+    /// one issuer, so the record is pinned to this.
+    /// </summary>
+    public string? ProviderAuthority { get; init; }
+}
+
 public interface IUserTenantService
 {
     Task<ServiceResult<List<TenantInfoDto>>> GetCurrentUserTenants(string token);
@@ -66,7 +91,7 @@ public interface IUserTenantService
     Task<ServiceResult<List<TenantInfoDto>>> GetTenantsForUser(string userId);
     Task<ServiceResult<List<TenantInfoDto>>> GetApprovedTenantsForUserId(string userId);
     Task<ServiceResult<ResolvedUserAccess>> EnsureUserAndGetApprovedTenants(
-        string userId, string? email, string? name, string? providerAuthority, string? requestedTenantId = null);
+        SignInIdentity identity, string? requestedTenantId = null, bool approveNewMembership = false);
     Task<ServiceResult<List<User>>> GetUnapprovedUsers();
     Task<ServiceResult<bool>> AddTenantToUser(string userId, string tenantId);
     Task<ServiceResult<bool>> RemoveTenantFromUser(string userId, string tenantId);
@@ -151,24 +176,32 @@ public class UserTenantService : IUserTenantService
 
     /// <summary>
     /// Creates the user record if this is their first sign-in, then returns the tenants they are an
-    /// approved member of. A brand new user is approved for nothing, so this returns an empty list
-    /// and the caller refuses the request until an admin acts. Identity comes from an
-    /// already-validated token; the token is not re-parsed here.
+    /// approved member of. Where the membership still needs approving this returns an empty list and
+    /// the caller refuses the request until an admin acts. Identity comes from an already-validated
+    /// token; the token is not re-parsed here.
     ///
-    /// <paramref name="providerAuthority"/> ties the subject to the provider that authenticated it.
-    /// A subject is only unique within one issuer, so without this a provider could assert another
-    /// provider's subject and resolve that person's record.
+    /// <see cref="SignInIdentity.ProviderAuthority"/> ties the subject to the provider that
+    /// authenticated it. A subject is only unique within one issuer, so without this a provider
+    /// could assert another provider's subject and resolve that person's record.
     ///
     /// <paramref name="requestedTenantId"/> is the tenant the caller was trying to reach. Supplying
-    /// it registers the user as pending on that tenant, which is what makes them visible to its
-    /// admins; without it a rejected first-time user leaves no trace anyone can act on.
+    /// it registers the user on that tenant, which is what makes them visible to its admins; without
+    /// it a rejected first-time user leaves no trace anyone can act on.
+    ///
+    /// <paramref name="approveNewMembership"/> makes that membership approved rather than pending.
+    /// Only for callers that validated the token against the tenant's own OIDC configuration, where
+    /// holding such a token is itself the tenant's statement that this person belongs to it. The
+    /// WebAPI console path must not set it: its tokens are validated against the deployment-wide
+    /// provider, so a token holder could otherwise join any tenant they name.
     /// </summary>
     public async Task<ServiceResult<ResolvedUserAccess>> EnsureUserAndGetApprovedTenants(
-        string userId, string? email, string? name, string? providerAuthority, string? requestedTenantId = null)
+        SignInIdentity identity, string? requestedTenantId = null, bool approveNewMembership = false)
     {
+        var userId = identity.UserId;
         if (string.IsNullOrEmpty(userId))
             return ServiceResult<ResolvedUserAccess>.Unauthorized("User not authenticated");
 
+        var providerAuthority = identity.ProviderAuthority;
         if (string.IsNullOrEmpty(providerAuthority))
         {
             _logger.LogWarning("No provider authority for user {UserId}; cannot establish which provider " +
@@ -188,8 +221,9 @@ public class UserTenantService : IUserTenantService
                     new UserDto
                     {
                         UserId = userId,
-                        Email = email ?? string.Empty,
-                        Name = name ?? string.Empty,
+                        Email = identity.Email ?? string.Empty,
+                        EmailVerified = identity.EmailVerified,
+                        Name = identity.Name ?? string.Empty,
                         ProviderAuthority = providerAuthority
                     },
                     allowFirstUserSysAdminBootstrap: false);
@@ -197,7 +231,7 @@ public class UserTenantService : IUserTenantService
                 if (created.IsSuccess)
                 {
                     _logger.LogInformation("Provisioned user {UserId} on first sign-in", LogSanitizer.RedactUserId(userId));
-                    await RegisterAsPendingMemberAsync(userId, requestedTenantId);
+                    await RegisterMembershipAsync(userId, requestedTenantId, approveNewMembership);
                     return await GetAccessForUserId(userId);
                 }
 
@@ -213,9 +247,11 @@ public class UserTenantService : IUserTenantService
                 existingUser = await _userRepository.GetByUserIdAsync(userId);
                 if (existingUser == null)
                 {
-                    // ...or the conflict was on the email, which already belongs to a different
-                    // subject. The token only proves that this provider *says* this person's email
-                    // is that string; merging into the existing account would hand over its access.
+                    // ...or the conflict was on the email. A second account at another provider is
+                    // allowed — including one whose address a system administrator holds, which is
+                    // created disabled instead — so reaching here means the address is
+                    // indistinguishable from an existing one: the same provider, or a provider that
+                    // cannot be identified.
                     _logger.LogWarning(
                         "Refusing to provision {UserId} from {Authority}: the email in this token is " +
                         "already registered to a different account.",
@@ -231,9 +267,11 @@ public class UserTenantService : IUserTenantService
                     "This subject is registered to a different identity provider");
             }
 
+            await BackfillMissingProfileAsync(existingUser, identity);
+
             // Also for an existing record: a known user reaching a tenant they have never been a
             // member of is the same situation as a brand new one, and needs the same visibility.
-            await RegisterAsPendingMemberAsync(userId, requestedTenantId);
+            await RegisterMembershipAsync(userId, requestedTenantId, approveNewMembership);
         }
         catch (Exception ex)
         {
@@ -252,31 +290,109 @@ public class UserTenantService : IUserTenantService
         var tenants = await GetApprovedTenantsForUserId(userId);
         if (!tenants.IsSuccess || tenants.Data == null)
         {
-            return ServiceResult<ResolvedUserAccess>.InternalServerError(
-                tenants.ErrorMessage ?? "Error getting tenants for user");
+            // Carries the original status through: a disabled account is refused there, and
+            // flattening that to a 500 would tell the caller the server broke.
+            return ServiceResult<ResolvedUserAccess>.Failure(
+                tenants.ErrorMessage ?? "Error getting tenants for user",
+                tenants.StatusCode);
         }
 
         var user = await _userRepository.GetByUserIdAsync(userId);
-        string? email = null;
-        if (!string.IsNullOrWhiteSpace(user?.Email))
-        {
-            email = user.Email.Trim().ToLowerInvariant();
-        }
 
         return ServiceResult<ResolvedUserAccess>.Success(
-            new ResolvedUserAccess { UserId = userId, Tenants = tenants.Data, Email = email });
+            new ResolvedUserAccess
+            {
+                UserId = userId,
+                Tenants = tenants.Data,
+                Email = await ConversationIdentityEmailAsync(user)
+            });
     }
 
     /// <summary>
-    /// Registers the user as pending on the tenant they tried to reach, so that its admins can see
-    /// and approve them. Grants no access: the membership is unapproved, and the caller still
-    /// refuses this request.
+    /// The address this account may be named by in conversations, or null when it may not be.
+    ///
+    /// The caller uses this as the participant id, which is the namespace their message threads live
+    /// in, so an address two accounts answer to would put both in one namespace and let either read
+    /// the other's conversations. Where the address does not name a single account, the account
+    /// falls back to being named by its provider subject, which always does.
+    /// </summary>
+    private async Task<string?> ConversationIdentityEmailAsync(User? user)
+    {
+        if (user == null || string.IsNullOrWhiteSpace(user.Email))
+        {
+            return null;
+        }
+
+        if (await _userRepository.IsEmailSharedAsync(user.Email, user.UserId))
+        {
+            _logger.LogWarning(
+                "Not using the email of {UserId} as their conversation identity: another account holds " +
+                "the same address, and sharing one would merge their message threads",
+                LogSanitizer.RedactUserId(user.UserId));
+            return null;
+        }
+
+        return user.Email.Trim().ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Fills in an address or a name the record is missing, from what the token says.
+    ///
+    /// Records provisioned before the address was stored have neither, and nothing else ever
+    /// revisits them — the create path only runs on a first sign-in. Only blanks are filled: a value
+    /// already on the record may have been set by an admin, and a verified address is never replaced
+    /// by an unverified one, which would turn a proven address into an asserted one.
+    /// </summary>
+    private async Task BackfillMissingProfileAsync(User user, SignInIdentity identity)
+    {
+        var fillEmail = string.IsNullOrWhiteSpace(user.Email) && !string.IsNullOrWhiteSpace(identity.Email);
+        var fillName = string.IsNullOrWhiteSpace(user.Name) && !string.IsNullOrWhiteSpace(identity.Name);
+        var confirmEmail = !fillEmail && !user.EmailVerified && identity.EmailVerified
+            && string.Equals(user.Email, identity.Email, StringComparison.OrdinalIgnoreCase);
+
+        if (!fillEmail && !fillName && !confirmEmail)
+        {
+            return;
+        }
+
+        try
+        {
+            // Written field by field rather than as a whole record, so a membership another request
+            // is appending right now cannot be undone by writing back the copy read a moment ago.
+            await _userRepository.UpdateProfileFieldsAsync(
+                user.UserId,
+                email: fillEmail ? identity.Email : null,
+                emailVerified: fillEmail || confirmEmail ? identity.EmailVerified : null,
+                name: fillName ? identity.Name : null);
+
+            _logger.LogInformation(
+                "Filled in missing profile fields for {UserId} from their token (email: {FilledEmail}, name: {FilledName})",
+                LogSanitizer.RedactUserId(user.UserId), fillEmail, fillName);
+        }
+        catch (Exception ex)
+        {
+            // Cosmetic next to the reason the caller is here, so a failure must not deny the sign-in.
+            _logger.LogWarning(ex, "Could not fill in missing profile fields for {UserId}",
+                LogSanitizer.RedactUserId(user.UserId));
+        }
+    }
+
+    /// <summary>
+    /// Registers the user on the tenant they tried to reach, so that its admins can see them.
+    ///
+    /// Unapproved, the membership grants no access and exists only for an admin to approve or
+    /// ignore. Approved — see <c>approveNewMembership</c> on the caller — it admits them as a
+    /// participant, which is what lets an agent hold a conversation with them without also handing
+    /// them the WebAPI console.
+    ///
+    /// Only ever adds a missing membership. An existing row is left as it stands: an admin may have
+    /// deliberately withheld approval, and there is no separate state that says so.
     ///
     /// Skipped when the tenant does not exist or is disabled. The tenant id arrives from the caller,
     /// so without that check anyone holding a valid token could append a row to their own user
     /// record for every name they cared to try.
     /// </summary>
-    private async Task RegisterAsPendingMemberAsync(string userId, string? requestedTenantId)
+    private async Task RegisterMembershipAsync(string userId, string? requestedTenantId, bool approve)
     {
         if (string.IsNullOrWhiteSpace(requestedTenantId))
         {
@@ -291,12 +407,19 @@ public class UserTenantService : IUserTenantService
                 return;
             }
 
+            // Participant rather than TenantUser: the WebAPI console admits SysAdmin, TenantAdmin and
+            // TenantUser, so granting TenantUser here would hand the console to everyone who ever
+            // signed in to a tenant's own app.
+            var roles = approve ? new[] { SystemRoles.TenantParticipant } : Array.Empty<string>();
+
             // Uses the stored casing so the membership matches how the tenant is recorded elsewhere.
-            var added = await _userRepository.AddPendingTenantRoleIfAbsentAsync(userId, tenant.TenantId);
+            var added = await _userRepository.AddTenantRoleIfAbsentAsync(userId, tenant.TenantId, approve, roles);
             if (added)
             {
                 _logger.LogInformation(
-                    "User {UserId} requested access to tenant {TenantId} and is awaiting approval",
+                    approve
+                        ? "User {UserId} joined tenant {TenantId} as a participant"
+                        : "User {UserId} requested access to tenant {TenantId} and is awaiting approval",
                     LogSanitizer.RedactUserId(userId), LogSanitizer.Sanitize(tenant.TenantId));
             }
         }
@@ -304,7 +427,7 @@ public class UserTenantService : IUserTenantService
         {
             // Visibility for admins is a convenience; failing to record it must not turn an ordinary
             // "not a member" refusal into an error.
-            _logger.LogWarning(ex, "Could not record pending membership of {TenantId} for {UserId}",
+            _logger.LogWarning(ex, "Could not record membership of {TenantId} for {UserId}",
                 LogSanitizer.Sanitize(requestedTenantId), LogSanitizer.RedactUserId(userId));
         }
     }
@@ -370,9 +493,21 @@ public class UserTenantService : IUserTenantService
             if (string.IsNullOrEmpty(userId))
                 return ServiceResult<List<TenantInfoDto>>.Unauthorized("User not authenticated");
 
-            var isSysAdmin = await _userRepository.IsSysAdmin(userId);
+            var user = await _userRepository.GetByUserIdAsync(userId);
 
-            if (isSysAdmin)
+            // Every sign-in door reaches its tenants through here, so this is where a disabled
+            // account is turned away. Certificates were checking the flag and nothing else was, so
+            // an account disabled pending review could still sign in and be handed its tenants.
+            if (user != null && user.IsLockedOut)
+            {
+                _logger.LogWarning(
+                    "Refusing sign-in for {UserId}: the account is disabled. {Reason}",
+                    LogSanitizer.RedactUserId(userId),
+                    LogSanitizer.Sanitize(user.LockedOutReason ?? "(no reason recorded)"));
+                return ServiceResult<List<TenantInfoDto>>.Unauthorized("This account is disabled");
+            }
+
+            if (user != null && user.IsSysAdmin)
             {
                 var allTenants = await _tenantRepository.GetAllAsync();
                 var enabledTenants = allTenants
@@ -857,9 +992,35 @@ public class UserTenantService : IUserTenantService
             .Concat(_jwtClaimsExtractor.ExtractClaims(token, "roles"));
 
         var isSysAdmin = tokenGroupIds.Any(id => configuredIds.Contains(id));
+
+        // Nobody decides this per user — it follows from a group claim on every login — so without
+        // the check a second account at another directory would be promoted merely for being in
+        // that directory's admin group, which is the escalation this whole area exists to stop.
+        // Accepting two accounts as the same person is an operator's decision, made through the
+        // global user endpoint. Demotion is never blocked: taking the role away is always safe.
+        if (isSysAdmin && await IsEmailSharedWithAnotherAccountAsync(userId))
+        {
+            _logger.LogError(
+                "Not granting SysAdmin to {UserId} from group claims: another account holds the same " +
+                "email. If they are the same person, grant it through global user administration",
+                LogSanitizer.RedactUserId(userId));
+            return;
+        }
+
         await _userRepository.SetSysAdminAsync(userId, isSysAdmin);
 
         _logger.LogInformation("Azure AD group SysAdmin sync: user={UserId} isSysAdmin={IsSysAdmin}", userId, isSysAdmin);
+    }
+
+    private async Task<bool> IsEmailSharedWithAnotherAccountAsync(string userId)
+    {
+        var user = await _userRepository.GetByUserIdAsync(userId);
+        if (user == null || string.IsNullOrWhiteSpace(user.Email))
+        {
+            return false;
+        }
+
+        return await _userRepository.IsEmailSharedAsync(user.Email, user.UserId);
     }
 
     /// <summary>

--- a/XiansAi.Server.Src/Shared/Services/UserTenantService.cs
+++ b/XiansAi.Server.Src/Shared/Services/UserTenantService.cs
@@ -76,12 +76,6 @@ public sealed class SignInIdentity
 
     public string? Email { get; init; }
 
-    /// <summary>
-    /// Whether the provider stated the holder owns <see cref="Email"/>. An unverified address is
-    /// still stored for display and contact, but only a verified one may decide identity.
-    /// </summary>
-    public bool EmailVerified { get; init; }
-
     public string? Name { get; init; }
 
     /// <summary>
@@ -229,7 +223,6 @@ public class UserTenantService : IUserTenantService
                     {
                         UserId = userId,
                         Email = identity.Email ?? string.Empty,
-                        EmailVerified = identity.EmailVerified,
                         Name = identity.Name ?? string.Empty,
                         ProviderAuthority = providerAuthority
                     },
@@ -352,18 +345,15 @@ public class UserTenantService : IUserTenantService
     /// Fills in an address or a name the record is missing, from what the token says.
     ///
     /// Records provisioned before the address was stored have neither, and nothing else ever
-    /// revisits them — the create path only runs on a first sign-in. Only blanks are filled: a value
-    /// already on the record may have been set by an admin, and a verified address is never replaced
-    /// by an unverified one, which would turn a proven address into an asserted one.
+    /// revisits them — the create path only runs on a first sign-in. Only blanks are filled, because
+    /// a value already on the record may have been set by an admin.
     /// </summary>
     private async Task BackfillMissingProfileAsync(User user, SignInIdentity identity)
     {
         var fillEmail = string.IsNullOrWhiteSpace(user.Email) && !string.IsNullOrWhiteSpace(identity.Email);
         var fillName = string.IsNullOrWhiteSpace(user.Name) && !string.IsNullOrWhiteSpace(identity.Name);
-        var confirmEmail = !fillEmail && !user.EmailVerified && identity.EmailVerified
-            && string.Equals(user.Email, identity.Email, StringComparison.OrdinalIgnoreCase);
 
-        if (!fillEmail && !fillName && !confirmEmail)
+        if (!fillEmail && !fillName)
         {
             return;
         }
@@ -375,7 +365,6 @@ public class UserTenantService : IUserTenantService
             await _userRepository.UpdateProfileFieldsAsync(
                 user.UserId,
                 email: fillEmail ? identity.Email : null,
-                emailVerified: fillEmail || confirmEmail ? identity.EmailVerified : null,
                 name: fillName ? identity.Name : null);
 
             _logger.LogInformation(
@@ -618,9 +607,31 @@ public class UserTenantService : IUserTenantService
             if (!validationResult.IsSuccess)
                 return ServiceResult<bool>.Forbidden(validationResult.ErrorMessage!, validationResult.StatusCode);
 
-            var user = await _userRepository.GetByUserEmailAsync(email);
+            // This grants an approved membership, which names one person. An address can answer to
+            // more than one account, so it is refused rather than resolved to whichever record came
+            // back first — that would put a different account in the tenant than the admin meant.
+            var lookup = EmailAccountLookup.From(await _userRepository.GetAllByUserEmailAsync(email));
+            if (lookup.IsAmbiguous)
+            {
+                _logger.LogWarning(
+                    "Refusing to add {Email} to tenant {TenantId}: it matches {Count} accounts",
+                    LogSanitizer.RedactEmail(email), LogSanitizer.Sanitize(_tenantContext.TenantId),
+                    lookup.MatchCount);
+                return ServiceResult<bool>.Conflict(EmailAccountLookup.AmbiguousError);
+            }
+
+            var user = lookup.Account;
             if (user == null)
                 return ServiceResult<bool>.NotFound("User not found");
+
+            if (user.IsLockedOut)
+            {
+                _logger.LogWarning(
+                    "Refusing to add disabled account {UserId} to tenant {TenantId}",
+                    LogSanitizer.RedactUserId(user.UserId), LogSanitizer.Sanitize(_tenantContext.TenantId));
+                return ServiceResult<bool>.Conflict(
+                    "This account is disabled, so it cannot be given a tenant membership. Enable it first.");
+            }
 
             var tenantEntry = user.TenantRoles.FirstOrDefault(tr => tr.Tenant == _tenantContext.TenantId);
 
@@ -645,8 +656,9 @@ public class UserTenantService : IUserTenantService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error adding user with email user {email} to tenant {TenantId}", LogSanitizer.Sanitize(_tenantContext.TenantId), LogSanitizer.RedactEmail(email));
-            return ServiceResult<bool>.InternalServerError("Error adding tenant to user with email {email}, email");
+            _logger.LogError(ex, "Error adding user with email {Email} to tenant {TenantId}",
+                LogSanitizer.RedactEmail(email), LogSanitizer.Sanitize(_tenantContext.TenantId));
+            return ServiceResult<bool>.InternalServerError("Error adding tenant to user with this email");
         }
     }
 

--- a/XiansAi.Server.Src/docs/AUTH_CONFIGURATION.md
+++ b/XiansAi.Server.Src/docs/AUTH_CONFIGURATION.md
@@ -285,13 +285,25 @@ the deployment-wide provider, so holding one says nothing about any particular t
 
 ### Email collisions at sign-in
 
-A user record is keyed on the provider subject (`sub` / `oid`, or the configured `userIdClaim`).
-Sign-in refuses to provision a second account when the token's email already belongs to a different
-subject — merging on email alone would hand over that account's access. Leave `userIdClaim` unset
-(or set it to a stable claim) so the same person keeps the same account across sessions.
+A user record is keyed on the provider subject (`sub` / `oid`, or the configured `userIdClaim`), and
+a subject is only unique within one issuer. One person signing in through two directories therefore
+has two records carrying the same address, which is expected rather than an error.
+
+Sign-in refuses to provision a second account when the address is already held **at the same
+provider**, or when either record's provider cannot be identified — there the address really does
+name one account, and merging on it alone would hand over that account's access. A second account at
+a genuinely different provider is allowed, except when the address belongs to a system
+administrator, where the record is created disabled for an operator to review.
+
+Leave `userIdClaim` unset (or set it to a stable claim) so the same person keeps the same account
+across sessions.
 
 Conversation threads may still be keyed by email: the User API accepts the account's stored email as
-`participantId` even when the account id is the provider subject.
+`participantId` even when the account id is the provider subject — unless the address is held by
+more than one account, in which case it falls back to the subject.
+
+See [`EMAIL_IDENTITY_RESOLUTION.md`](EMAIL_IDENTITY_RESOLUTION.md) for how identity and authority are
+resolved when an address names several accounts, including the rules for system administrators.
 
 ### Certificate Validation Caching (Agent API)
 

--- a/XiansAi.Server.Src/docs/AUTH_CONFIGURATION.md
+++ b/XiansAi.Server.Src/docs/AUTH_CONFIGURATION.md
@@ -239,6 +239,12 @@ Auth__OidcWarningIntervalMinutes=15
 
   This blocks addresses written directly into a configuration. It cannot stop a hostname that
   resolves to an internal address, which needs egress control at the network layer.
+- A provider must declare `expectedAudience`. Without one it accepts any token its issuer signed,
+  including one minted for an unrelated application at that same identity provider, and a UserApi
+  sign-in turns a valid token into approved tenant membership. This is refused at save time even for
+  a provider that predates the rule and even on a save that does not touch it, so a tenant
+  configured that way cannot save any OIDC change until it declares one. Sign-in is unaffected until
+  `Auth__RequireOidcAudience` is enabled; membership is (see below).
 - A mutable `userIdClaim` / `userIdClaims` entry (`email`, `emails`, `preferred_username`, `upn`,
   `name`, `nameid`, `unique_name`, and the matching claim-type URIs) is refused when newly
   introduced or changed. The portal resolves identity from the deployment auth provider's stable
@@ -258,8 +264,24 @@ watch the logs for the warning it emits, fix each tenant it names, then set the 
 
 | Switch | Warning it emits | Fix before enabling |
 | --- | --- | --- |
-| `Auth__RequireOidcAudience` | Provider declares no `expectedAudience` | Set `expectedAudience` on the provider. Until then, any token that issuer signed is accepted — including one minted for an unrelated application at the same identity provider. |
+| `Auth__RequireOidcAudience` | Provider declares no `expectedAudience` | Set `expectedAudience` on the provider. Until then, any token that issuer signed is accepted — including one minted for an unrelated application at the same identity provider. New configurations cannot be saved without one, so this warning only names tenants configured before that rule. |
 | `Auth__StrictSubjectClaim` | Identity fell back to a claim users can change | Leave `userIdClaim` unset (defaults to `sub`/`oid`), or set it to a stable claim. Note that this changes the user id of anyone currently signing in through a fallback claim, orphaning their existing record — naming the claim they already resolve to keeps them on it. Do not set it to a mutable claim; that is refused at save time for new configurations. |
+
+### Tenant membership on User API sign-in
+
+A first-time User API sign-in records the caller as a member of the tenant they asked for. That
+membership is created **approved** — no admin step — when the token was checked against the
+provider's `expectedAudience`, because an audience proves the token was minted for this tenant's own
+application, which is what makes holding one the tenant's own statement that the person belongs to
+it.
+
+When the provider declares no `expectedAudience`, the token was accepted on its issuer's signature
+alone and could have been minted for an unrelated application at that issuer. The membership is then
+created **pending** instead, waiting for an admin, and a throttled warning names the tenant. Setting
+`expectedAudience` is what restores automatic approval.
+
+The WebAPI console always creates a pending membership regardless: its tokens are validated against
+the deployment-wide provider, so holding one says nothing about any particular tenant.
 
 ### Email collisions at sign-in
 

--- a/XiansAi.Server.Src/docs/AUTH_CONFIGURATION.md
+++ b/XiansAi.Server.Src/docs/AUTH_CONFIGURATION.md
@@ -310,8 +310,11 @@ resolved when an address names several accounts, including the rules for system 
 The Agent API uses certificate-based authentication and caches validation results for performance:
 
 ```bash
-# Certificate validation cache duration in minutes (default: 10)
-AgentApi__CertificateValidationCacheDurationMinutes=10
+# Idle window: an agent that keeps calling within this window never revalidates (default: 2)
+AgentApi__CertificateValidationCacheDurationMinutes=2
+
+# Hard ceiling regardless of activity (default: 5)
+AgentApi__CertificateValidationCacheMaxDurationMinutes=5
 
 # Size per cache entry for eviction policy (default: 1)
 AgentApi__CertificateValidationCacheEntrySize=1
@@ -320,7 +323,12 @@ AgentApi__CertificateValidationCacheEntrySize=1
 **Security Notes:**
 
 - Only successful certificate validations are cached
-- Cache is automatically invalidated when a certificate is revoked
+- Revoking a certificate and disabling the account both evict the entry directly
+- The ceiling bounds how long a disabled agent survives on the server instances that did not
+  handle the request that disabled it, since the cache is in-process. It matches the token and
+  role caches so that every cached authorization decision has the same worst case
+- Set the ceiling below the idle window and it is ignored, with a warning: the idle window becomes
+  the ceiling, because an entry cannot outlive the point at which it is discarded anyway
 - Uses the same global cache size limit as token validation
 - Failed validations always trigger fresh validation
 

--- a/XiansAi.Server.Src/docs/EMAIL_IDENTITY_RESOLUTION.md
+++ b/XiansAi.Server.Src/docs/EMAIL_IDENTITY_RESOLUTION.md
@@ -15,7 +15,6 @@ a customer-facing one — legitimately has two records carrying the same address
 | `UserId` | The provider's subject (`sub` / `oid`, or the configured `userIdClaim`). The collection is keyed on this. Unique only within one issuer. |
 | `ProviderAuthority` | The normalized OIDC authority whose signing keys authenticated this subject. Pins the record to one provider so a second provider cannot claim the same subject. Null on records created before pinning existed; those are pinned on first use. |
 | `Email` | Stored lowercase. Used for display, for contact, and — on the credentials listed below — for identifying the caller. Not unique. |
-| `EmailVerified` | Whether the provider stated the holder owns the address, rather than merely asserting it. False on older records, so read it as "not known to be verified". |
 
 `UserId` is the identity. `Email` is a label that usually happens to be unique and sometimes is not.
 Everything in this document follows from that distinction.
@@ -178,14 +177,26 @@ not visible under the subject.
 
 ## Endpoints that refuse instead of folding
 
-Two Admin API surfaces describe or modify exactly one account, so folding would give a wrong answer
-rather than a combined one. Both count every record holding the address and refuse when there is
-more than one:
+The fold answers "what may this credential do", where combining the accounts is the right answer.
+An operator naming a person by address is asking something else — *which* account — and there
+folding would act on an account they did not mean. These surfaces count every record holding the
+address and refuse when there is more than one.
+
+Describing or transferring to one account:
 
 - **Ownership transfer** (`AdminOwnershipEndpoints`) — `409` with "matches more than one account.
   Use the user id of the intended account."
 - **Participant lookup** (`AdminParticipantsEndpoints`) — `409` with "This email matches more than
   one account, so participant details cannot be resolved from it."
+
+Granting a membership, which is the same question with a write attached. Both resolve through
+`EmailAccountLookup.From` and refuse with its shared wording, and both also refuse a disabled
+account rather than leaving a grant on a record that cannot sign in:
+
+- **Add user to current tenant** (`UserTenantService.AddTenantToUserIfExist`) — grants an approved
+  `TenantUser`, which is console access.
+- **Create tenant participant** (`TenantParticipantUserService.CreateAsync`) — grants any tenant
+  role, up to `TenantAdmin`, when the address already has an account.
 
 ## Worked examples
 
@@ -223,6 +234,35 @@ Addresses are redacted in logs, so match on the message text:
 | `Not using the email of {UserId} as their conversation identity` | This account's threads are namespaced by its subject, not its address. |
 | `subject is pinned to provider {Pinned} but was asserted by {Presented}` | A provider presented another provider's subject. Always investigate. |
 
+## Disabling an account takes effect immediately
+
+Every API caches the authorization decision it made, and none of those caches re-check whether the
+account is still enabled: the User API keeps the approved tenant list, the Agent API keeps the
+certificate's user and roles, the Admin API keeps the resolved roles, and validated tokens are kept
+for all of them. Each cache is therefore a window during which a disabled account keeps working.
+
+`IUserCacheIndex` records which entries were written for which account, because the keys are built
+from what the request presented — a token hash, a certificate thumbprint, a provider authority and
+subject — and none of those can be reconstructed from a user id. `IUserAuthorizationInvalidator`
+evicts them, and is called wherever an account is disabled, enabled, or has its roles changed.
+
+It also evicts the accounts that share the address, because a credential naming only an address
+resolves through all of them: disabling one drops it from the combined roles and withdraws the
+administrator role from the rest, so what the others resolve to has changed too.
+
+Two limits are worth knowing:
+
+- **It is per process.** The caches are in-process, so eviction on the instance that served the
+  admin request does not reach the others. Their entries expire on their own, which the absolute
+  expirations bound: 30 seconds for User API approved tenants
+  (`Auth:ApprovedTenantCacheDurationSeconds`), and 5 minutes for tokens
+  (`Auth:TokenValidationCacheDurationMinutes`), roles, and certificates
+  (`AgentApi:CertificateValidationCacheMaxDurationMinutes`). Five minutes is therefore the worst
+  case for a disabled account anywhere in the deployment.
+- **It must be a singleton.** The caches are registered scoped. An index owned by one of them would
+  be discarded with the request that wrote the entry, leaving the later request with nothing to
+  evict — which is exactly how the token cache's own reverse index behaved before this existed.
+
 ## Known edges
 
 - **`UserRepository.GetUserRolesAsync` does not fold.** Given an email it resolves by `UserId`
@@ -232,15 +272,21 @@ Addresses are redacted in logs, so match on the message text:
   semantics survive.
 - **`RoleCacheService` never caches address-shaped keys.** Entries are keyed on the value passed in,
   while every invalidation passes a canonical user id, so an entry keyed on an address would never
-  be invalidated and would serve stale roles for the full five minutes.
-- **Ownership transfer and participant lookup count disabled records too.** They count every record
-  holding the address, unlike the fold, which drops disabled ones first. So an administrator's
-  address that has a disabled duplicate awaiting review will get a `409` from those two endpoints
-  even though every other path resolves it without difficulty. Use the user id there.
-- **An unverified address is still stored.** `EmailVerified` records whether the provider vouched
-  for it. Only a verified address should be allowed to decide *who someone is*; an unverified one is
-  for display and contact, because otherwise anyone able to assert an arbitrary address at their own
-  IdP could claim a victim's.
+  be invalidated and would serve stale roles for the full five minutes. Entries keyed on a user id
+  are tracked and evicted as described above.
+- **The endpoints that refuse count disabled records too.** They count every record holding the
+  address, unlike the fold, which drops disabled ones first. So an administrator's address that has
+  a disabled duplicate awaiting review will get a `409` from all four of them even though every
+  other path resolves it without difficulty. Use the user id there.
+- **No record is kept of whether a provider vouched for an address.** An address a provider merely
+  asserted admits a second record on exactly the same terms as one it verified, so someone able to
+  set an arbitrary address at their own IdP can put a victim's address on a record they control.
+  Nothing downstream trusts an address by itself, which is what contains this: the provider pin
+  keys identity on the subject, the fold refuses to combine administrator rights across records
+  that were not accepted as the same person, and the endpoints above refuse an ambiguous address
+  rather than picking. Enforcing verification at provisioning would be the stronger answer, but it
+  is not available on Azure AD B2C, which issues no verification claim at all — every B2C sign-in
+  would be treated as unverified and refused.
 
 ## Related
 

--- a/XiansAi.Server.Src/docs/EMAIL_IDENTITY_RESOLUTION.md
+++ b/XiansAi.Server.Src/docs/EMAIL_IDENTITY_RESOLUTION.md
@@ -179,24 +179,28 @@ not visible under the subject.
 
 The fold answers "what may this credential do", where combining the accounts is the right answer.
 An operator naming a person by address is asking something else — *which* account — and there
-folding would act on an account they did not mean. These surfaces count every record holding the
-address and refuse when there is more than one.
+folding would act on an account they did not mean.
 
-Describing or transferring to one account:
+These surfaces count every record holding the address and refuse when more than one does. An
+address exactly one account holds names it as surely as a user id would, so that case proceeds:
+refusing it would not make anything safer, since an operator sent to find the user id would search
+by the same address and arrive at the same record.
 
-- **Ownership transfer** (`AdminOwnershipEndpoints`) — `409` with "matches more than one account.
-  Use the user id of the intended account."
 - **Participant lookup** (`AdminParticipantsEndpoints`) — `409` with "This email matches more than
-  one account, so participant details cannot be resolved from it."
-
-Granting a membership, which is the same question with a write attached. Both resolve through
-`EmailAccountLookup.From` and refuse with its shared wording, and both also refuse a disabled
-account rather than leaving a grant on a record that cannot sign in:
-
-- **Add user to current tenant** (`UserTenantService.AddTenantToUserIfExist`) — grants an approved
-  `TenantUser`, which is console access.
+  one account, so participant details cannot be resolved from it." Read-only.
 - **Create tenant participant** (`TenantParticipantUserService.CreateAsync`) — grants any tenant
-  role, up to `TenantAdmin`, when the address already has an account.
+  role, up to `TenantAdmin`. `userId` names an account outright and is the way past an ambiguous
+  address; otherwise `email` names the single account holding it, or creates one when none does.
+  Refuses a disabled account, rather than leaving a grant on a record that cannot sign in.
+- **Add user to current tenant** (`UserTenantService.AddTenantToUserIfExist`) — grants an approved
+  `TenantUser`, which is console access. Resolves through `EmailAccountLookup.From` and refuses a
+  disabled account. WebAPI only.
+
+One surface takes no address at all, because it names a single account and its caller always has
+the user id to hand:
+
+- **Ownership transfer** (`AdminOwnershipEndpoints`) — `400`, "newAdminId must be a user id, not an
+  email address."
 
 ## Worked examples
 

--- a/XiansAi.Server.Src/docs/EMAIL_IDENTITY_RESOLUTION.md
+++ b/XiansAi.Server.Src/docs/EMAIL_IDENTITY_RESOLUTION.md
@@ -64,7 +64,8 @@ Address-based resolution only happens where the credential carries nothing else.
 | Admin API key, legacy `CreatedBy` | An email | Folded (below). Roles come back with the identity and are **not** read from the cache. Participant roles are dropped. |
 | Agent API certificate, OU is a user id | The `UserId` | `CertificateUserAccess.Resolve`, which applies the same rules as the fold to that one record. |
 | Agent API certificate, OU is an email | An email | Folded. |
-| WebAPI console / User API sign-in | The provider subject | Direct lookup. Never folded — a token names its subject exactly. |
+| User API sign-in | The provider subject | Direct lookup. Never folded — a token names its subject exactly. |
+| WebAPI console sign-in | Whatever `ClaimMappings.UserIdClaim` names, `sub` by default | Direct lookup. Folded only where that claim is configured to an address, since then the token names one no more exactly than a legacy API key does. |
 | Admin ownership transfer, participant lookup | Either | **Refused** on an ambiguous address rather than folded. See [Endpoints that refuse](#endpoints-that-refuse-instead-of-folding). |
 
 ## The fold
@@ -272,11 +273,6 @@ Two limits are worth knowing:
 
 ## Known edges
 
-- **`UserRepository.GetUserRolesAsync` does not fold.** Given an email it resolves by `UserId`
-  first, then falls back to the first record that happens to hold the address. Every caller that can
-  receive an address folds before reaching it — the Admin API resolver does so explicitly — so this
-  is a fallback rather than a live path, but it is the one remaining place where "first record wins"
-  semantics survive.
 - **`RoleCacheService` never caches address-shaped keys.** Entries are keyed on the value passed in,
   while every invalidation passes a canonical user id, so an entry keyed on an address would never
   be invalidated and would serve stale roles for the full five minutes. Entries keyed on a user id

--- a/XiansAi.Server.Src/docs/EMAIL_IDENTITY_RESOLUTION.md
+++ b/XiansAi.Server.Src/docs/EMAIL_IDENTITY_RESOLUTION.md
@@ -165,6 +165,13 @@ than one record it is withheld, logging `Not using the email of {UserId} as thei
 identity`, and the account falls back to being named by its provider subject — which always names
 exactly one account.
 
+The address is withheld only from *naming threads*. It is still carried as the account's email, so a
+caller is recognised when they name themselves by it: `ParticipantIdResolver` treats any id the
+caller answers to — participant id, canonical login id, account email, or provider subject — as a
+request for their own threads, and resolves it to the id they were actually issued. Clients that
+send an email address as `participantId` therefore keep working when it turns out to be shared,
+instead of being refused with a 403.
+
 The practical consequence is that a person whose address is shared gets a *different*
 `participantId` than they would with a unique address. Their existing threads under the address are
 not visible under the subject.

--- a/XiansAi.Server.Src/docs/EMAIL_IDENTITY_RESOLUTION.md
+++ b/XiansAi.Server.Src/docs/EMAIL_IDENTITY_RESOLUTION.md
@@ -1,0 +1,241 @@
+# Email Identity Resolution Across Providers
+
+How the server decides *who* a caller is, and *what authority they carry*, when the same email
+address belongs to more than one user record.
+
+This situation is normal rather than exceptional: a user record is keyed on the identity provider's
+subject, and a subject is only unique within one issuer. One person signing in through two
+directories — two Azure B2C tenants, an Entra directory and a Google workspace, a corporate IdP and
+a customer-facing one — legitimately has two records carrying the same address.
+
+## What identifies an account
+
+| Field | Meaning |
+| --- | --- |
+| `UserId` | The provider's subject (`sub` / `oid`, or the configured `userIdClaim`). The collection is keyed on this. Unique only within one issuer. |
+| `ProviderAuthority` | The normalized OIDC authority whose signing keys authenticated this subject. Pins the record to one provider so a second provider cannot claim the same subject. Null on records created before pinning existed; those are pinned on first use. |
+| `Email` | Stored lowercase. Used for display, for contact, and — on the credentials listed below — for identifying the caller. Not unique. |
+| `EmailVerified` | Whether the provider stated the holder owns the address, rather than merely asserting it. False on older records, so read it as "not known to be verified". |
+
+`UserId` is the identity. `Email` is a label that usually happens to be unique and sometimes is not.
+Everything in this document follows from that distinction.
+
+### The provider pin
+
+On every sign-in, `UserTenantService.IsSameProviderAsync` compares the record's `ProviderAuthority`
+against the authority that actually served the discovery document for this token:
+
+- **Pinned and matching** — the sign-in proceeds.
+- **Pinned and different** — refused with "This subject is registered to a different identity
+  provider". Without this, a second provider asserting the same subject string would resolve to this
+  person's record.
+- **Not pinned** — the record adopts the presented authority via `PinProviderAuthorityIfUnsetAsync`,
+  which is a conditional write. If a concurrent sign-in pinned it to something else first, the loser
+  is refused.
+
+The authority is used rather than the token's `iss` claim deliberately: the expected issuer comes
+from tenant-supplied configuration and can name any string, whereas the authority must actually
+serve the discovery document, so it cannot be pointed at a provider the configurer does not control.
+
+## When a second record with the same address is created
+
+All of this happens in `UserManagementService.CreateNewUser`, which every provisioning path funnels
+through. `AdmitEmailAsync` decides the outcome.
+
+| Situation | Outcome |
+| --- | --- |
+| Nobody holds the address | Created normally. |
+| Held at the **same** provider | **Refused** — `A user with this email already exists`. Within one directory the address really does name one account, so a second record is a duplicate. |
+| Either side has **no** `ProviderAuthority` | **Refused**. Records that cannot be told apart have to be assumed to be the same account, or an unpinned record would be a way around the rule. |
+| Held at a **different** provider by an ordinary account | Created normally. This is the case the design exists for. |
+| Held at a **different** provider by a **system administrator** | Created **disabled**, with `IsSysAdmin` false and a `LockedOutReason` explaining what to do. See [System administrators](#system-administrators-across-providers). |
+| The new record has **no** address | Created, with a warning. Blank addresses are not compared — comparing them would make every address-less record collide with the first. |
+
+The same-provider check runs first, so a duplicate inside one directory is refused for being a
+duplicate rather than queued for a review that should never happen.
+
+## Which credentials resolve by address
+
+Most of the system never touches any of this, because most credentials name the account directly.
+Address-based resolution only happens where the credential carries nothing else.
+
+| Path | What the credential names | How it resolves |
+| --- | --- | --- |
+| Admin API key, modern | The canonical `UserId` | Direct lookup, roles served from `RoleCacheService`. |
+| Admin API key, legacy `CreatedBy` | An email | Folded (below). Roles come back with the identity and are **not** read from the cache. Participant roles are dropped. |
+| Agent API certificate, OU is a user id | The `UserId` | `CertificateUserAccess.Resolve`, which applies the same rules as the fold to that one record. |
+| Agent API certificate, OU is an email | An email | Folded. |
+| WebAPI console / User API sign-in | The provider subject | Direct lookup. Never folded — a token names its subject exactly. |
+| Admin ownership transfer, participant lookup | Either | **Refused** on an ambiguous address rather than folded. See [Endpoints that refuse](#endpoints-that-refuse-instead-of-folding). |
+
+## The fold
+
+`EmailIdentityResolution.From` turns every record holding an address into the single identity the
+credential acts as. Given the address and the tenant the request is for:
+
+1. **Drop every disabled record.** A locked-out account contributes nothing — not its roles, not its
+   SysAdmin flag, not its candidacy for being the primary account.
+2. **If nothing is left, the result is null** and the caller denies the request.
+3. **Order the survivors** by `CreatedAt`, then by `UserId` ordinally. This ordering is the reason a
+   credential resolves to the same account on every request instead of to whatever a collection scan
+   returned first.
+4. **`PrimaryUserId` is the first of them.** This is the account the request acts as, and what its
+   data is scoped and attributed to.
+5. **Union the roles** of every survivor's *approved* membership of the requested tenant. A
+   membership still awaiting approval contributes nothing, so reaching a tenant this way still
+   requires one of its admins to have granted the membership.
+6. **Decide SysAdmin** — true only when *every* survivor holds it. See below.
+7. **`IsAmbiguous`** is true when more than one record contributed, and the fold logs
+   `Email {Email} resolves to {Count} accounts`.
+
+The union in step 5 is what makes a shared address usable at all: the person gets the combined
+tenant access of their accounts, which is what someone holding a credential that names only their
+address would expect.
+
+## System administrators across providers
+
+SysAdmin is global — it grants access to every tenant — so it is never assembled out of records that
+disagree about it.
+
+> An address carries SysAdmin only when **every enabled record holding that address** has the role.
+
+One record short and the answer is no, and the fold logs
+`Refusing SysAdmin for {Email}: it is held by a system administrator and by {Others}`.
+
+This is not merely a read-time rule. It works because a second record for an administrator's address
+is created inert:
+
+### Accepting two accounts as the same administrator
+
+1. The person signs in from the second directory. A record is created **disabled**, with
+   `IsSysAdmin` false and a `LockedOutReason` naming the administrator it collides with. While it is
+   disabled it is dropped in step 1 of the fold, so the existing administrator is entirely
+   unaffected.
+2. An operator reviews it. If the two really are the same person, they **enable** the account and
+   **grant it SysAdmin** through `PUT /api/v1/admin/users/{userId}/sysadmin`.
+3. Both records now hold the role, so the address resolves as SysAdmin again — now from either
+   account.
+
+Order does not matter: granting the role while the account is still disabled is harmless, because a
+disabled record is dropped before anything else is decided.
+
+### Why only that one endpoint
+
+Every other route to the flag refuses while the address is shared, because none of them represents a
+person deciding that these two accounts are the same someone:
+
+- `RoleManagementService` (WebAPI role management) returns a conflict pointing at the global user
+  endpoint.
+- Azure AD group-claim sync refuses to *grant*, logging `Not granting SysAdmin to {UserId} from
+  group claims`. Being in the admin group of a second directory is that directory's decision, not
+  this platform's. **Demotion is never blocked** — taking the role away is always the safe
+  direction.
+
+### The gap between enabling and granting
+
+If the account is enabled but not yet granted the role, there are two enabled records and they do
+not agree, so the address stops carrying SysAdmin. The blast radius is only credentials that name an
+address — legacy API keys with an email `CreatedBy`, certificates with an email OU. Anything keyed
+by user id reads `IsSysAdmin` off the record and is unaffected, and completing the grant restores
+it.
+
+Two things make this visible rather than silent: the `LockedOutReason` written at creation says so
+in as many words and is surfaced as `disabledReason` on the admin user detail, and enabling such an
+account logs `Enabled {UserId}, which holds the same email as system administrator(s) {Others}`.
+
+## What a disabled account can do
+
+Nothing. `IsLockedOut` is enforced at every door:
+
+- **Sign-in** — `UserTenantService.GetApprovedTenantsForUserId` is the funnel every sign-in path
+  reaches its tenants through, and refuses with "This account is disabled". This holds for a
+  disabled SysAdmin too, who would otherwise be handed every tenant.
+- **Roles by user id** — `UserRepository.GetUserRolesAsync` returns an empty list.
+- **The fold** — the record is dropped before anything is computed.
+- **Certificates** — `CertificateUserAccess` refuses with "User account is locked out".
+
+## Conversation identity
+
+The User API uses an account's stored email as the `participantId`, which is the namespace its
+message threads live in. Two accounts answering to one address would therefore share one namespace,
+and either could read the other's conversations.
+
+`UserTenantService.ConversationIdentityEmailAsync` prevents this: when the address is held by more
+than one record it is withheld, logging `Not using the email of {UserId} as their conversation
+identity`, and the account falls back to being named by its provider subject — which always names
+exactly one account.
+
+The practical consequence is that a person whose address is shared gets a *different*
+`participantId` than they would with a unique address. Their existing threads under the address are
+not visible under the subject.
+
+## Endpoints that refuse instead of folding
+
+Two Admin API surfaces describe or modify exactly one account, so folding would give a wrong answer
+rather than a combined one. Both count every record holding the address and refuse when there is
+more than one:
+
+- **Ownership transfer** (`AdminOwnershipEndpoints`) — `409` with "matches more than one account.
+  Use the user id of the intended account."
+- **Participant lookup** (`AdminParticipantsEndpoints`) — `409` with "This email matches more than
+  one account, so participant details cannot be resolved from it."
+
+## Worked examples
+
+**An ordinary person in two directories.** `dana@example.com` has a record in directory A (created
+January, `TenantUser` on `acme`) and directory B (created March, `TenantAdmin` on `acme`). A legacy
+API key stores `dana@example.com` as `CreatedBy`. The fold keeps both, orders A first, and the
+request acts as A's user id with roles `TenantUser, TenantAdmin` on `acme`. Dana's API key works
+with the combined access of both accounts, and consistently attributes its writes to A.
+
+**Someone registering an administrator's address.** `admin@corp.com` is a SysAdmin in directory A.
+An unrelated person registers the same address in directory B and signs in. A record is created
+disabled. The administrator's certificate and legacy API keys keep working with SysAdmin throughout,
+because the disabled record is dropped before the flag is decided. The person cannot sign in at all
+until an operator reviews the record, and the operator sees exactly whose address it collides with.
+
+**The same administrator, genuinely.** Same as above, except the operator recognises the person,
+enables the record and grants it SysAdmin. Between those two actions the address stops carrying
+SysAdmin on address-named credentials; afterwards it carries it from either account.
+
+**A duplicate inside one directory.** Two subjects in directory A both claiming `sam@example.com`.
+The second is refused outright at creation. Nothing is folded, because nothing was created.
+
+## Diagnosing from the logs
+
+Addresses are redacted in logs, so match on the message text:
+
+| Log line | What it means |
+| --- | --- |
+| `resolves to {Count} accounts` | An address-named credential was folded. Informational, not a fault. |
+| `Refusing SysAdmin for {Email}` | Enabled records disagree about the role. Either finish the grant or disable the extra account. |
+| `Creating {UserId} from {Authority} disabled` | A record was created for review; an operator needs to decide. |
+| `Refusing to create {UserId} from {Authority}` | Same-provider or unidentifiable-provider duplicate. The person cannot sign in until the conflict is resolved. |
+| `Refusing sign-in for {UserId}: the account is disabled` | A disabled account tried to sign in. |
+| `Enabled {UserId}, which holds the same email as system administrator(s)` | An administrator has just lost the role on address-named credentials. |
+| `Not using the email of {UserId} as their conversation identity` | This account's threads are namespaced by its subject, not its address. |
+| `subject is pinned to provider {Pinned} but was asserted by {Presented}` | A provider presented another provider's subject. Always investigate. |
+
+## Known edges
+
+- **`UserRepository.GetUserRolesAsync` does not fold.** Given an email it resolves by `UserId`
+  first, then falls back to the first record that happens to hold the address. Every caller that can
+  receive an address folds before reaching it — the Admin API resolver does so explicitly — so this
+  is a fallback rather than a live path, but it is the one remaining place where "first record wins"
+  semantics survive.
+- **`RoleCacheService` never caches address-shaped keys.** Entries are keyed on the value passed in,
+  while every invalidation passes a canonical user id, so an entry keyed on an address would never
+  be invalidated and would serve stale roles for the full five minutes.
+- **Ownership transfer and participant lookup count disabled records too.** They count every record
+  holding the address, unlike the fold, which drops disabled ones first. So an administrator's
+  address that has a disabled duplicate awaiting review will get a `409` from those two endpoints
+  even though every other path resolves it without difficulty. Use the user id there.
+- **An unverified address is still stored.** `EmailVerified` records whether the provider vouched
+  for it. Only a verified address should be allowed to decide *who someone is*; an unverified one is
+  for display and contact, because otherwise anyone able to assert an arbitrary address at their own
+  IdP could claim a victim's.
+
+## Related
+
+- [`AUTH_CONFIGURATION.md`](AUTH_CONFIGURATION.md) — provider configuration, the `userIdClaim`
+  rules, and how User API tenant membership is approved.

--- a/XiansAi.Server.Src/docs/EMAIL_IDENTITY_RESOLUTION.md
+++ b/XiansAi.Server.Src/docs/EMAIL_IDENTITY_RESOLUTION.md
@@ -196,11 +196,14 @@ by the same address and arrive at the same record.
   `TenantUser`, which is console access. Resolves through `EmailAccountLookup.From` and refuses a
   disabled account. WebAPI only.
 
-One surface takes no address at all, because it names a single account and its caller always has
-the user id to hand:
+One surface takes no address at all. It never creates an account, so its target always exists and
+the caller has necessarily obtained it from something that returned a user id; accepting an address
+would only add a resolution step that can be redundant or wrong, never necessary:
 
 - **Ownership transfer** (`AdminOwnershipEndpoints`) — `400`, "newAdminId must be a user id, not an
-  email address."
+  email address." The account is also refused when disabled, and when it holds no approved
+  membership of the tenant unless it is a system administrator — the lookup is not tenant-scoped,
+  so without that any account in the deployment could be made owner of a tenant's agent.
 
 ## Worked examples
 

--- a/XiansAi.Server.Tests/UnitTests/Features/AdminApi/Auth/AdminRoleTenantResolverTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Features/AdminApi/Auth/AdminRoleTenantResolverTests.cs
@@ -1,0 +1,101 @@
+using Features.AdminApi.Auth;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Shared.Auth;
+using Shared.Data.Models;
+using Shared.Repositories;
+using Shared.Services;
+
+namespace Tests.UnitTests.Features.AdminApi.Auth;
+
+public class AdminRoleTenantResolverTests
+{
+    private const string TenantId = "tenant-a";
+    private const string UserId = "11111111-1111-1111-1111-111111111111";
+    private const string Email = "admin@example.com";
+
+    private readonly Mock<IUserRepository> _userRepo = new();
+    private readonly Mock<IRoleCacheService> _roleCache = new();
+    private readonly Mock<ITenantCacheService> _tenantCache = new();
+
+    private AdminRoleTenantResolver BuildResolver() =>
+        new(_userRepo.Object, _roleCache.Object, _tenantCache.Object,
+            NullLogger<AdminRoleTenantResolver>.Instance);
+
+    private static ApiKey KeyOwnedBy(string createdBy) => new()
+    {
+        TenantId = TenantId,
+        Name = "test",
+        HashedKey = "hash",
+        CreatedAt = DateTime.UtcNow,
+        CreatedBy = createdBy
+    };
+
+    [Fact]
+    public async Task ResolveAsync_SkipsUserLookup_WhenOwnerIsAlreadyAUserId()
+    {
+        _roleCache
+            .Setup(x => x.GetUserRolesAsync(UserId, TenantId))
+            .ReturnsAsync(new List<string> { SystemRoles.TenantAdmin });
+
+        var result = await BuildResolver().ResolveAsync(UserId, KeyOwnedBy(UserId), string.Empty);
+
+        Assert.True(result.Success);
+        Assert.Equal(UserId, result.ResolvedUserId);
+        _userRepo.Verify(x => x.GetByUserEmailAsync(It.IsAny<string>()), Times.Never);
+        _userRepo.Verify(x => x.GetByUserIdOrEmailAsync(It.IsAny<string>()), Times.Never);
+        _userRepo.Verify(x => x.GetByUserIdAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_LooksUpRolesByCanonicalUserId_WhenOwnerIsAnEmail()
+    {
+        _userRepo
+            .Setup(x => x.GetByUserEmailAsync(Email))
+            .ReturnsAsync(new User { UserId = UserId, Email = Email });
+        _roleCache
+            .Setup(x => x.GetUserRolesAsync(UserId, TenantId))
+            .ReturnsAsync(new List<string> { SystemRoles.TenantAdmin });
+
+        var result = await BuildResolver().ResolveAsync(Email, KeyOwnedBy(Email), string.Empty);
+
+        Assert.True(result.Success);
+        Assert.Equal(UserId, result.ResolvedUserId);
+        Assert.Equal(TenantId, result.FinalTenantId);
+        _userRepo.Verify(x => x.GetByUserEmailAsync(Email), Times.Once);
+        _roleCache.Verify(x => x.GetUserRolesAsync(UserId, TenantId), Times.Once);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_FallsBackToEmail_WhenNoUserRecordMatches()
+    {
+        _userRepo
+            .Setup(x => x.GetByUserEmailAsync(Email))
+            .ReturnsAsync((User?)null);
+        _roleCache
+            .Setup(x => x.GetUserRolesAsync(Email, TenantId))
+            .ReturnsAsync(new List<string> { SystemRoles.TenantAdmin });
+
+        var result = await BuildResolver().ResolveAsync(Email, KeyOwnedBy(Email), string.Empty);
+
+        Assert.True(result.Success);
+        Assert.Equal(Email, result.ResolvedUserId);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_Fails_WhenUserHasNoAdminRole()
+    {
+        _userRepo
+            .Setup(x => x.GetByUserEmailAsync(Email))
+            .ReturnsAsync(new User { UserId = UserId, Email = Email });
+        _roleCache
+            .Setup(x => x.GetUserRolesAsync(UserId, TenantId))
+            .ReturnsAsync(new List<string> { SystemRoles.TenantUser });
+
+        var result = await BuildResolver().ResolveAsync(Email, KeyOwnedBy(Email), string.Empty);
+
+        Assert.False(result.Success);
+        Assert.Equal(UserId, result.ResolvedUserId);
+        Assert.Equal("User does not have required admin role", result.ErrorMessage);
+    }
+}

--- a/XiansAi.Server.Tests/UnitTests/Features/AdminApi/Auth/AdminRoleTenantResolverTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Features/AdminApi/Auth/AdminRoleTenantResolverTests.cs
@@ -31,6 +31,18 @@ public class AdminRoleTenantResolverTests
         CreatedBy = createdBy
     };
 
+    private void ResolvesTo(string primaryUserId, params string[] roles)
+    {
+        _userRepo
+            .Setup(x => x.ResolveEmailIdentityAsync(Email, TenantId))
+            .ReturnsAsync(new EmailIdentityResolution(
+                PrimaryUserId: primaryUserId,
+                CandidateUserIds: new[] { primaryUserId },
+                Roles: roles,
+                IsSysAdmin: roles.Contains(SystemRoles.SysAdmin),
+                IsAmbiguous: false));
+    }
+
     [Fact]
     public async Task ResolveAsync_SkipsUserLookup_WhenOwnerIsAlreadyAUserId()
     {
@@ -42,60 +54,69 @@ public class AdminRoleTenantResolverTests
 
         Assert.True(result.Success);
         Assert.Equal(UserId, result.ResolvedUserId);
-        _userRepo.Verify(x => x.GetByUserEmailAsync(It.IsAny<string>()), Times.Never);
-        _userRepo.Verify(x => x.GetByUserIdOrEmailAsync(It.IsAny<string>()), Times.Never);
+        _userRepo.Verify(x => x.ResolveEmailIdentityAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
         _userRepo.Verify(x => x.GetByUserIdAsync(It.IsAny<string>()), Times.Never);
     }
 
     [Fact]
     public async Task ResolveAsync_LooksUpRolesByCanonicalUserId_WhenOwnerIsAnEmail()
     {
-        _userRepo
-            .Setup(x => x.GetByUserEmailAsync(Email))
-            .ReturnsAsync(new User { UserId = UserId, Email = Email });
-        _roleCache
-            .Setup(x => x.GetUserRolesAsync(UserId, TenantId))
-            .ReturnsAsync(new List<string> { SystemRoles.TenantAdmin });
+        ResolvesTo(UserId, SystemRoles.TenantAdmin);
 
         var result = await BuildResolver().ResolveAsync(Email, KeyOwnedBy(Email), string.Empty);
 
         Assert.True(result.Success);
         Assert.Equal(UserId, result.ResolvedUserId);
         Assert.Equal(TenantId, result.FinalTenantId);
-        _userRepo.Verify(x => x.GetByUserEmailAsync(Email), Times.Once);
-        _roleCache.Verify(x => x.GetUserRolesAsync(UserId, TenantId), Times.Once);
+        _userRepo.Verify(x => x.ResolveEmailIdentityAsync(Email, TenantId), Times.Once);
     }
 
     [Fact]
-    public async Task ResolveAsync_FallsBackToEmail_WhenNoUserRecordMatches()
+    public async Task ResolveAsync_DoesNotConsultTheRoleCache_ForAnEmail()
+    {
+        // The cache is keyed on whatever it is handed but only ever invalidated by user id, so an
+        // email-keyed entry would serve roles that a revocation had already removed.
+        ResolvesTo(UserId, SystemRoles.TenantAdmin);
+
+        await BuildResolver().ResolveAsync(Email, KeyOwnedBy(Email), string.Empty);
+
+        _roleCache.Verify(x => x.GetUserRolesAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_Fails_WhenNoUserRecordHoldsTheEmail()
     {
         _userRepo
-            .Setup(x => x.GetByUserEmailAsync(Email))
-            .ReturnsAsync((User?)null);
-        _roleCache
-            .Setup(x => x.GetUserRolesAsync(Email, TenantId))
-            .ReturnsAsync(new List<string> { SystemRoles.TenantAdmin });
+            .Setup(x => x.ResolveEmailIdentityAsync(Email, TenantId))
+            .ReturnsAsync((EmailIdentityResolution?)null);
 
         var result = await BuildResolver().ResolveAsync(Email, KeyOwnedBy(Email), string.Empty);
 
-        Assert.True(result.Success);
+        Assert.False(result.Success);
         Assert.Equal(Email, result.ResolvedUserId);
     }
 
     [Fact]
     public async Task ResolveAsync_Fails_WhenUserHasNoAdminRole()
     {
-        _userRepo
-            .Setup(x => x.GetByUserEmailAsync(Email))
-            .ReturnsAsync(new User { UserId = UserId, Email = Email });
-        _roleCache
-            .Setup(x => x.GetUserRolesAsync(UserId, TenantId))
-            .ReturnsAsync(new List<string> { SystemRoles.TenantUser });
+        ResolvesTo(UserId, SystemRoles.TenantUser);
 
         var result = await BuildResolver().ResolveAsync(Email, KeyOwnedBy(Email), string.Empty);
 
         Assert.False(result.Success);
         Assert.Equal(UserId, result.ResolvedUserId);
         Assert.Equal("User does not have required admin role", result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_DropsParticipantRoles_SoTheyMatchWhatTheCachedPathWouldReturn()
+    {
+        // A participant is someone an agent talks to, not someone who acts on a request.
+        ResolvesTo(UserId, SystemRoles.TenantAdmin, SystemRoles.TenantParticipant);
+
+        var result = await BuildResolver().ResolveAsync(Email, KeyOwnedBy(Email), string.Empty);
+
+        Assert.True(result.Success);
+        Assert.DoesNotContain(SystemRoles.TenantParticipant, result.UserRoles!);
     }
 }

--- a/XiansAi.Server.Tests/UnitTests/Features/AgentApi/Auth/CertificateUserAccessTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Features/AgentApi/Auth/CertificateUserAccessTests.cs
@@ -1,0 +1,79 @@
+using Features.AgentApi.Auth;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shared.Data.Models;
+using Shared.Repositories;
+
+namespace Tests.UnitTests.Features.AgentApi.Auth;
+
+/// <summary>
+/// A certificate whose OU is a user id must apply the same rules as one whose OU is an email:
+/// a locked-out account cannot authenticate, and only an approved membership of the
+/// certificate's tenant contributes roles.
+/// </summary>
+public class CertificateUserAccessTests
+{
+    private const string TenantId = "tenant-a";
+    private const string UserId = "user-1";
+
+    private static User Account(
+        bool lockedOut = false,
+        bool isSysAdmin = false,
+        params TenantRole[] tenantRoles) =>
+        new()
+        {
+            UserId = UserId,
+            Email = "user@example.com",
+            IsLockedOut = lockedOut,
+            IsSysAdmin = isSysAdmin,
+            TenantRoles = tenantRoles.ToList()
+        };
+
+    private static TenantRole Membership(bool approved, params string[] roles) =>
+        new() { Tenant = TenantId, IsApproved = approved, Roles = roles.ToList() };
+
+    private static (string? Error, EmailIdentityResolution? Identity) Resolve(User user) =>
+        CertificateUserAccess.Resolve(user, TenantId, NullLogger.Instance);
+
+    [Fact]
+    public void Resolve_RefusesALockedOutAccount()
+    {
+        var (error, identity) = Resolve(
+            Account(lockedOut: true, tenantRoles: Membership(approved: true, SystemRoles.TenantAdmin)));
+
+        Assert.Equal(CertificateUserAccess.LockedOutError, error);
+        Assert.Null(identity);
+    }
+
+    [Fact]
+    public void Resolve_DoesNotCountAnUnapprovedMembership()
+    {
+        var (error, identity) = Resolve(
+            Account(tenantRoles: Membership(approved: false, SystemRoles.TenantAdmin)));
+
+        Assert.Null(error);
+        Assert.Empty(identity!.Roles);
+        Assert.False(identity.IsSysAdmin);
+    }
+
+    [Fact]
+    public void Resolve_TakesTheApprovedMembershipsRoles()
+    {
+        var (error, identity) = Resolve(
+            Account(tenantRoles: Membership(approved: true, SystemRoles.TenantAdmin)));
+
+        Assert.Null(error);
+        Assert.Equal(new[] { SystemRoles.TenantAdmin }, identity!.Roles);
+    }
+
+    [Fact]
+    public void Resolve_StillTreatsASysAdminAsSysAdmin_WithoutAnApprovedMembership()
+    {
+        // SysAdmin is global. Lacking a membership of this tenant does not strip it — the email
+        // path behaves the same way.
+        var (error, identity) = Resolve(Account(isSysAdmin: true));
+
+        Assert.Null(error);
+        Assert.True(identity!.IsSysAdmin);
+        Assert.Contains(SystemRoles.SysAdmin, identity.Roles);
+    }
+}

--- a/XiansAi.Server.Tests/UnitTests/Features/UserApi/Auth/AuthorizedTenantResolverTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Features/UserApi/Auth/AuthorizedTenantResolverTests.cs
@@ -1,6 +1,7 @@
 using Features.UserApi.Auth;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Shared.Auth;
@@ -25,11 +26,31 @@ public class AuthorizedTenantResolverTests
             _userTenantService.Object,
             cache ?? new MemoryCache(new MemoryCacheOptions { SizeLimit = 100 }),
             configuration,
+            BuildPolicy(),
             NullLogger<AuthorizedTenantResolver>.Instance);
     }
 
+    private static OidcValidationPolicy BuildPolicy() =>
+        new(
+            new ConfigurationBuilder().Build(),
+            Mock.Of<IHostEnvironment>(env => env.EnvironmentName == "Production"),
+            new MemoryCache(new MemoryCacheOptions { SizeLimit = 100 }),
+            NullLogger<OidcValidationPolicy>.Instance);
+
+    /// <summary>A token checked against the audiences its tenant's provider declared.</summary>
     private static OidcValidationResult ValidToken() =>
-        OidcValidationResult.Ok(CanonicalUserId, ProviderUserId, ProviderAuthority, "user@example.com", "Test User");
+        OidcValidationResult.Ok(
+            CanonicalUserId, ProviderUserId, ProviderAuthority, "user@example.com", "Test User",
+            audienceValidated: true);
+
+    /// <summary>
+    /// A token from a tenant whose provider declares no expectedAudience, so it was accepted on its
+    /// issuer's signature alone and may have been minted for an unrelated application.
+    /// </summary>
+    private static OidcValidationResult TokenWithNoAudienceChecked() =>
+        OidcValidationResult.Ok(
+            CanonicalUserId, ProviderUserId, ProviderAuthority, "user@example.com", "Test User",
+            audienceValidated: false);
 
     private void SetupApprovedTenants(params string[] tenantIds)
     {
@@ -41,10 +62,13 @@ public class AuthorizedTenantResolverTests
         var tenants = tenantIds.Select(t => new TenantInfoDto { TenantId = t, Name = t }).ToList();
         _userTenantService
             .Setup(x => x.EnsureUserAndGetApprovedTenants(
-                providerUserId, It.IsAny<string?>(), It.IsAny<string?>(), providerAuthority, It.IsAny<string?>()))
+                IdentityOf(providerUserId, providerAuthority), It.IsAny<string?>(), It.IsAny<bool>()))
             .ReturnsAsync(ServiceResult<ResolvedUserAccess>.Success(
                 new ResolvedUserAccess { UserId = providerUserId, Tenants = tenants }));
     }
+
+    private static SignInIdentity IdentityOf(string providerUserId, string providerAuthority) =>
+        It.Is<SignInIdentity>(i => i.UserId == providerUserId && i.ProviderAuthority == providerAuthority);
 
     [Fact]
     public async Task ResolveAsync_Denies_WhenUserHasNoApprovedTenants()
@@ -138,7 +162,7 @@ public class AuthorizedTenantResolverTests
     {
         _userTenantService
             .Setup(x => x.EnsureUserAndGetApprovedTenants(
-                ProviderUserId, It.IsAny<string?>(), It.IsAny<string?>(), ProviderAuthority, It.IsAny<string?>()))
+                IdentityOf(ProviderUserId, ProviderAuthority), It.IsAny<string?>(), It.IsAny<bool>()))
             .ReturnsAsync(ServiceResult<ResolvedUserAccess>.InternalServerError("boom"));
         var resolver = BuildResolver();
 
@@ -158,7 +182,7 @@ public class AuthorizedTenantResolverTests
 
         _userTenantService.Verify(
             x => x.EnsureUserAndGetApprovedTenants(
-                ProviderUserId, It.IsAny<string?>(), It.IsAny<string?>(), ProviderAuthority, It.IsAny<string?>()),
+                IdentityOf(ProviderUserId, ProviderAuthority), It.IsAny<string?>(), It.IsAny<bool>()),
             Times.Once);
     }
 
@@ -174,31 +198,34 @@ public class AuthorizedTenantResolverTests
 
         _userTenantService.Verify(
             x => x.EnsureUserAndGetApprovedTenants(
-                ProviderUserId, It.IsAny<string?>(), It.IsAny<string?>(), ProviderAuthority, "tenant-a"),
+                IdentityOf(ProviderUserId, ProviderAuthority), "tenant-a", It.IsAny<bool>()),
             Times.Once);
     }
 
     [Fact]
-    public async Task ResolveAsync_DoesNotPassAnUnverifiedEmail_ForAccountLinking()
+    public async Task ResolveAsync_PassesAnUnverifiedEmail_ButMarksItUnverified()
     {
-        // Email uniqueness and ParticipantId treat the address as identity. An unverified claim
-        // must not be written onto the user record or an attacker can claim a victim's address.
+        // Providers that issue no email_verified claim at all — Azure B2C among them — would
+        // otherwise leave every record they provision with no address, and nothing later fills it
+        // in. The address is stored; the flag is what keeps it from deciding identity.
         SetupApprovedTenants("tenant-a");
         var resolver = BuildResolver();
         var validation = OidcValidationResult.Ok(
-            CanonicalUserId, ProviderUserId, ProviderAuthority, "victim@example.com", "Test User",
+            CanonicalUserId, ProviderUserId, ProviderAuthority, "user@example.com", "Test User",
             emailVerified: false);
 
         await resolver.ResolveAsync(validation, "tenant-a");
 
         _userTenantService.Verify(
             x => x.EnsureUserAndGetApprovedTenants(
-                ProviderUserId, null, "Test User", ProviderAuthority, "tenant-a"),
+                It.Is<SignInIdentity>(i =>
+                    i.Email == "user@example.com" && !i.EmailVerified && i.Name == "Test User"),
+                "tenant-a", It.IsAny<bool>()),
             Times.Once);
     }
 
     [Fact]
-    public async Task ResolveAsync_PassesAVerifiedEmail_ForAccountLinking()
+    public async Task ResolveAsync_PassesAVerifiedEmail_AsVerified()
     {
         SetupApprovedTenants("tenant-a");
         var resolver = BuildResolver();
@@ -210,7 +237,40 @@ public class AuthorizedTenantResolverTests
 
         _userTenantService.Verify(
             x => x.EnsureUserAndGetApprovedTenants(
-                ProviderUserId, "user@example.com", "Test User", ProviderAuthority, "tenant-a"),
+                It.Is<SignInIdentity>(i => i.Email == "user@example.com" && i.EmailVerified),
+                "tenant-a", It.IsAny<bool>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_AsksForTheMembershipToBeApproved()
+    {
+        // This token was checked against the audiences the tenant declared, so it was minted for
+        // this tenant's own application — which is what makes holding one the tenant's statement
+        // that this person belongs to it.
+        SetupApprovedTenants("tenant-a");
+        var resolver = BuildResolver();
+
+        await resolver.ResolveAsync(ValidToken(), "tenant-a");
+
+        _userTenantService.Verify(
+            x => x.EnsureUserAndGetApprovedTenants(It.IsAny<SignInIdentity>(), "tenant-a", true),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_DoesNotAskForApproval_WhenNoAudienceWasChecked()
+    {
+        // Without a declared audience the provider accepts anything its issuer signed, including a
+        // token minted for an unrelated application there. That says nothing about this tenant, so
+        // the membership goes back to waiting for an admin.
+        SetupApprovedTenants("tenant-a");
+        var resolver = BuildResolver();
+
+        await resolver.ResolveAsync(TokenWithNoAudienceChecked(), "tenant-a");
+
+        _userTenantService.Verify(
+            x => x.EnsureUserAndGetApprovedTenants(It.IsAny<SignInIdentity>(), "tenant-a", false),
             Times.Once);
     }
 
@@ -219,7 +279,7 @@ public class AuthorizedTenantResolverTests
     {
         _userTenantService
             .SetupSequence(x => x.EnsureUserAndGetApprovedTenants(
-                ProviderUserId, It.IsAny<string?>(), It.IsAny<string?>(), ProviderAuthority, It.IsAny<string?>()))
+                IdentityOf(ProviderUserId, ProviderAuthority), It.IsAny<string?>(), It.IsAny<bool>()))
             .ReturnsAsync(ServiceResult<ResolvedUserAccess>.InternalServerError("transient"))
             .ReturnsAsync(ServiceResult<ResolvedUserAccess>.Success(new ResolvedUserAccess
             {
@@ -275,7 +335,7 @@ public class AuthorizedTenantResolverTests
     {
         _userTenantService.Verify(
             x => x.EnsureUserAndGetApprovedTenants(
-                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>()),
+                It.IsAny<SignInIdentity>(), It.IsAny<string?>(), It.IsAny<bool>()),
             Times.Never);
     }
 }

--- a/XiansAi.Server.Tests/UnitTests/Features/UserApi/Auth/AuthorizedTenantResolverTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Features/UserApi/Auth/AuthorizedTenantResolverTests.cs
@@ -18,13 +18,16 @@ public class AuthorizedTenantResolverTests
 
     private readonly Mock<IUserTenantService> _userTenantService = new();
 
-    private AuthorizedTenantResolver BuildResolver(IMemoryCache? cache = null)
+    private AuthorizedTenantResolver BuildResolver(
+        IMemoryCache? cache = null, IUserCacheIndex? userCacheIndex = null)
     {
         var configuration = new ConfigurationBuilder().Build();
+        var memoryCache = cache ?? new MemoryCache(new MemoryCacheOptions { SizeLimit = 100 });
 
         return new AuthorizedTenantResolver(
             _userTenantService.Object,
-            cache ?? new MemoryCache(new MemoryCacheOptions { SizeLimit = 100 }),
+            memoryCache,
+            userCacheIndex ?? new UserCacheIndex(memoryCache, NullLogger<UserCacheIndex>.Instance),
             configuration,
             BuildPolicy(),
             NullLogger<AuthorizedTenantResolver>.Instance);
@@ -158,6 +161,29 @@ public class AuthorizedTenantResolverTests
     }
 
     [Fact]
+    public async Task ResolveAsync_ReChecksTheAccount_AfterItsCachedAccessIsInvalidated()
+    {
+        // The cached entry holds the approved tenants, so a hit never reaches the lockout check.
+        // Disabling the account has to drop the entry, or the account keeps its access for as long
+        // as the entry lives.
+        var cache = new MemoryCache(new MemoryCacheOptions { SizeLimit = 100 });
+        var index = new UserCacheIndex(cache, NullLogger<UserCacheIndex>.Instance);
+        SetupApprovedTenants("tenant-a");
+        var resolver = BuildResolver(cache, index);
+        await resolver.ResolveAsync(ValidToken(), "tenant-a");
+
+        index.Invalidate(ProviderUserId);
+        _userTenantService
+            .Setup(x => x.EnsureUserAndGetApprovedTenants(
+                IdentityOf(ProviderUserId, ProviderAuthority), It.IsAny<string?>(), It.IsAny<bool>()))
+            .ReturnsAsync(ServiceResult<ResolvedUserAccess>.Forbidden("User account is disabled"));
+
+        var resolution = await resolver.ResolveAsync(ValidToken(), "tenant-a");
+
+        Assert.False(resolution.IsAuthorized);
+    }
+
+    [Fact]
     public async Task ResolveAsync_Denies_WhenTenantLookupFails()
     {
         _userTenantService
@@ -203,41 +229,22 @@ public class AuthorizedTenantResolverTests
     }
 
     [Fact]
-    public async Task ResolveAsync_PassesAnUnverifiedEmail_ButMarksItUnverified()
+    public async Task ResolveAsync_PassesTheAddressAndNameOnForProvisioning()
     {
-        // Providers that issue no email_verified claim at all — Azure B2C among them — would
-        // otherwise leave every record they provision with no address, and nothing later fills it
-        // in. The address is stored; the flag is what keeps it from deciding identity.
+        // Whatever the provider says about the address is passed through, because a record with no
+        // address cannot be matched to a person and nothing later fills it in. Azure B2C in
+        // particular vouches for nothing, and its users still need an address on the record.
         SetupApprovedTenants("tenant-a");
         var resolver = BuildResolver();
         var validation = OidcValidationResult.Ok(
-            CanonicalUserId, ProviderUserId, ProviderAuthority, "user@example.com", "Test User",
-            emailVerified: false);
+            CanonicalUserId, ProviderUserId, ProviderAuthority, "user@example.com", "Test User");
 
         await resolver.ResolveAsync(validation, "tenant-a");
 
         _userTenantService.Verify(
             x => x.EnsureUserAndGetApprovedTenants(
                 It.Is<SignInIdentity>(i =>
-                    i.Email == "user@example.com" && !i.EmailVerified && i.Name == "Test User"),
-                "tenant-a", It.IsAny<bool>()),
-            Times.Once);
-    }
-
-    [Fact]
-    public async Task ResolveAsync_PassesAVerifiedEmail_AsVerified()
-    {
-        SetupApprovedTenants("tenant-a");
-        var resolver = BuildResolver();
-        var validation = OidcValidationResult.Ok(
-            CanonicalUserId, ProviderUserId, ProviderAuthority, "user@example.com", "Test User",
-            emailVerified: true);
-
-        await resolver.ResolveAsync(validation, "tenant-a");
-
-        _userTenantService.Verify(
-            x => x.EnsureUserAndGetApprovedTenants(
-                It.Is<SignInIdentity>(i => i.Email == "user@example.com" && i.EmailVerified),
+                    i.Email == "user@example.com" && i.Name == "Test User"),
                 "tenant-a", It.IsAny<bool>()),
             Times.Once);
     }

--- a/XiansAi.Server.Tests/UnitTests/Features/UserApi/Auth/UserApiCredentialAuthenticatorTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Features/UserApi/Auth/UserApiCredentialAuthenticatorTests.cs
@@ -158,7 +158,7 @@ public class UserApiCredentialAuthenticatorTests
         _tenantResolver
             .Setup(x => x.ResolveAsync(It.IsAny<OidcValidationResult>(), "tenant-a"))
             .ReturnsAsync(AuthorizedTenantResolution.Authorized(
-                "tenant-a", ["tenant-a"], ProviderUserId, accountEmail));
+                "tenant-a", ["tenant-a"], ProviderUserId, accountEmail, accountEmail));
 
         var result = await BuildAuthenticator().AuthenticateAsync(FromHeader(Jwt), "tenant-a", SchemeName);
 
@@ -169,6 +169,28 @@ public class UserApiCredentialAuthenticatorTests
         Assert.Equal(accountEmail, _tenantContext.Object.ParticipantId);
         Assert.Equal(accountEmail, _tenantContext.Object.Email);
         Assert.Equal(ProviderUserId, _tenantContext.Object.ProviderSubject);
+    }
+
+    [Fact]
+    public async Task Jwt_NamesTheCallerByTheirSubject_ButStillReportsAWithheldSharedEmail()
+    {
+        // Another account holds the address, so it cannot namespace threads. It is still carried as
+        // the account email so a client that keeps sending it is recognised rather than refused.
+        const string sharedEmail = "shared@example.com";
+
+        SetupValidJwt();
+        _tenantResolver
+            .Setup(x => x.ResolveAsync(It.IsAny<OidcValidationResult>(), "tenant-a"))
+            .ReturnsAsync(AuthorizedTenantResolution.Authorized(
+                "tenant-a", ["tenant-a"], ProviderUserId, conversationEmail: null, accountEmail: sharedEmail));
+
+        var result = await BuildAuthenticator().AuthenticateAsync(FromHeader(Jwt), "tenant-a", SchemeName);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(ProviderUserId, result.Principal!.FindFirst(UserApiClaimTypes.ParticipantId)?.Value);
+        Assert.Equal(sharedEmail, result.Principal.FindFirst(UserApiClaimTypes.Email)?.Value);
+        Assert.Equal(ProviderUserId, _tenantContext.Object.ParticipantId);
+        Assert.Equal(sharedEmail, _tenantContext.Object.Email);
     }
 
     [Fact]

--- a/XiansAi.Server.Tests/UnitTests/Features/UserApi/Utils/ParticipantIdResolverTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Features/UserApi/Utils/ParticipantIdResolverTests.cs
@@ -202,4 +202,69 @@ public class ParticipantIdResolverTests
     {
         Assert.False(ParticipantIdResolver.CanActAs("", TenantContext(CanonicalUserId, ProviderUserId)));
     }
+
+    /// <summary>
+    /// The address is held by a second account, so it namespaces nothing and the caller was issued
+    /// their provider subject instead. Naming themselves by it must still land on their own threads.
+    /// </summary>
+    private static ITenantContext WithheldEmailContext() =>
+        TenantContext(
+            CanonicalUserId,
+            participantId: ProviderUserId,
+            email: "shared@example.com",
+            providerSubject: ProviderUserId);
+
+    [Theory]
+    [InlineData("shared@example.com")]
+    [InlineData("Shared@Example.COM")]
+    public void Resolve_ResolvesAWithheldEmailToTheCallersOwnParticipantId(string requested)
+    {
+        var resolved = ParticipantIdResolver.Resolve(requested, WithheldEmailContext());
+
+        Assert.Equal(ProviderUserId, resolved.ParticipantId);
+    }
+
+    [Fact]
+    public void TryResolve_AllowsAWithheldEmail_WithoutPuttingTheCallerInTheSharedNamespace()
+    {
+        var allowed = ParticipantIdResolver.TryResolve(
+            "shared@example.com", WithheldEmailContext(), out var participant);
+
+        Assert.True(allowed);
+        Assert.Equal(ProviderUserId, participant.ParticipantId);
+    }
+
+    [Fact]
+    public void Resolve_KeepsTheEmailAsTheNamespace_WhenItNamesOnlyTheCaller()
+    {
+        var context = TenantContext(
+            CanonicalUserId,
+            participantId: "user@example.com",
+            email: "user@example.com",
+            providerSubject: ProviderUserId);
+
+        var resolved = ParticipantIdResolver.Resolve("user@example.com", context);
+
+        Assert.Equal("user@example.com", resolved.ParticipantId);
+    }
+
+    [Fact]
+    public void Resolve_ResolvesTheCanonicalLoginIdToTheCallersOwnParticipantId()
+    {
+        var resolved = ParticipantIdResolver.Resolve(
+            CanonicalUserId, TenantContext(CanonicalUserId, ProviderUserId));
+
+        Assert.Equal(ProviderUserId, resolved.ParticipantId);
+        Assert.Equal(CanonicalUserId, resolved.LegacyParticipantId);
+    }
+
+    [Fact]
+    public void Resolve_LeavesAnApiKeyNamingAnEndUserAlone()
+    {
+        var tenantContext = TenantContext("service-account", "service-account", UserType.UserApiKey);
+
+        var resolved = ParticipantIdResolver.Resolve("shared@example.com", tenantContext);
+
+        Assert.Equal("shared@example.com", resolved.ParticipantId);
+    }
 }

--- a/XiansAi.Server.Tests/UnitTests/Features/WebApi/Services/RoleManagementServiceSysAdminEmailTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Features/WebApi/Services/RoleManagementServiceSysAdminEmailTests.cs
@@ -1,0 +1,101 @@
+using Features.WebApi.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Shared.Auth;
+using Shared.Data.Models;
+using Shared.Providers.Auth;
+using Shared.Repositories;
+using Shared.Services;
+using Shared.Utils;
+using Shared.Utils.Services;
+
+namespace Tests.UnitTests.Features.WebApi.Services;
+
+/// <summary>
+/// A credential that names only an email address — a legacy API key, a certificate whose OU is an
+/// email — cannot say which account it meant when several hold that address, so SysAdmin is never
+/// resolved from a shared one. Granting it to such an account would therefore be silently
+/// ineffective on exactly the paths where it matters, so the grant is refused up front.
+/// </summary>
+public class RoleManagementServiceSysAdminEmailTests
+{
+    private const string TargetUserId = "target-subject";
+    private const string Email = "admin@example.com";
+
+    private readonly Mock<IUserRepository> _userRepo = new();
+    private readonly Mock<ITenantContext> _tenantContext = new();
+
+    public RoleManagementServiceSysAdminEmailTests()
+    {
+        _tenantContext.SetupGet(x => x.UserRoles).Returns(new[] { SystemRoles.SysAdmin });
+        _tenantContext.SetupGet(x => x.TenantId).Returns("tenant-a");
+        _tenantContext.SetupGet(x => x.LoggedInUser).Returns("acting-admin");
+    }
+
+    private RoleManagementService BuildService() =>
+        new(
+            _userRepo.Object,
+            Mock.Of<IRoleCacheService>(),
+            _tenantContext.Object,
+            NullLogger<RoleManagementService>.Instance,
+            Mock.Of<IAuthProviderFactory>(),
+            Mock.Of<ITokenValidationCache>());
+
+    private void ArrangeTarget(string email, bool emailIsShared)
+    {
+        _userRepo.Setup(x => x.GetByUserIdAsync(TargetUserId))
+            .ReturnsAsync(new User { UserId = TargetUserId, Email = email });
+        _userRepo.Setup(x => x.IsEmailSharedAsync(It.IsAny<string>(), TargetUserId))
+            .ReturnsAsync(emailIsShared);
+        _userRepo.Setup(x => x.UpdateAsync(It.IsAny<string>(), It.IsAny<User>())).ReturnsAsync(true);
+    }
+
+    [Fact]
+    public async Task AssignSysAdminRolesToUserAsync_RefusesWhenAnotherAccountHoldsTheSameEmail()
+    {
+        ArrangeTarget(Email, emailIsShared: true);
+
+        var result = await BuildService().AssignSysAdminRolesToUserAsync(TargetUserId);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(StatusCode.Conflict, result.StatusCode);
+        _userRepo.Verify(x => x.UpdateAsync(It.IsAny<string>(), It.IsAny<User>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task AssignSysAdminRolesToUserAsync_GrantsWhenTheEmailNamesOneAccount()
+    {
+        ArrangeTarget(Email, emailIsShared: false);
+
+        var result = await BuildService().AssignSysAdminRolesToUserAsync(TargetUserId);
+
+        Assert.True(result.IsSuccess);
+        _userRepo.Verify(x => x.UpdateAsync(TargetUserId, It.Is<User>(u => u.IsSysAdmin)), Times.Once);
+    }
+
+    [Fact]
+    public async Task AssignSysAdminRolesToUserAsync_GrantsWhenTheAccountHasNoEmail()
+    {
+        // Nothing can collide with a blank address, and comparing them would match every record
+        // that has none.
+        ArrangeTarget(string.Empty, emailIsShared: true);
+
+        var result = await BuildService().AssignSysAdminRolesToUserAsync(TargetUserId);
+
+        Assert.True(result.IsSuccess);
+        _userRepo.Verify(x => x.IsEmailSharedAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RemoveSysAdminRolesToUserAsync_StillWorksForASharedEmail()
+    {
+        // Taking the role away is always the safe direction, so it is never blocked — otherwise a
+        // duplicate account would be a way to keep an administrator from being demoted.
+        ArrangeTarget(Email, emailIsShared: true);
+
+        var result = await BuildService().RemoveSysAdminRolesToUserAsync(TargetUserId);
+
+        Assert.True(result.IsSuccess);
+        _userRepo.Verify(x => x.UpdateAsync(TargetUserId, It.Is<User>(u => !u.IsSysAdmin)), Times.Once);
+    }
+}

--- a/XiansAi.Server.Tests/UnitTests/Shared/Auth/OidcTokenInspectorTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Shared/Auth/OidcTokenInspectorTests.cs
@@ -196,17 +196,6 @@ public class OidcTokenInspectorTests
     }
 
     [Fact]
-    public void TheB2CEmailsArrayIsNotTreatedAsVerified()
-    {
-        // B2C states nothing about ownership of the address, and it may have come from a social
-        // account the directory never checked. Treating it as verified would let a sign-in attach
-        // itself to an existing account on that basis alone.
-        var jwt = TokenWith(("sub", "user-1"), ("emails", new[] { "a@b.com" }));
-
-        Assert.False(OidcTokenInspector.IsEmailVerified(jwt));
-    }
-
-    [Fact]
     public void NoScopeRequirementAcceptsAnyToken()
     {
         Assert.Null(OidcTokenInspector.DescribeMissingScope(new OidcProviderRule(), TokenWith(("sub", "u"))));

--- a/XiansAi.Server.Tests/UnitTests/Shared/Data/MongoIndexDefinitionTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Shared/Data/MongoIndexDefinitionTests.cs
@@ -1,0 +1,134 @@
+using MongoDB.Bson;
+using Shared.Data;
+
+namespace Tests.UnitTests.Shared.Data;
+
+public class MongoIndexDefinitionTests
+{
+    private static MongoIndexDefinition DomainIndex(bool? unique = null) => new()
+    {
+        Name = "domain_1",
+        Keys = new Dictionary<string, string> { ["domain"] = "asc" },
+        Unique = unique
+    };
+
+    private static BsonDocument ExistingIndex(BsonDocument keys, bool? unique = null, bool? sparse = null)
+    {
+        var index = new BsonDocument
+        {
+            { "v", 2 },
+            { "name", "domain_1" },
+            { "key", keys }
+        };
+        if (unique.HasValue) index["unique"] = unique.Value;
+        if (sparse.HasValue) index["sparse"] = sparse.Value;
+        return index;
+    }
+
+    [Fact]
+    public void MatchesExistingIndex_IgnoresServerMetadata_WhenKeysAndOptionsAgree()
+    {
+        var existing = ExistingIndex(new BsonDocument { { "domain", 1 } });
+        existing["ns"] = "xiansai.tenants";
+
+        Assert.True(DomainIndex().MatchesExistingIndex(existing));
+    }
+
+    [Fact]
+    public void MatchesExistingIndex_DetectsUniqueConstraintThatDefinitionNoLongerAsksFor()
+    {
+        var existing = ExistingIndex(new BsonDocument { { "domain", 1 } }, unique: true);
+
+        Assert.False(DomainIndex().MatchesExistingIndex(existing));
+    }
+
+    [Fact]
+    public void MatchesExistingIndex_DetectsMissingUniqueConstraint()
+    {
+        var existing = ExistingIndex(new BsonDocument { { "domain", 1 } });
+
+        Assert.False(DomainIndex(unique: true).MatchesExistingIndex(existing));
+    }
+
+    [Fact]
+    public void MatchesExistingIndex_DetectsSparseDifference()
+    {
+        var existing = ExistingIndex(new BsonDocument { { "domain", 1 } }, sparse: true);
+
+        Assert.False(DomainIndex().MatchesExistingIndex(existing));
+    }
+
+    [Fact]
+    public void MatchesExistingIndex_DetectsChangedKeyDirection()
+    {
+        var existing = ExistingIndex(new BsonDocument { { "domain", -1 } });
+
+        Assert.False(DomainIndex().MatchesExistingIndex(existing));
+    }
+
+    [Fact]
+    public void MatchesExistingIndex_ComparesCompoundKeyOrder()
+    {
+        var definition = new MongoIndexDefinition
+        {
+            Name = "tenant_1_created_at_-1",
+            Keys = new Dictionary<string, string> { ["tenant"] = "asc", ["created_at"] = "desc" }
+        };
+
+        var sameOrder = new BsonDocument
+        {
+            { "name", "tenant_1_created_at_-1" },
+            { "key", new BsonDocument { { "tenant", 1 }, { "created_at", -1 } } }
+        };
+        var reversedOrder = new BsonDocument
+        {
+            { "name", "tenant_1_created_at_-1" },
+            { "key", new BsonDocument { { "created_at", -1 }, { "tenant", 1 } } }
+        };
+
+        Assert.True(definition.MatchesExistingIndex(sameOrder));
+        Assert.False(definition.MatchesExistingIndex(reversedOrder));
+    }
+
+    [Fact]
+    public void MatchesExistingIndex_ComparesTimeToLive()
+    {
+        var definition = new MongoIndexDefinition
+        {
+            Name = "logs_ttl_created_at",
+            Keys = new Dictionary<string, string> { ["created_at"] = "asc" },
+            ExpireAfter = TimeSpan.FromDays(15)
+        };
+
+        var matchingTtl = new BsonDocument
+        {
+            { "name", "logs_ttl_created_at" },
+            { "key", new BsonDocument { { "created_at", 1 } } },
+            { "expireAfterSeconds", TimeSpan.FromDays(15).TotalSeconds }
+        };
+        var differentTtl = new BsonDocument
+        {
+            { "name", "logs_ttl_created_at" },
+            { "key", new BsonDocument { { "created_at", 1 } } },
+            { "expireAfterSeconds", TimeSpan.FromDays(30).TotalSeconds }
+        };
+        var noTtl = new BsonDocument
+        {
+            { "name", "logs_ttl_created_at" },
+            { "key", new BsonDocument { { "created_at", 1 } } }
+        };
+
+        Assert.True(definition.MatchesExistingIndex(matchingTtl));
+        Assert.False(definition.MatchesExistingIndex(differentTtl));
+        Assert.False(definition.MatchesExistingIndex(noTtl));
+    }
+
+    [Fact]
+    public void MatchesExistingIndex_DetectsUnexpectedTimeToLive()
+    {
+        var existing = ExistingIndex(new BsonDocument { { "domain", 1 } });
+        existing["expireAfterSeconds"] = 3600;
+
+        Assert.False(DomainIndex().MatchesExistingIndex(existing));
+    }
+}

--- a/XiansAi.Server.Tests/UnitTests/Shared/Repositories/EmailIdentityResolutionTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Shared/Repositories/EmailIdentityResolutionTests.cs
@@ -1,0 +1,169 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Shared.Data.Models;
+using Shared.Repositories;
+
+namespace Tests.UnitTests.Shared.Repositories;
+
+/// <summary>
+/// One address can be held by several accounts — a record is keyed on the provider subject, so two
+/// identity providers each holding an account for the same person is ordinary. A credential that
+/// names only the address cannot say which of them it meant, so they are folded into one identity
+/// rather than one being picked arbitrarily.
+/// </summary>
+public class EmailIdentityResolutionTests
+{
+    private const string Email = "person@example.com";
+    private const string TenantId = "tenant-a";
+
+    private static User Record(
+        string userId,
+        DateTime? createdAt = null,
+        bool isSysAdmin = false,
+        bool isLockedOut = false,
+        params TenantRole[] tenantRoles) =>
+        new()
+        {
+            UserId = userId,
+            Email = Email,
+            IsSysAdmin = isSysAdmin,
+            IsLockedOut = isLockedOut,
+            CreatedAt = createdAt ?? new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            TenantRoles = tenantRoles.ToList()
+        };
+
+    private static TenantRole Membership(string tenant, bool approved, params string[] roles) =>
+        new() { Tenant = tenant, IsApproved = approved, Roles = roles.ToList() };
+
+    private static EmailIdentityResolution? Fold(params User[] records) =>
+        EmailIdentityResolution.From(Email, records, TenantId, NullLogger.Instance);
+
+    [Fact]
+    public void From_ReturnsNull_WhenNoRecordHoldsTheAddress()
+    {
+        Assert.Null(Fold());
+    }
+
+    [Fact]
+    public void From_ReturnsNull_WhenEveryRecordHoldingItIsLockedOut()
+    {
+        Assert.Null(Fold(Record("locked", isLockedOut: true)));
+    }
+
+    [Fact]
+    public void From_TakesTheRolesOfTheOnlyRecordThatIsAMemberOfTheTenant()
+    {
+        var resolution = Fold(
+            Record("a", tenantRoles: Membership(TenantId, approved: true, SystemRoles.TenantAdmin)),
+            Record("b", tenantRoles: Membership("other-tenant", approved: true, SystemRoles.TenantAdmin)));
+
+        Assert.Equal(new[] { SystemRoles.TenantAdmin }, resolution!.Roles);
+        Assert.True(resolution.IsAmbiguous);
+    }
+
+    [Fact]
+    public void From_UnionsTheRolesOfEveryRecordThatIsAMemberOfTheTenant()
+    {
+        var resolution = Fold(
+            Record("a", tenantRoles: Membership(TenantId, approved: true, SystemRoles.TenantUser)),
+            Record("b", tenantRoles: Membership(TenantId, approved: true, SystemRoles.TenantAdmin)));
+
+        Assert.Equal(
+            new[] { SystemRoles.TenantUser, SystemRoles.TenantAdmin },
+            resolution!.Roles.OrderBy(r => r == SystemRoles.TenantAdmin));
+    }
+
+    [Fact]
+    public void From_IgnoresAMembershipNobodyApproved()
+    {
+        // Reaching a tenant this way still requires one of its admins to have granted the
+        // membership, so a row that is merely awaiting approval contributes nothing.
+        var resolution = Fold(
+            Record("a", tenantRoles: Membership(TenantId, approved: false, SystemRoles.TenantAdmin)));
+
+        Assert.Empty(resolution!.Roles);
+    }
+
+    [Fact]
+    public void From_ResolvesSysAdmin_ForAnAddressHeldByOneRecord()
+    {
+        var resolution = Fold(Record("a", isSysAdmin: true));
+
+        Assert.True(resolution!.IsSysAdmin);
+        Assert.Contains(SystemRoles.SysAdmin, resolution.Roles);
+        Assert.False(resolution.IsAmbiguous);
+    }
+
+    [Fact]
+    public void From_RefusesSysAdmin_WhenAnotherRecordSharesTheAddressWithoutTheRole()
+    {
+        // Guessing the administrator would let anyone able to register that address at a second
+        // directory become one. A record that has not been granted the role is a record nobody has
+        // accepted as the same person yet.
+        var resolution = Fold(
+            Record("admin", isSysAdmin: true),
+            Record("someone-else"));
+
+        Assert.False(resolution!.IsSysAdmin);
+        Assert.DoesNotContain(SystemRoles.SysAdmin, resolution.Roles);
+    }
+
+    [Fact]
+    public void From_ResolvesSysAdmin_WhenEveryRecordHoldingTheAddressHasTheRole()
+    {
+        // The same person holding an administrator account in two directories. Both were granted
+        // the role deliberately, which is what makes the address safe to resolve from.
+        var resolution = Fold(
+            Record("admin-directory-one", isSysAdmin: true),
+            Record("admin-directory-two", isSysAdmin: true));
+
+        Assert.True(resolution!.IsSysAdmin);
+        Assert.Contains(SystemRoles.SysAdmin, resolution.Roles);
+        Assert.True(resolution.IsAmbiguous);
+    }
+
+    [Fact]
+    public void From_StillResolvesSysAdmin_WhenTheOtherRecordIsLockedOut()
+    {
+        // A second account created for an administrator's address is created disabled, and disabled
+        // records are dropped before the rest is decided. So merely registering that address at
+        // another directory cannot take the role away from the account that holds it.
+        var resolution = Fold(
+            Record("admin", isSysAdmin: true),
+            Record("awaiting-review", isLockedOut: true));
+
+        Assert.True(resolution!.IsSysAdmin);
+    }
+
+    [Fact]
+    public void From_PicksTheSamePrimaryAccount_WhicheverOrderTheRecordsArriveIn()
+    {
+        // The primary account is what the request acts as, and what its data is scoped to, so it
+        // must not depend on the order a collection scan happened to return.
+        var older = Record("zzz", createdAt: new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        var newer = Record("aaa", createdAt: new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        Assert.Equal("zzz", Fold(older, newer)!.PrimaryUserId);
+        Assert.Equal("zzz", Fold(newer, older)!.PrimaryUserId);
+    }
+
+    [Fact]
+    public void From_BreaksATieOnCreationTimeWithTheUserId()
+    {
+        var sameMoment = new DateTime(2024, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        Assert.Equal(
+            "aaa",
+            Fold(Record("zzz", createdAt: sameMoment), Record("aaa", createdAt: sameMoment))!.PrimaryUserId);
+    }
+
+    [Fact]
+    public void From_ReportsEveryRecordThatContributed()
+    {
+        var resolution = Fold(
+            Record("a", createdAt: new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc)),
+            Record("b", createdAt: new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc)),
+            Record("locked", isLockedOut: true));
+
+        Assert.Equal(new[] { "a", "b" }, resolution!.CandidateUserIds);
+    }
+}

--- a/XiansAi.Server.Tests/UnitTests/Shared/Services/TenantAssignmentByEmailTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Shared/Services/TenantAssignmentByEmailTests.cs
@@ -1,0 +1,165 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Shared.Auth;
+using Shared.Data.Models;
+using Shared.Providers.Auth;
+using Shared.Repositories;
+using Shared.Services;
+using Shared.Utils;
+using Shared.Utils.Services;
+
+namespace Tests.UnitTests.Shared.Services;
+
+/// <summary>
+/// The two paths where an admin names a person by email and that person is given a tenant
+/// membership.
+///
+/// An address does not always name one account — two providers can each hold a record for the same
+/// address — so resolving it to whichever record came back first would put a different account in
+/// the tenant than the admin meant. Both paths refuse an ambiguous address instead.
+/// </summary>
+public class TenantAssignmentByEmailTests
+{
+    private const string TenantId = "acme";
+    private const string Email = "shared@example.com";
+
+    private readonly Mock<IUserRepository> _userRepo = new();
+    private readonly Mock<ITenantContext> _tenantContext = new();
+
+    public TenantAssignmentByEmailTests()
+    {
+        _userRepo.Setup(x => x.UpdateAsync(It.IsAny<string>(), It.IsAny<User>())).ReturnsAsync(true);
+        _tenantContext.Setup(x => x.LoggedInUser).Returns("the-admin");
+        _tenantContext.Setup(x => x.TenantId).Returns(TenantId);
+        _tenantContext.Setup(x => x.UserRoles).Returns(new[] { SystemRoles.TenantAdmin });
+    }
+
+    private void EmailIsHeldBy(params User[] owners)
+    {
+        _userRepo.Setup(x => x.GetAllByUserEmailAsync(Email)).ReturnsAsync(owners.ToList());
+    }
+
+    private static User Account(string userId, bool isLockedOut = false) => new()
+    {
+        UserId = userId,
+        Email = Email,
+        Name = "Test User",
+        IsLockedOut = isLockedOut,
+        TenantRoles = new List<TenantRole>()
+    };
+
+    // The shape this exists for: one person signed in through two directories.
+    private static User[] TwoAccountsForOnePerson() =>
+        new[] { Account("directory-a-subject"), Account("directory-b-subject") };
+
+    private UserTenantService BuildUserTenantService() => new(
+        _userRepo.Object,
+        NullLogger<UserTenantService>.Instance,
+        _tenantContext.Object,
+        Mock.Of<IAuthMgtConnect>(),
+        new ConfigurationBuilder().Build(),
+        Mock.Of<IUserManagementService>(),
+        Mock.Of<ITenantRepository>(),
+        Mock.Of<IJwtClaimsExtractor>());
+
+    private TenantParticipantUserService BuildParticipantService() => new(
+        _userRepo.Object,
+        Mock.Of<IUserTenantService>(),
+        Mock.Of<IRoleCacheService>(),
+        Mock.Of<ITokenValidationCache>(),
+        Mock.Of<IWebhookEventPublisher>(),
+        NullLogger<TenantParticipantUserService>.Instance);
+
+    [Fact]
+    public async Task AddTenantToUserIfExist_RefusesAnAddressHeldByMoreThanOneAccount()
+    {
+        EmailIsHeldBy(TwoAccountsForOnePerson());
+
+        var result = await BuildUserTenantService().AddTenantToUserIfExist(Email);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(StatusCode.Conflict, result.StatusCode);
+        _userRepo.Verify(x => x.UpdateAsync(It.IsAny<string>(), It.IsAny<User>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task AddTenantToUserIfExist_AddsTheMembership_WhenTheAddressNamesOneAccount()
+    {
+        EmailIsHeldBy(Account("the-only-subject"));
+
+        var result = await BuildUserTenantService().AddTenantToUserIfExist(Email);
+
+        Assert.True(result.IsSuccess);
+        _userRepo.Verify(
+            x => x.UpdateAsync("the-only-subject", It.Is<User>(u =>
+                u.TenantRoles.Any(tr => tr.Tenant == TenantId && tr.IsApproved))),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task AddTenantToUserIfExist_RefusesADisabledAccount()
+    {
+        EmailIsHeldBy(Account("the-only-subject", isLockedOut: true));
+
+        var result = await BuildUserTenantService().AddTenantToUserIfExist(Email);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(StatusCode.Conflict, result.StatusCode);
+        _userRepo.Verify(x => x.UpdateAsync(It.IsAny<string>(), It.IsAny<User>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task AddTenantToUserIfExist_ReportsAnAddressNobodyHolds()
+    {
+        EmailIsHeldBy();
+
+        var result = await BuildUserTenantService().AddTenantToUserIfExist(Email);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(StatusCode.NotFound, result.StatusCode);
+    }
+
+    [Fact]
+    public async Task ParticipantCreate_RefusesAnAddressHeldByMoreThanOneAccount()
+    {
+        // The role granted here can be TenantAdmin, so landing on the wrong record matters more.
+        EmailIsHeldBy(TwoAccountsForOnePerson());
+
+        var result = await BuildParticipantService()
+            .CreateAsync(TenantId, Email, "Test User", SystemRoles.TenantAdmin);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(StatusCode.Conflict, result.StatusCode);
+        _userRepo.Verify(x => x.UpdateAsync(It.IsAny<string>(), It.IsAny<User>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ParticipantCreate_AddsTheRole_WhenTheAddressNamesOneAccount()
+    {
+        EmailIsHeldBy(Account("the-only-subject"));
+
+        var result = await BuildParticipantService()
+            .CreateAsync(TenantId, Email, "Test User", SystemRoles.TenantParticipant);
+
+        Assert.True(result.IsSuccess);
+        _userRepo.Verify(
+            x => x.UpdateAsync("the-only-subject", It.Is<User>(u =>
+                u.TenantRoles.Any(tr =>
+                    tr.Tenant == TenantId && tr.Roles.Contains(SystemRoles.TenantParticipant)))),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ParticipantCreate_RefusesADisabledAccount()
+    {
+        EmailIsHeldBy(Account("the-only-subject", isLockedOut: true));
+
+        var result = await BuildParticipantService()
+            .CreateAsync(TenantId, Email, "Test User", SystemRoles.TenantParticipant);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(StatusCode.Conflict, result.StatusCode);
+        _userRepo.Verify(x => x.UpdateAsync(It.IsAny<string>(), It.IsAny<User>()), Times.Never);
+    }
+}

--- a/XiansAi.Server.Tests/UnitTests/Shared/Services/TenantAssignmentByEmailTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Shared/Services/TenantAssignmentByEmailTests.cs
@@ -40,6 +40,11 @@ public class TenantAssignmentByEmailTests
         _userRepo.Setup(x => x.GetAllByUserEmailAsync(Email)).ReturnsAsync(owners.ToList());
     }
 
+    private void AccountExists(User user)
+    {
+        _userRepo.Setup(x => x.GetByUserIdAsync(user.UserId)).ReturnsAsync(user);
+    }
+
     private static User Account(string userId, bool isLockedOut = false) => new()
     {
         UserId = userId,
@@ -121,22 +126,11 @@ public class TenantAssignmentByEmailTests
     }
 
     [Fact]
-    public async Task ParticipantCreate_RefusesAnAddressHeldByMoreThanOneAccount()
-    {
-        // The role granted here can be TenantAdmin, so landing on the wrong record matters more.
-        EmailIsHeldBy(TwoAccountsForOnePerson());
-
-        var result = await BuildParticipantService()
-            .CreateAsync(TenantId, Email, "Test User", SystemRoles.TenantAdmin);
-
-        Assert.False(result.IsSuccess);
-        Assert.Equal(StatusCode.Conflict, result.StatusCode);
-        _userRepo.Verify(x => x.UpdateAsync(It.IsAny<string>(), It.IsAny<User>()), Times.Never);
-    }
-
-    [Fact]
     public async Task ParticipantCreate_AddsTheRole_WhenTheAddressNamesOneAccount()
     {
+        // One account holding the address settles which is meant, so there is nothing for a user
+        // id to disambiguate: an operator sent to find one would search by this same address and
+        // arrive at this same record.
         EmailIsHeldBy(Account("the-only-subject"));
 
         var result = await BuildParticipantService()
@@ -151,12 +145,93 @@ public class TenantAssignmentByEmailTests
     }
 
     [Fact]
-    public async Task ParticipantCreate_RefusesADisabledAccount()
+    public async Task ParticipantCreate_AddsAnExistingAccountWithoutRequiringAName()
+    {
+        // The name on the record stands; only a new account needs one supplied.
+        EmailIsHeldBy(Account("the-only-subject"));
+
+        var result = await BuildParticipantService()
+            .CreateAsync(TenantId, Email, name: null, SystemRoles.TenantParticipant);
+
+        Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task ParticipantCreate_RefusesAnAddressHeldByMoreThanOneAccount()
+    {
+        // The role granted here can be TenantAdmin, so landing on the wrong record matters more.
+        EmailIsHeldBy(TwoAccountsForOnePerson());
+
+        var result = await BuildParticipantService()
+            .CreateAsync(TenantId, Email, "Test User", SystemRoles.TenantAdmin);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(StatusCode.Conflict, result.StatusCode);
+        _userRepo.Verify(x => x.UpdateAsync(It.IsAny<string>(), It.IsAny<User>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ParticipantCreate_RefusesADisabledAccountFoundByAddress()
     {
         EmailIsHeldBy(Account("the-only-subject", isLockedOut: true));
 
         var result = await BuildParticipantService()
             .CreateAsync(TenantId, Email, "Test User", SystemRoles.TenantParticipant);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(StatusCode.Conflict, result.StatusCode);
+        _userRepo.Verify(x => x.UpdateAsync(It.IsAny<string>(), It.IsAny<User>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ParticipantCreate_AddsTheRole_ToTheAccountNamedByUserId()
+    {
+        AccountExists(Account("the-only-subject"));
+
+        var result = await BuildParticipantService().CreateAsync(
+            TenantId, email: null, name: null, SystemRoles.TenantParticipant,
+            userId: "the-only-subject");
+
+        Assert.True(result.IsSuccess);
+        _userRepo.Verify(
+            x => x.UpdateAsync("the-only-subject", It.Is<User>(u =>
+                u.TenantRoles.Any(tr =>
+                    tr.Tenant == TenantId && tr.Roles.Contains(SystemRoles.TenantParticipant)))),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ParticipantCreate_RefusesAnAddressInPlaceOfAUserId()
+    {
+        var result = await BuildParticipantService().CreateAsync(
+            TenantId, email: null, name: null, SystemRoles.TenantParticipant, userId: Email);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(StatusCode.BadRequest, result.StatusCode);
+        _userRepo.Verify(x => x.GetAllByUserEmailAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ParticipantCreate_ReportsAUserIdNobodyHolds()
+    {
+        _userRepo.Setup(x => x.GetByUserIdAsync("no-such-subject")).ReturnsAsync((User?)null);
+
+        var result = await BuildParticipantService().CreateAsync(
+            TenantId, email: null, name: null, SystemRoles.TenantParticipant,
+            userId: "no-such-subject");
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(StatusCode.NotFound, result.StatusCode);
+    }
+
+    [Fact]
+    public async Task ParticipantCreate_RefusesADisabledAccount()
+    {
+        AccountExists(Account("the-only-subject", isLockedOut: true));
+
+        var result = await BuildParticipantService().CreateAsync(
+            TenantId, email: null, name: null, SystemRoles.TenantParticipant,
+            userId: "the-only-subject");
 
         Assert.False(result.IsSuccess);
         Assert.Equal(StatusCode.Conflict, result.StatusCode);

--- a/XiansAi.Server.Tests/UnitTests/Shared/Services/TenantOidcConfigServiceValidationTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Shared/Services/TenantOidcConfigServiceValidationTests.cs
@@ -137,11 +137,11 @@ public class TenantOidcConfigServiceValidationTests
     }
 
     [Fact]
-    public async Task ProviderWithoutAnAudienceIsStillAccepted()
+    public async Task ProviderWithoutAnAudienceIsRejected()
     {
-        // Existing configurations were never required to declare an audience, so refusing here
-        // would block those tenants from making unrelated edits. It is warned about instead, and
-        // only becomes a hard failure once Auth:RequireOidcAudience is enabled.
+        // Without one the provider accepts anything its issuer signed, including a token minted for
+        // an unrelated application there — and a UserApi sign-in turns a valid token into tenant
+        // membership.
         var config = ConfigWith("""
             {
               "issuer": "https://login.example.com",
@@ -151,7 +151,46 @@ public class TenantOidcConfigServiceValidationTests
 
         var result = await CreateService().UpsertAsync(TenantId, config, "admin");
 
-        Assert.True(result.IsSuccess);
+        Assert.False(result.IsSuccess);
+        Assert.Contains("expectedAudience", result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task ProviderWithAnEmptyAudienceListIsRejected()
+    {
+        // An empty list checks nothing, so it must not read as having declared an audience.
+        var config = ConfigWith("""
+            {
+              "issuer": "https://login.example.com",
+              "authority": "https://login.example.com",
+              "expectedAudience": []
+            }
+            """);
+
+        var result = await CreateService().UpsertAsync(TenantId, config, "admin");
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("expectedAudience", result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task PreExistingProviderWithoutAnAudienceIsStillRejected()
+    {
+        // Deliberately not grandfathered, unlike a mutable userIdClaim. Nothing else ever forces
+        // these configurations to be revisited, so allowing unrelated edits to go through would
+        // leave them audience-less forever. Sign-in keeps working; only saving is blocked.
+        var existing = ConfigWith("""
+            {
+              "issuer": "https://login.example.com",
+              "authority": "https://login.example.com"
+            }
+            """);
+
+        var result = await CreateService(existingConfigJson: existing)
+            .UpsertAsync(TenantId, existing, "admin");
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("expectedAudience", result.ErrorMessage);
     }
 
     [Fact]

--- a/XiansAi.Server.Tests/UnitTests/Shared/Services/UserCacheInvalidationTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Shared/Services/UserCacheInvalidationTests.cs
@@ -1,0 +1,169 @@
+using Features.AgentApi.Auth;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Shared.Data.Models;
+using Shared.Providers.Auth;
+using Shared.Repositories;
+using Shared.Services;
+
+namespace Tests.UnitTests.Shared.Services;
+
+/// <summary>
+/// Disabling an account is checked when an authorization decision is made, never when a cached one
+/// is reused, so each cache in front of that check is a window during which a disabled account
+/// keeps working. These cover that the window closes on the next request instead.
+/// </summary>
+public class UserCacheInvalidationTests
+{
+    private const string UserId = "provider-subject-abc123";
+    private const string TenantId = "acme";
+
+    private readonly MemoryCache _cache = new(new MemoryCacheOptions { SizeLimit = 100 });
+    private readonly Mock<IUserRepository> _userRepo = new();
+
+    private UserCacheIndex BuildIndex() => new(_cache, NullLogger<UserCacheIndex>.Instance);
+
+    private static IConfiguration EmptyConfiguration() => new ConfigurationBuilder().Build();
+
+    [Fact]
+    public void Invalidate_RemovesEveryEntryTrackedForTheUser()
+    {
+        var index = BuildIndex();
+        _cache.Set("first", "value", new MemoryCacheEntryOptions().SetSize(1));
+        _cache.Set("second", "value", new MemoryCacheEntryOptions().SetSize(1));
+        index.Track(UserId, "first");
+        index.Track(UserId, "second");
+
+        var removed = index.Invalidate(UserId);
+
+        Assert.Equal(2, removed);
+        Assert.False(_cache.TryGetValue("first", out _));
+        Assert.False(_cache.TryGetValue("second", out _));
+    }
+
+    [Fact]
+    public void Invalidate_LeavesAnotherUsersEntriesAlone()
+    {
+        var index = BuildIndex();
+        _cache.Set("theirs", "value", new MemoryCacheEntryOptions().SetSize(1));
+        index.Track("someone-else", "theirs");
+
+        Assert.Equal(0, index.Invalidate(UserId));
+        Assert.True(_cache.TryGetValue("theirs", out _));
+    }
+
+    [Fact]
+    public void Forget_StopsTheIndexGrowingAsEntriesExpireOnTheirOwn()
+    {
+        var index = BuildIndex();
+        _cache.Set("key", "value", new MemoryCacheEntryOptions().SetSize(1));
+        index.Track(UserId, "key");
+
+        index.Forget(UserId, "key");
+
+        Assert.Equal(0, index.Invalidate(UserId));
+    }
+
+    [Fact]
+    public async Task TokenCache_InvalidatesTokensCachedByAnEarlierRequest()
+    {
+        // The cache is registered scoped, so the instance that caches a token during one request is
+        // not the instance that invalidates it when an administrator disables the account. An index
+        // belonging to either instance would be empty in the other.
+        var index = BuildIndex();
+        var cachingRequest = BuildTokenCache(index);
+        var lockingRequest = BuildTokenCache(index);
+        await cachingRequest.CacheValidation("a-token", valid: true, UserId, new[] { TenantId });
+
+        await lockingRequest.InvalidateUserTokens(UserId);
+
+        var (found, _, _, _) = await cachingRequest.GetValidation("a-token");
+        Assert.False(found);
+    }
+
+    private MemoryTokenValidationCache BuildTokenCache(IUserCacheIndex index) =>
+        new(_cache, index, NullLogger<MemoryTokenValidationCache>.Instance, EmptyConfiguration());
+
+    [Fact]
+    public async Task RoleCache_DropsRolesForEveryTenantOnInvalidation()
+    {
+        var index = BuildIndex();
+        _userRepo.Setup(x => x.GetUserRolesAsync(UserId, It.IsAny<string>()))
+            .ReturnsAsync(new List<string> { SystemRoles.TenantAdmin });
+        var roleCache = new RoleCacheService(_cache, _userRepo.Object, index);
+        await roleCache.GetUserRolesAsync(UserId, TenantId);
+        await roleCache.GetUserRolesAsync(UserId, "other-tenant");
+
+        index.Invalidate(UserId);
+
+        // Both tenants are re-read, including the one the record no longer lists a membership for,
+        // which the caller could not have worked out from the record alone.
+        _userRepo.Invocations.Clear();
+        await roleCache.GetUserRolesAsync(UserId, TenantId);
+        await roleCache.GetUserRolesAsync(UserId, "other-tenant");
+        _userRepo.Verify(x => x.GetUserRolesAsync(UserId, It.IsAny<string>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public void CertificateCache_DropsAValidatedCertificateWhenItsAccountIsDisabled()
+    {
+        // The entry carries the roles and the SysAdmin flag, so a hit never revisits the record and
+        // the agent would otherwise keep running for the lifetime of the entry.
+        var index = BuildIndex();
+        var certCache = new MemoryCertificateValidationCache(
+            _cache, index, NullLogger<MemoryCertificateValidationCache>.Instance, EmptyConfiguration());
+        certCache.CacheValidation("THUMBPRINT", new CachedCertificateValidation
+        {
+            IsValid = true,
+            TenantId = TenantId,
+            UserId = UserId,
+            Roles = new[] { SystemRoles.TenantAdmin }
+        });
+
+        index.Invalidate(UserId);
+
+        var (found, _) = certCache.GetValidation("THUMBPRINT");
+        Assert.False(found);
+    }
+
+    [Fact]
+    public async Task Invalidator_AlsoDropsTheAccountsSharingTheAddress()
+    {
+        // An address that names more than one account resolves through all of them, so disabling
+        // one changes what the others resolve to — their cached decisions are stale as well.
+        var index = BuildIndex();
+        _cache.Set("theirs", "value", new MemoryCacheEntryOptions().SetSize(1));
+        index.Track("the-sibling", "theirs");
+        _userRepo.Setup(x => x.GetAllByUserEmailAsync("shared@example.com"))
+            .ReturnsAsync(new List<User>
+            {
+                new() { UserId = UserId, Email = "shared@example.com" },
+                new() { UserId = "the-sibling", Email = "shared@example.com" }
+            });
+
+        await BuildInvalidator(index).InvalidateAsync(
+            new User { UserId = UserId, Email = "shared@example.com" });
+
+        Assert.False(_cache.TryGetValue("theirs", out _));
+    }
+
+    [Fact]
+    public async Task Invalidator_StillDropsTheAccountsOwnEntries_WhenTheSiblingLookupFails()
+    {
+        var index = BuildIndex();
+        _cache.Set("mine", "value", new MemoryCacheEntryOptions().SetSize(1));
+        index.Track(UserId, "mine");
+        _userRepo.Setup(x => x.GetAllByUserEmailAsync(It.IsAny<string>()))
+            .ThrowsAsync(new InvalidOperationException("the database is unreachable"));
+
+        await BuildInvalidator(index).InvalidateAsync(
+            new User { UserId = UserId, Email = "shared@example.com" });
+
+        Assert.False(_cache.TryGetValue("mine", out _));
+    }
+
+    private UserAuthorizationInvalidator BuildInvalidator(IUserCacheIndex index) =>
+        new(index, _userRepo.Object, NullLogger<UserAuthorizationInvalidator>.Instance);
+}

--- a/XiansAi.Server.Tests/UnitTests/Shared/Services/UserManagementServiceEmailUniquenessTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Shared/Services/UserManagementServiceEmailUniquenessTests.cs
@@ -39,6 +39,7 @@ public class UserManagementServiceEmailUniquenessTests
             Mock.Of<IEmailService>(),
             Mock.Of<IJwtClaimsExtractor>(),
             Mock.Of<ITokenValidationCache>(),
+            Mock.Of<IUserAuthorizationInvalidator>(),
             NullLogger<UserManagementService>.Instance);
     }
 
@@ -228,23 +229,6 @@ public class UserManagementServiceEmailUniquenessTests
 
         Assert.True(result.IsSuccess);
         _userRepo.Verify(x => x.CreateAsync(It.Is<User>(u => u.UserId == "google-subject-123")), Times.Once);
-    }
-
-    [Fact]
-    public async Task CreateNewUser_RecordsWhetherTheProviderVouchedForTheAddress()
-    {
-        ArrangeCreatable();
-
-        await BuildService().CreateNewUser(new UserDto
-        {
-            UserId = "google-subject-123",
-            Email = "fresh@example.com",
-            EmailVerified = true,
-            Name = "Test User",
-            ProviderAuthority = Provider
-        });
-
-        _userRepo.Verify(x => x.CreateAsync(It.Is<User>(u => u.EmailVerified)), Times.Once);
     }
 
     [Theory]

--- a/XiansAi.Server.Tests/UnitTests/Shared/Services/UserManagementServiceEmailUniquenessTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Shared/Services/UserManagementServiceEmailUniquenessTests.cs
@@ -12,15 +12,20 @@ using Shared.Utils.Services;
 namespace Tests.UnitTests.Shared.Services;
 
 /// <summary>
-/// Email is unique across the system, and this is the single creation path everything funnels
-/// through.
+/// The single creation path everything funnels through, and where it is decided whether an address
+/// may be held twice.
 ///
-/// The invariant is load-bearing rather than cosmetic: <c>GetByUserEmailAsync</c> returns the first
-/// match, and both certificate authentication and ownership transfer accept an email in place of a
-/// user id. A second record sharing an email makes those resolve to an arbitrary one of the two.
+/// One person can legitimately hold an account at two identity providers, so an address shared
+/// across providers is allowed. Two records under the same provider are not, since there the
+/// address really does name one account. An address a system administrator holds is neither: the
+/// record is created disabled, so the person is not turned away at the door and the role is not
+/// taken from the account that has it, until somebody decides which of those should happen.
 /// </summary>
 public class UserManagementServiceEmailUniquenessTests
 {
+    private const string Provider = "https://login.example.com";
+    private const string OtherProvider = "https://b2c.example.com";
+
     private readonly Mock<IUserRepository> _userRepo = new();
 
     private UserManagementService BuildService()
@@ -40,24 +45,37 @@ public class UserManagementServiceEmailUniquenessTests
     private void ArrangeCreatable()
     {
         _userRepo.Setup(x => x.GetByUserIdAsync(It.IsAny<string>())).ReturnsAsync((User?)null);
-        _userRepo.Setup(x => x.GetByUserEmailAsync(It.IsAny<string>())).ReturnsAsync((User?)null);
+        _userRepo.Setup(x => x.GetAllByUserEmailAsync(It.IsAny<string>())).ReturnsAsync(new List<User>());
         _userRepo.Setup(x => x.GetAnyUserAsync()).ReturnsAsync(new User { UserId = "someone-else" });
         _userRepo.Setup(x => x.CreateAsync(It.IsAny<User>())).ReturnsAsync(true);
     }
 
-    [Fact]
-    public async Task CreateNewUser_RefusesAnEmailThatBelongsToADifferentSubject()
+    private void EmailIsHeldBy(string email, params User[] owners)
     {
-        ArrangeCreatable();
-        _userRepo.Setup(x => x.GetByUserEmailAsync("taken@example.com"))
-            .ReturnsAsync(new User { UserId = "some-other-subject", Email = "taken@example.com" });
+        _userRepo.Setup(x => x.GetAllByUserEmailAsync(email)).ReturnsAsync(owners.ToList());
+    }
 
-        var result = await BuildService().CreateNewUser(new UserDto
+    private Task<ServiceResult<bool>> Create(string email, string? providerAuthority = Provider) =>
+        BuildService().CreateNewUser(new UserDto
         {
             UserId = "google-subject-123",
-            Email = "taken@example.com",
-            Name = "Test User"
+            Email = email,
+            Name = "Test User",
+            ProviderAuthority = providerAuthority
         });
+
+    [Fact]
+    public async Task CreateNewUser_RefusesAnEmailAlreadyHeldAtTheSameProvider()
+    {
+        ArrangeCreatable();
+        EmailIsHeldBy("taken@example.com", new User
+        {
+            UserId = "some-other-subject",
+            Email = "taken@example.com",
+            ProviderAuthority = Provider
+        });
+
+        var result = await Create("taken@example.com");
 
         Assert.False(result.IsSuccess);
         Assert.Equal(StatusCode.Conflict, result.StatusCode);
@@ -65,19 +83,168 @@ public class UserManagementServiceEmailUniquenessTests
     }
 
     [Fact]
+    public async Task CreateNewUser_AcceptsAnEmailHeldAtADifferentProvider()
+    {
+        // The case this exists for: the same person signing in through a second directory. Their
+        // two records resolve as one identity where a credential names only the address.
+        ArrangeCreatable();
+        EmailIsHeldBy("shared@example.com", new User
+        {
+            UserId = "some-other-subject",
+            Email = "shared@example.com",
+            ProviderAuthority = OtherProvider
+        });
+
+        var result = await Create("shared@example.com");
+
+        Assert.True(result.IsSuccess);
+        _userRepo.Verify(x => x.CreateAsync(It.Is<User>(u => u.UserId == "google-subject-123")), Times.Once);
+    }
+
+    /// <summary>An administrator at another directory already holding the address.</summary>
+    private void EmailIsHeldByASystemAdministrator(string email)
+    {
+        EmailIsHeldBy(email, new User
+        {
+            UserId = "the-admin",
+            Email = email,
+            ProviderAuthority = OtherProvider,
+            IsSysAdmin = true
+        });
+    }
+
+    [Fact]
+    public async Task CreateNewUser_CreatesADisabledRecord_WhenASystemAdministratorHoldsTheEmail()
+    {
+        // Refusing would leave a real person at a second directory unable to sign in at all, with
+        // no way through that does not involve deleting somebody's account. Creating it enabled
+        // would take SysAdmin off the account that has it. Disabled is neither, and waits.
+        ArrangeCreatable();
+        EmailIsHeldByASystemAdministrator("admin@example.com");
+
+        var result = await Create("admin@example.com");
+
+        Assert.True(result.IsSuccess);
+        _userRepo.Verify(
+            x => x.CreateAsync(It.Is<User>(u => u.IsLockedOut && !u.IsSysAdmin)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateNewUser_SaysWhyTheDisabledRecordIsDisabled()
+    {
+        // The consequence of enabling it lands on a different account than the one being enabled,
+        // so it has to be written down where whoever enables it will read it.
+        ArrangeCreatable();
+        EmailIsHeldByASystemAdministrator("admin@example.com");
+
+        await Create("admin@example.com");
+
+        _userRepo.Verify(
+            x => x.CreateAsync(It.Is<User>(u =>
+                u.LockedOutReason != null
+                && u.LockedOutReason.Contains("the-admin")
+                && u.LockedOutAt != null)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateNewUser_StillRefusesASystemAdministratorsEmailAtTheSameProvider()
+    {
+        // Within one directory the address really does name one account, so this is a duplicate
+        // rather than a second account for the same person, and there is nothing to review.
+        ArrangeCreatable();
+        EmailIsHeldBy("admin@example.com", new User
+        {
+            UserId = "the-admin",
+            Email = "admin@example.com",
+            ProviderAuthority = Provider,
+            IsSysAdmin = true
+        });
+
+        var result = await Create("admin@example.com");
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(StatusCode.Conflict, result.StatusCode);
+        _userRepo.Verify(x => x.CreateAsync(It.IsAny<User>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateNewUser_LeavesAnOrdinaryRecordEnabled()
+    {
+        ArrangeCreatable();
+
+        await Create("fresh@example.com");
+
+        _userRepo.Verify(
+            x => x.CreateAsync(It.Is<User>(u => !u.IsLockedOut && u.LockedOutReason == null)),
+            Times.Once);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task CreateNewUser_RefusesWhenEitherSidesProviderIsUnknown(string? incomingAuthority)
+    {
+        // Records that cannot be told apart have to be assumed to be the same account, or an
+        // unpinned record would be a way around the rule.
+        ArrangeCreatable();
+        EmailIsHeldBy("taken@example.com", new User
+        {
+            UserId = "some-other-subject",
+            Email = "taken@example.com",
+            ProviderAuthority = Provider
+        });
+
+        var result = await Create("taken@example.com", incomingAuthority);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(StatusCode.Conflict, result.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateNewUser_RefusesWhenTheExistingRecordHasNoPinnedProvider()
+    {
+        ArrangeCreatable();
+        EmailIsHeldBy("taken@example.com", new User
+        {
+            UserId = "legacy-subject",
+            Email = "taken@example.com",
+            ProviderAuthority = null
+        });
+
+        var result = await Create("taken@example.com");
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(StatusCode.Conflict, result.StatusCode);
+    }
+
+    [Fact]
     public async Task CreateNewUser_AcceptsAnUnusedEmail()
     {
         ArrangeCreatable();
 
-        var result = await BuildService().CreateNewUser(new UserDto
-        {
-            UserId = "google-subject-123",
-            Email = "fresh@example.com",
-            Name = "Test User"
-        });
+        var result = await Create("fresh@example.com");
 
         Assert.True(result.IsSuccess);
         _userRepo.Verify(x => x.CreateAsync(It.Is<User>(u => u.UserId == "google-subject-123")), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateNewUser_RecordsWhetherTheProviderVouchedForTheAddress()
+    {
+        ArrangeCreatable();
+
+        await BuildService().CreateNewUser(new UserDto
+        {
+            UserId = "google-subject-123",
+            Email = "fresh@example.com",
+            EmailVerified = true,
+            Name = "Test User",
+            ProviderAuthority = Provider
+        });
+
+        _userRepo.Verify(x => x.CreateAsync(It.Is<User>(u => u.EmailVerified)), Times.Once);
     }
 
     [Theory]
@@ -89,15 +256,10 @@ public class UserManagementServiceEmailUniquenessTests
         // would refuse creation for all of them.
         ArrangeCreatable();
 
-        var result = await BuildService().CreateNewUser(new UserDto
-        {
-            UserId = "subject-with-no-email",
-            Email = email,
-            Name = "Test User"
-        });
+        var result = await Create(email);
 
         Assert.True(result.IsSuccess);
-        _userRepo.Verify(x => x.GetByUserEmailAsync(It.IsAny<string>()), Times.Never);
+        _userRepo.Verify(x => x.GetAllByUserEmailAsync(It.IsAny<string>()), Times.Never);
     }
 
     [Fact]
@@ -107,12 +269,7 @@ public class UserManagementServiceEmailUniquenessTests
         _userRepo.Setup(x => x.GetByUserIdAsync("google-subject-123"))
             .ReturnsAsync(new User { UserId = "google-subject-123" });
 
-        var result = await BuildService().CreateNewUser(new UserDto
-        {
-            UserId = "google-subject-123",
-            Email = "fresh@example.com",
-            Name = "Test User"
-        });
+        var result = await Create("fresh@example.com");
 
         Assert.False(result.IsSuccess);
         Assert.Equal(StatusCode.Conflict, result.StatusCode);

--- a/XiansAi.Server.Tests/UnitTests/Shared/Services/UserTenantServiceApprovedTenantsTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Shared/Services/UserTenantServiceApprovedTenantsTests.cs
@@ -312,7 +312,7 @@ public class UserTenantServiceApprovedTenantsTests
 
         Assert.True(result.IsSuccess);
         Assert.Equal("acme", Assert.Single(result.Data!.Tenants).TenantId);
-        Assert.Equal("user@example.com", result.Data.Email);
+        Assert.Equal("user@example.com", result.Data.ConversationEmail);
     }
 
     [Fact]
@@ -579,7 +579,11 @@ public class UserTenantServiceApprovedTenantsTests
         var result = await BuildService().EnsureUserAndGetApprovedTenants(IdentityFor());
 
         Assert.True(result.IsSuccess);
-        Assert.Null(result.Data!.Email);
+        Assert.Null(result.Data!.ConversationEmail);
+
+        // Still reported as the account's address, so the caller stays recognisable when they name
+        // themselves by it — it just does not become the namespace.
+        Assert.Equal("shared@example.com", result.Data.AccountEmail);
     }
 
     [Fact]

--- a/XiansAi.Server.Tests/UnitTests/Shared/Services/UserTenantServiceApprovedTenantsTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Shared/Services/UserTenantServiceApprovedTenantsTests.cs
@@ -534,14 +534,14 @@ public class UserTenantServiceApprovedTenantsTests
         await BuildService().EnsureUserAndGetApprovedTenants(IdentityFor());
 
         _userRepo.Verify(
-            x => x.UpdateProfileFieldsAsync(UserId, "user@example.com", false, "Test User"),
+            x => x.UpdateProfileFieldsAsync(UserId, "user@example.com", "Test User"),
             Times.Once);
     }
 
     [Fact]
     public async Task EnsureUserAndGetApprovedTenants_DoesNotOverwriteAnEmailTheRecordAlreadyHas()
     {
-        // An admin may have set it deliberately, and an unverified claim must never replace it.
+        // An admin may have set it deliberately, so a token claim must never replace it.
         _userRepo.Setup(x => x.GetByUserIdAsync(UserId)).ReturnsAsync(new User
         {
             UserId = UserId,
@@ -556,7 +556,7 @@ public class UserTenantServiceApprovedTenantsTests
 
         _userRepo.Verify(
             x => x.UpdateProfileFieldsAsync(
-                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<bool?>(), It.IsAny<string?>()),
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>()),
             Times.Never);
     }
 

--- a/XiansAi.Server.Tests/UnitTests/Shared/Services/UserTenantServiceApprovedTenantsTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Shared/Services/UserTenantServiceApprovedTenantsTests.cs
@@ -44,6 +44,40 @@ public class UserTenantServiceApprovedTenantsTests
             CreatedBy = "test-user"
         };
 
+    private static SignInIdentity IdentityFor(
+        string userId = UserId,
+        string? email = "user@example.com",
+        string? name = "Test User",
+        string? authority = Authority) =>
+        new() { UserId = userId, Email = email, Name = name, ProviderAuthority = authority };
+
+    /// <summary>The pending membership every caller but the UserApi sign-in path records.</summary>
+    private void VerifyPendingMembershipRecorded(string tenantId, Times times) =>
+        _userRepo.Verify(
+            x => x.AddTenantRoleIfAbsentAsync(UserId, tenantId, false, It.Is<IReadOnlyList<string>>(r => r.Count == 0)),
+            times);
+
+    private void VerifyNoMembershipRecorded() =>
+        _userRepo.Verify(
+            x => x.AddTenantRoleIfAbsentAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<IReadOnlyList<string>>()),
+            Times.Never);
+
+    /// <summary>
+    /// A concurrent request that creates the record first: the lookup finds nothing until the
+    /// creation attempt loses the race, and finds it from then on. Modelled as state rather than a
+    /// fixed sequence of answers, so it does not depend on how many times the record is read.
+    /// </summary>
+    private void ArrangeLostRaceToCreate(User racedUser)
+    {
+        var exists = false;
+        _userRepo.Setup(x => x.GetByUserIdAsync(UserId)).ReturnsAsync(() => exists ? racedUser : null);
+        _userManagementService
+            .Setup(x => x.CreateNewUser(It.IsAny<UserDto>(), It.IsAny<bool>()))
+            .Callback(() => exists = true)
+            .ReturnsAsync(ServiceResult<bool>.Conflict("User already exists"));
+    }
+
     /// <summary>Lets an unpinned record adopt whichever authority is presented.</summary>
     private void AllowPinAdoption()
     {
@@ -55,7 +89,8 @@ public class UserTenantServiceApprovedTenantsTests
     [Fact]
     public async Task EnsureUserAndGetApprovedTenants_RejectsAnEmptyUserId()
     {
-        var result = await BuildService().EnsureUserAndGetApprovedTenants(string.Empty, null, null, Authority);
+        var result = await BuildService().EnsureUserAndGetApprovedTenants(
+            IdentityFor(userId: string.Empty, email: null, name: null));
 
         Assert.False(result.IsSuccess);
         Assert.Equal(StatusCode.Unauthorized, result.StatusCode);
@@ -64,7 +99,8 @@ public class UserTenantServiceApprovedTenantsTests
     [Fact]
     public async Task EnsureUserAndGetApprovedTenants_RejectsATokenWithNoProviderAuthority()
     {
-        var result = await BuildService().EnsureUserAndGetApprovedTenants(UserId, null, null, null);
+        var result = await BuildService().EnsureUserAndGetApprovedTenants(
+            IdentityFor(email: null, name: null, authority: null));
 
         Assert.False(result.IsSuccess);
         Assert.Equal(StatusCode.Unauthorized, result.StatusCode);
@@ -81,8 +117,7 @@ public class UserTenantServiceApprovedTenantsTests
             .Setup(x => x.CreateNewUser(It.IsAny<UserDto>(), It.IsAny<bool>()))
             .ReturnsAsync(ServiceResult<bool>.Success(true));
 
-        var result = await BuildService().EnsureUserAndGetApprovedTenants(
-            UserId, "user@example.com", "Test User", Authority);
+        var result = await BuildService().EnsureUserAndGetApprovedTenants(IdentityFor());
 
         Assert.True(result.IsSuccess);
         Assert.Empty(result.Data!.Tenants);
@@ -112,9 +147,9 @@ public class UserTenantServiceApprovedTenantsTests
         ArrangeFirstTimeUserRequesting("acme");
 
         await BuildService().EnsureUserAndGetApprovedTenants(
-            UserId, "user@example.com", "Test User", Authority, "acme");
+            IdentityFor(), "acme");
 
-        _userRepo.Verify(x => x.AddPendingTenantRoleIfAbsentAsync(UserId, "acme"), Times.Once);
+        VerifyPendingMembershipRecorded("acme", Times.Once());
     }
 
     [Fact]
@@ -123,7 +158,7 @@ public class UserTenantServiceApprovedTenantsTests
         ArrangeFirstTimeUserRequesting("acme");
 
         var result = await BuildService().EnsureUserAndGetApprovedTenants(
-            UserId, "user@example.com", "Test User", Authority, "acme");
+            IdentityFor(), "acme");
 
         // Being registered as pending must not put the tenant in the approved list, or the caller
         // would let them straight in.
@@ -145,9 +180,9 @@ public class UserTenantServiceApprovedTenantsTests
             .ReturnsAsync(BuildTenant("id-1", "acme", "Tenant", true));
 
         await BuildService().EnsureUserAndGetApprovedTenants(
-            UserId, "user@example.com", "Test User", Authority, "ACME");
+            IdentityFor(), "ACME");
 
-        _userRepo.Verify(x => x.AddPendingTenantRoleIfAbsentAsync(UserId, "acme"), Times.Once);
+        VerifyPendingMembershipRecorded("acme", Times.Once());
     }
 
     [Theory]
@@ -158,9 +193,9 @@ public class UserTenantServiceApprovedTenantsTests
         ArrangeFirstTimeUserRequesting("acme");
 
         await BuildService().EnsureUserAndGetApprovedTenants(
-            UserId, "user@example.com", "Test User", Authority, tenantId);
+            IdentityFor(), tenantId);
 
-        _userRepo.Verify(x => x.AddPendingTenantRoleIfAbsentAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        VerifyNoMembershipRecorded();
     }
 
     [Fact]
@@ -172,9 +207,9 @@ public class UserTenantServiceApprovedTenantsTests
         _tenantRepo.Setup(x => x.GetByTenantIdAsync("does-not-exist")).ReturnsAsync((Tenant?)null);
 
         await BuildService().EnsureUserAndGetApprovedTenants(
-            UserId, "user@example.com", "Test User", Authority, "does-not-exist");
+            IdentityFor(), "does-not-exist");
 
-        _userRepo.Verify(x => x.AddPendingTenantRoleIfAbsentAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        VerifyNoMembershipRecorded();
     }
 
     [Fact]
@@ -183,9 +218,9 @@ public class UserTenantServiceApprovedTenantsTests
         ArrangeFirstTimeUserRequesting("acme", tenantEnabled: false);
 
         await BuildService().EnsureUserAndGetApprovedTenants(
-            UserId, "user@example.com", "Test User", Authority, "acme");
+            IdentityFor(), "acme");
 
-        _userRepo.Verify(x => x.AddPendingTenantRoleIfAbsentAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        VerifyNoMembershipRecorded();
     }
 
     [Fact]
@@ -207,9 +242,9 @@ public class UserTenantServiceApprovedTenantsTests
             .ReturnsAsync(BuildTenant("id-1", "acme", "Tenant", true));
 
         await BuildService().EnsureUserAndGetApprovedTenants(
-            UserId, "user@example.com", "Test User", Authority, "acme");
+            IdentityFor(), "acme");
 
-        _userRepo.Verify(x => x.AddPendingTenantRoleIfAbsentAsync(UserId, "acme"), Times.Once);
+        VerifyPendingMembershipRecorded("acme", Times.Once());
     }
 
     [Fact]
@@ -230,11 +265,12 @@ public class UserTenantServiceApprovedTenantsTests
             .Setup(x => x.GetByTenantIdAsync("acme"))
             .ReturnsAsync(BuildTenant("id-1", "acme", "Tenant", true));
         _userRepo
-            .Setup(x => x.AddPendingTenantRoleIfAbsentAsync(UserId, "acme"))
+            .Setup(x => x.AddTenantRoleIfAbsentAsync(
+                UserId, "acme", It.IsAny<bool>(), It.IsAny<IReadOnlyList<string>>()))
             .ThrowsAsync(new Exception("mongo unavailable"));
 
         var result = await BuildService().EnsureUserAndGetApprovedTenants(
-            UserId, "user@example.com", "Test User", Authority, "acme");
+            IdentityFor(), "acme");
 
         Assert.True(result.IsSuccess);
         Assert.Equal("other", Assert.Single(result.Data!.Tenants).TenantId);
@@ -252,11 +288,11 @@ public class UserTenantServiceApprovedTenantsTests
             .ReturnsAsync(ServiceResult<bool>.Conflict("A user with this email already exists"));
 
         var result = await BuildService().EnsureUserAndGetApprovedTenants(
-            UserId, "taken@example.com", "Test User", Authority, "acme");
+            IdentityFor(email: "taken@example.com"), "acme");
 
         Assert.False(result.IsSuccess);
         Assert.Equal(StatusCode.Unauthorized, result.StatusCode);
-        _userRepo.Verify(x => x.AddPendingTenantRoleIfAbsentAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        VerifyNoMembershipRecorded();
     }
 
     [Fact]
@@ -264,22 +300,15 @@ public class UserTenantServiceApprovedTenantsTests
     {
         // Same Conflict from the creator, but here the record really is this subject's, so the
         // sign-in continues rather than being mistaken for an email collision.
-        var racedUser = new User { UserId = UserId, ProviderAuthority = Authority, Email = "user@example.com" };
-        _userRepo.SetupSequence(x => x.GetByUserIdAsync(UserId))
-            .ReturnsAsync((User?)null)
-            .ReturnsAsync(racedUser)
-            .ReturnsAsync(racedUser);
-        _userRepo.Setup(x => x.IsSysAdmin(UserId)).ReturnsAsync(false);
+        ArrangeLostRaceToCreate(
+            new User { UserId = UserId, ProviderAuthority = Authority, Email = "user@example.com" });
         _userRepo.Setup(x => x.GetUserTenantsAsync(UserId))
             .ReturnsAsync(new List<TenantInfoDto> { new() { TenantId = "acme", Name = "Acme" } });
-        _userManagementService
-            .Setup(x => x.CreateNewUser(It.IsAny<UserDto>(), It.IsAny<bool>()))
-            .ReturnsAsync(ServiceResult<bool>.Conflict("User already exists"));
         _tenantRepo.Setup(x => x.GetByTenantIdAsync("acme"))
             .ReturnsAsync(BuildTenant("id-1", "acme", "Acme", true));
 
         var result = await BuildService().EnsureUserAndGetApprovedTenants(
-            UserId, "user@example.com", "Test User", Authority, "acme");
+            IdentityFor(), "acme");
 
         Assert.True(result.IsSuccess);
         Assert.Equal("acme", Assert.Single(result.Data!.Tenants).TenantId);
@@ -296,7 +325,7 @@ public class UserTenantServiceApprovedTenantsTests
             .Setup(x => x.CreateNewUser(It.IsAny<UserDto>(), It.IsAny<bool>()))
             .ReturnsAsync(ServiceResult<bool>.Success(true));
 
-        await BuildService().EnsureUserAndGetApprovedTenants(UserId, "user@example.com", "Test User", Authority);
+        await BuildService().EnsureUserAndGetApprovedTenants(IdentityFor());
 
         _userManagementService.Verify(
             x => x.CreateNewUser(It.Is<UserDto>(u => u.UserId == UserId), false),
@@ -313,7 +342,7 @@ public class UserTenantServiceApprovedTenantsTests
             .Setup(x => x.CreateNewUser(It.IsAny<UserDto>(), It.IsAny<bool>()))
             .ReturnsAsync(ServiceResult<bool>.Success(true));
 
-        await BuildService().EnsureUserAndGetApprovedTenants(UserId, null, null, Authority);
+        await BuildService().EnsureUserAndGetApprovedTenants(IdentityFor(email: null, name: null));
 
         _userManagementService.Verify(
             x => x.CreateNewUser(It.Is<UserDto>(u => u.ProviderAuthority == Authority), false),
@@ -328,7 +357,7 @@ public class UserTenantServiceApprovedTenantsTests
         _userRepo.Setup(x => x.IsSysAdmin(UserId)).ReturnsAsync(false);
         _userRepo.Setup(x => x.GetUserTenantsAsync(UserId)).ReturnsAsync(new List<TenantInfoDto>());
 
-        await BuildService().EnsureUserAndGetApprovedTenants(UserId, null, null, Authority);
+        await BuildService().EnsureUserAndGetApprovedTenants(IdentityFor(email: null, name: null));
 
         _userManagementService.Verify(
             x => x.CreateNewUser(It.IsAny<UserDto>(), It.IsAny<bool>()),
@@ -338,19 +367,12 @@ public class UserTenantServiceApprovedTenantsTests
     [Fact]
     public async Task EnsureUserAndGetApprovedTenants_ToleratesAConcurrentProvisioningConflict()
     {
-        var racedUser = new User { UserId = UserId, ProviderAuthority = Authority };
-        _userRepo.SetupSequence(x => x.GetByUserIdAsync(UserId))
-            .ReturnsAsync((User?)null)
-            .ReturnsAsync(racedUser)
-            .ReturnsAsync(racedUser);
-        _userRepo.Setup(x => x.IsSysAdmin(UserId)).ReturnsAsync(false);
+        ArrangeLostRaceToCreate(new User { UserId = UserId, ProviderAuthority = Authority });
         _userRepo.Setup(x => x.GetUserTenantsAsync(UserId))
             .ReturnsAsync(new List<TenantInfoDto> { new() { TenantId = "tenant-a", Name = "Tenant A" } });
-        _userManagementService
-            .Setup(x => x.CreateNewUser(It.IsAny<UserDto>(), It.IsAny<bool>()))
-            .ReturnsAsync(ServiceResult<bool>.Conflict("User already exists"));
 
-        var result = await BuildService().EnsureUserAndGetApprovedTenants(UserId, null, null, Authority);
+        var result = await BuildService().EnsureUserAndGetApprovedTenants(
+            IdentityFor(email: null, name: null));
 
         Assert.True(result.IsSuccess);
         Assert.Equal("tenant-a", Assert.Single(result.Data!.Tenants).TenantId);
@@ -364,7 +386,8 @@ public class UserTenantServiceApprovedTenantsTests
             .Setup(x => x.CreateNewUser(It.IsAny<UserDto>(), It.IsAny<bool>()))
             .ReturnsAsync(ServiceResult<bool>.InternalServerError("database unavailable"));
 
-        var result = await BuildService().EnsureUserAndGetApprovedTenants(UserId, null, null, Authority);
+        var result = await BuildService().EnsureUserAndGetApprovedTenants(
+            IdentityFor(email: null, name: null));
 
         Assert.False(result.IsSuccess);
         _userRepo.Verify(x => x.GetUserTenantsAsync(It.IsAny<string>()), Times.Never);
@@ -378,7 +401,7 @@ public class UserTenantServiceApprovedTenantsTests
             .ReturnsAsync(new User { UserId = UserId, ProviderAuthority = Authority });
 
         var result = await BuildService().EnsureUserAndGetApprovedTenants(
-            UserId, null, null, "https://evil.example");
+            IdentityFor(email: null, name: null, authority: "https://evil.example"));
 
         Assert.False(result.IsSuccess);
         Assert.Equal(StatusCode.Unauthorized, result.StatusCode);
@@ -393,7 +416,8 @@ public class UserTenantServiceApprovedTenantsTests
         _userRepo.Setup(x => x.IsSysAdmin(UserId)).ReturnsAsync(false);
         _userRepo.Setup(x => x.GetUserTenantsAsync(UserId)).ReturnsAsync(new List<TenantInfoDto>());
 
-        var result = await BuildService().EnsureUserAndGetApprovedTenants(UserId, null, null, Authority);
+        var result = await BuildService().EnsureUserAndGetApprovedTenants(
+            IdentityFor(email: null, name: null));
 
         Assert.True(result.IsSuccess);
     }
@@ -407,7 +431,8 @@ public class UserTenantServiceApprovedTenantsTests
         _userRepo.Setup(x => x.GetUserTenantsAsync(UserId)).ReturnsAsync(new List<TenantInfoDto>());
         AllowPinAdoption();
 
-        var result = await BuildService().EnsureUserAndGetApprovedTenants(UserId, null, null, Authority);
+        var result = await BuildService().EnsureUserAndGetApprovedTenants(
+            IdentityFor(email: null, name: null));
 
         Assert.True(result.IsSuccess);
         _userRepo.Verify(x => x.PinProviderAuthorityIfUnsetAsync(UserId, Authority), Times.Once);
@@ -422,7 +447,8 @@ public class UserTenantServiceApprovedTenantsTests
             .Setup(x => x.PinProviderAuthorityIfUnsetAsync(UserId, It.IsAny<string>()))
             .ReturnsAsync("https://someone-else.example");
 
-        var result = await BuildService().EnsureUserAndGetApprovedTenants(UserId, null, null, Authority);
+        var result = await BuildService().EnsureUserAndGetApprovedTenants(
+            IdentityFor(email: null, name: null));
 
         Assert.False(result.IsSuccess);
         Assert.Equal(StatusCode.Unauthorized, result.StatusCode);
@@ -434,11 +460,11 @@ public class UserTenantServiceApprovedTenantsTests
         // Nothing pins a SysAdmin ahead of time, so refusing adoption would lock them out for good.
         _userRepo.Setup(x => x.GetByUserIdAsync(UserId))
             .ReturnsAsync(new User { UserId = UserId, ProviderAuthority = null, IsSysAdmin = true });
-        _userRepo.Setup(x => x.IsSysAdmin(UserId)).ReturnsAsync(false);
-        _userRepo.Setup(x => x.GetUserTenantsAsync(UserId)).ReturnsAsync(new List<TenantInfoDto>());
+        _tenantRepo.Setup(x => x.GetAllAsync()).ReturnsAsync(new List<Tenant>());
         AllowPinAdoption();
 
-        var result = await BuildService().EnsureUserAndGetApprovedTenants(UserId, null, null, Authority);
+        var result = await BuildService().EnsureUserAndGetApprovedTenants(
+            IdentityFor(email: null, name: null));
 
         Assert.True(result.IsSuccess);
         _userRepo.Verify(x => x.PinProviderAuthorityIfUnsetAsync(UserId, Authority), Times.Once);
@@ -451,10 +477,109 @@ public class UserTenantServiceApprovedTenantsTests
             .ReturnsAsync(new User { UserId = UserId, ProviderAuthority = Authority, IsSysAdmin = true });
 
         var result = await BuildService().EnsureUserAndGetApprovedTenants(
-            UserId, null, null, "https://evil.example");
+            IdentityFor(email: null, name: null, authority: "https://evil.example"));
 
         Assert.False(result.IsSuccess);
         Assert.Equal(StatusCode.Unauthorized, result.StatusCode);
+    }
+
+    [Fact]
+    public async Task EnsureUserAndGetApprovedTenants_CreatesAnApprovedParticipantMembership_WhenTheCallerAsksForOne()
+    {
+        // The UserApi path validated this token against the rules the tenant configured for its own
+        // identity provider, so holding one is the tenant's own statement that this person belongs
+        // to it — there is nothing further for an admin to decide.
+        ArrangeFirstTimeUserRequesting("acme");
+
+        await BuildService().EnsureUserAndGetApprovedTenants(
+            IdentityFor(), "acme", approveNewMembership: true);
+
+        _userRepo.Verify(
+            x => x.AddTenantRoleIfAbsentAsync(UserId, "acme", true,
+                It.Is<IReadOnlyList<string>>(r => r.Single() == SystemRoles.TenantParticipant)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task EnsureUserAndGetApprovedTenants_GrantsParticipant_NotTenantUser()
+    {
+        // TenantUser would admit them to the WebAPI console, which accepts SysAdmin, TenantAdmin and
+        // TenantUser. UserApi authorizes on approved membership rather than on a role.
+        ArrangeFirstTimeUserRequesting("acme");
+
+        await BuildService().EnsureUserAndGetApprovedTenants(
+            IdentityFor(), "acme", approveNewMembership: true);
+
+        _userRepo.Verify(
+            x => x.AddTenantRoleIfAbsentAsync(UserId, "acme", It.IsAny<bool>(),
+                It.Is<IReadOnlyList<string>>(r => !r.Contains(SystemRoles.TenantUser))),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task EnsureUserAndGetApprovedTenants_FillsInAnEmailAndNameTheRecordIsMissing()
+    {
+        // Records provisioned before the address was stored have neither, and nothing else ever
+        // revisits them — the create path only runs on a first sign-in.
+        _userRepo.Setup(x => x.GetByUserIdAsync(UserId)).ReturnsAsync(new User
+        {
+            UserId = UserId,
+            ProviderAuthority = Authority,
+            Email = string.Empty,
+            Name = string.Empty
+        });
+        _userRepo.Setup(x => x.IsSysAdmin(UserId)).ReturnsAsync(false);
+        _userRepo.Setup(x => x.GetUserTenantsAsync(UserId)).ReturnsAsync(new List<TenantInfoDto>());
+
+        await BuildService().EnsureUserAndGetApprovedTenants(IdentityFor());
+
+        _userRepo.Verify(
+            x => x.UpdateProfileFieldsAsync(UserId, "user@example.com", false, "Test User"),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task EnsureUserAndGetApprovedTenants_DoesNotOverwriteAnEmailTheRecordAlreadyHas()
+    {
+        // An admin may have set it deliberately, and an unverified claim must never replace it.
+        _userRepo.Setup(x => x.GetByUserIdAsync(UserId)).ReturnsAsync(new User
+        {
+            UserId = UserId,
+            ProviderAuthority = Authority,
+            Email = "set-by-an-admin@example.com",
+            Name = "Set By An Admin"
+        });
+        _userRepo.Setup(x => x.IsSysAdmin(UserId)).ReturnsAsync(false);
+        _userRepo.Setup(x => x.GetUserTenantsAsync(UserId)).ReturnsAsync(new List<TenantInfoDto>());
+
+        await BuildService().EnsureUserAndGetApprovedTenants(IdentityFor());
+
+        _userRepo.Verify(
+            x => x.UpdateProfileFieldsAsync(
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<bool?>(), It.IsAny<string?>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task EnsureUserAndGetApprovedTenants_WithholdsASharedEmailFromTheConversationIdentity()
+    {
+        // The caller uses this as the participant id, which is the namespace their message threads
+        // live in. Two accounts sharing one would let either read the other's conversations.
+        _userRepo.Setup(x => x.GetByUserIdAsync(UserId)).ReturnsAsync(new User
+        {
+            UserId = UserId,
+            ProviderAuthority = Authority,
+            Email = "shared@example.com",
+            Name = "Test User"
+        });
+        _userRepo.Setup(x => x.IsEmailSharedAsync("shared@example.com", UserId)).ReturnsAsync(true);
+        _userRepo.Setup(x => x.IsSysAdmin(UserId)).ReturnsAsync(false);
+        _userRepo.Setup(x => x.GetUserTenantsAsync(UserId)).ReturnsAsync(new List<TenantInfoDto>());
+
+        var result = await BuildService().EnsureUserAndGetApprovedTenants(IdentityFor());
+
+        Assert.True(result.IsSuccess);
+        Assert.Null(result.Data!.Email);
     }
 
     [Fact]
@@ -473,7 +598,8 @@ public class UserTenantServiceApprovedTenantsTests
     [Fact]
     public async Task GetApprovedTenantsForUserId_ReturnsAllEnabledTenants_ForASysAdmin()
     {
-        _userRepo.Setup(x => x.IsSysAdmin(UserId)).ReturnsAsync(true);
+        _userRepo.Setup(x => x.GetByUserIdAsync(UserId))
+            .ReturnsAsync(new User { UserId = UserId, IsSysAdmin = true });
         _tenantRepo.Setup(x => x.GetAllAsync()).ReturnsAsync(new List<Tenant>
         {
             BuildTenant("000000000000000000000001", "tenant-a", "Tenant A", enabled: true),
@@ -489,11 +615,65 @@ public class UserTenantServiceApprovedTenantsTests
     [Fact]
     public async Task GetApprovedTenantsForUserId_FailsClosed_WhenTheLookupThrows()
     {
-        _userRepo.Setup(x => x.IsSysAdmin(UserId)).ThrowsAsync(new InvalidOperationException("mongo down"));
+        _userRepo.Setup(x => x.GetByUserIdAsync(UserId))
+            .ThrowsAsync(new InvalidOperationException("mongo down"));
 
         var result = await BuildService().GetApprovedTenantsForUserId(UserId);
 
         Assert.False(result.IsSuccess);
         Assert.Null(result.Data);
+    }
+
+    [Fact]
+    public async Task GetApprovedTenantsForUserId_RefusesADisabledAccount()
+    {
+        // Every sign-in door reaches its tenants through here. Only certificates were checking the
+        // flag, so an account disabled pending review could sign in everywhere else.
+        _userRepo.Setup(x => x.GetByUserIdAsync(UserId)).ReturnsAsync(new User
+        {
+            UserId = UserId,
+            IsLockedOut = true,
+            LockedOutReason = "Created disabled for review"
+        });
+
+        var result = await BuildService().GetApprovedTenantsForUserId(UserId);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(StatusCode.Unauthorized, result.StatusCode);
+        _userRepo.Verify(x => x.GetUserTenantsAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetApprovedTenantsForUserId_RefusesADisabledSysAdmin()
+    {
+        // Being a system administrator does not survive the account being turned off, or disabling
+        // one would leave them with every tenant.
+        _userRepo.Setup(x => x.GetByUserIdAsync(UserId))
+            .ReturnsAsync(new User { UserId = UserId, IsSysAdmin = true, IsLockedOut = true });
+
+        var result = await BuildService().GetApprovedTenantsForUserId(UserId);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(StatusCode.Unauthorized, result.StatusCode);
+        _tenantRepo.Verify(x => x.GetAllAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task EnsureUserAndGetApprovedTenants_RefusesADisabledAccountAsUnauthorized()
+    {
+        // Not as a server error: the account being disabled is an answer, not a breakage.
+        _userRepo.Setup(x => x.GetByUserIdAsync(UserId)).ReturnsAsync(new User
+        {
+            UserId = UserId,
+            ProviderAuthority = Authority,
+            Email = "user@example.com",
+            Name = "Test User",
+            IsLockedOut = true
+        });
+
+        var result = await BuildService().EnsureUserAndGetApprovedTenants(IdentityFor());
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(StatusCode.Unauthorized, result.StatusCode);
     }
 }

--- a/XiansAi.Server.Tests/UnitTests/Shared/Services/UserTenantServiceGroupClaimSysAdminTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Shared/Services/UserTenantServiceGroupClaimSysAdminTests.cs
@@ -1,0 +1,86 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Shared.Auth;
+using Shared.Data.Models;
+using Shared.Repositories;
+using Shared.Services;
+using Shared.Utils;
+using Shared.Utils.Services;
+
+namespace Tests.UnitTests.Shared.Services;
+
+/// <summary>
+/// SysAdmin can also follow from an Azure AD group claim, re-evaluated on every WebAPI login.
+/// Nobody decides that per user, so without a check a duplicate account whose address happens to
+/// match a real administrator's would be promoted with no one having asked. SysAdmin is not
+/// resolved from an address several accounts answer to, so the promotion is refused instead.
+/// </summary>
+public class UserTenantServiceGroupClaimSysAdminTests
+{
+    private const string UserId = "provider-subject-abc123";
+    private const string AdminGroupId = "aad-admin-group";
+    private const string Token = "a.jwt.token";
+
+    private readonly Mock<IUserRepository> _userRepo = new();
+    private readonly Mock<ITenantContext> _tenantContext = new();
+    private readonly Mock<IJwtClaimsExtractor> _jwtExtractor = new();
+
+    private UserTenantService BuildService() =>
+        new(
+            _userRepo.Object,
+            NullLogger<UserTenantService>.Instance,
+            _tenantContext.Object,
+            Mock.Of<IAuthMgtConnect>(),
+            new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?> { ["Oidc:AdminGroupIds"] = AdminGroupId })
+                .Build(),
+            Mock.Of<IUserManagementService>(),
+            Mock.Of<ITenantRepository>(),
+            _jwtExtractor.Object);
+
+    private void ArrangeLogin(string email, bool inAdminGroup, bool emailIsShared)
+    {
+        _tenantContext.SetupGet(x => x.LoggedInUser).Returns(UserId);
+        _userRepo.Setup(x => x.GetByUserIdAsync(UserId))
+            .ReturnsAsync(new User { UserId = UserId, Email = email });
+        _userRepo.Setup(x => x.IsEmailSharedAsync(It.IsAny<string>(), UserId)).ReturnsAsync(emailIsShared);
+        _userRepo.Setup(x => x.IsSysAdmin(UserId)).ReturnsAsync(false);
+        _userRepo.Setup(x => x.GetUserTenantsAsync(UserId)).ReturnsAsync(new List<TenantInfoDto>());
+        _jwtExtractor.Setup(x => x.ExtractClaims(Token, "groups"))
+            .Returns(inAdminGroup ? new[] { AdminGroupId } : Array.Empty<string>());
+        _jwtExtractor.Setup(x => x.ExtractClaims(Token, "roles")).Returns(Array.Empty<string>());
+    }
+
+    [Fact]
+    public async Task GetCurrentUserTenants_DoesNotPromote_WhenAnotherAccountHoldsTheSameEmail()
+    {
+        ArrangeLogin("admin@example.com", inAdminGroup: true, emailIsShared: true);
+
+        await BuildService().GetCurrentUserTenants(Token);
+
+        _userRepo.Verify(x => x.SetSysAdminAsync(It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetCurrentUserTenants_Promotes_WhenTheEmailNamesOneAccount()
+    {
+        ArrangeLogin("admin@example.com", inAdminGroup: true, emailIsShared: false);
+
+        await BuildService().GetCurrentUserTenants(Token);
+
+        _userRepo.Verify(x => x.SetSysAdminAsync(UserId, true), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetCurrentUserTenants_StillDemotes_EvenWhenTheEmailIsShared()
+    {
+        // Failing closed is the safe direction, so a duplicate account must not become a way to
+        // hold on to the role after the group membership is gone.
+        ArrangeLogin("admin@example.com", inAdminGroup: false, emailIsShared: true);
+
+        await BuildService().GetCurrentUserTenants(Token);
+
+        _userRepo.Verify(x => x.SetSysAdminAsync(UserId, false), Times.Once);
+    }
+}

--- a/XiansAi.Server.Tests/UnitTests/Shared/Services/UserTenantServicePortalProvisioningTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Shared/Services/UserTenantServicePortalProvisioningTests.cs
@@ -74,12 +74,15 @@ public class UserTenantServicePortalProvisioningTests
     {
         // Genuine creation race: the conflict is on user id, and the record is there.
         ArrangeFirstSignIn("new@example.com");
+        // The record appears once the concurrent request has created it, rather than after a fixed
+        // number of reads, so the test does not depend on how often it is looked up.
+        var racedUser = new User { UserId = UserId, Email = "new@example.com" };
+        var exists = false;
+        _userRepo.Setup(x => x.GetByUserIdAsync(UserId)).ReturnsAsync(() => exists ? racedUser : null);
         _userManagementService
             .Setup(x => x.CreateNewUser(It.IsAny<UserDto>(), It.IsAny<bool>()))
+            .Callback(() => exists = true)
             .ReturnsAsync(ServiceResult<bool>.Conflict("User already exists"));
-        _userRepo.SetupSequence(x => x.GetByUserIdAsync(UserId))
-            .ReturnsAsync((User?)null)
-            .ReturnsAsync(new User { UserId = UserId, Email = "new@example.com" });
 
         var result = await BuildService().GetCurrentUserTenants(Token);
 


### PR DESCRIPTION
## Summary
- Resolve user identity and authority from email across Admin, User, and Agent APIs, including shared-email collisions.
- Tighten role, tenant, and ownership-transfer lookups so they stay consistent when an email maps to more than one account.
- Add cache invalidation, Mongo index updates, and docs for the email identity resolution path.

## Test plan
- [ ] Confirm Admin API rejects ownership transfer / participant lookup when an email matches multiple accounts
- [ ] Confirm User API tenant resolution still works for unique emails
- [ ] Confirm certificate auth still resolves the correct tenant user
- [ ] Run unit tests covering email identity resolution, role tenant resolver, ownership transfer, and user tenant service


Made with [Cursor](https://cursor.com)