### PR TITLE
docs(architecture): bootstrap architecture constraints

### DIFF
--- a/XiansAi.Server.Src/Features/AppsApi/architecture.md
+++ b/XiansAi.Server.Src/Features/AppsApi/architecture.md
@@ -1,5 +1,8 @@
 # AppsApi Architecture - Proxy Apps for Agent Integration
 
+> **Note:** This document describes the AppsApi feature implementation. For repository-wide architectural constraints and patterns, see [Architecture Constraints](../../../docs/architecture/constraints.md).
+
+
 ## Overview
 
 The **AppsApi** provides a framework for building proxy applications that enable bidirectional messaging between external platforms (Slack, MS Teams, Outlook, etc.) and XiansAi agent activations. These proxy apps act as middleware, translating platform-specific protocols into the XiansAi messaging system.

--- a/docs/architecture/constraints.md
+++ b/docs/architecture/constraints.md
@@ -1,0 +1,317 @@
+# Architecture Constraints
+
+This document defines testable architectural constraints for the XiansAi Server. All constraints marked as `proposed` require human ratification before enforcement.
+
+---
+
+### ARCH-001 — Feature-slice organization
+
+| Field | Value |
+|---|---|
+| **ID** | ARCH-001 |
+| **Severity** | high |
+| **Scope** | `XiansAi.Server.Src/Features/*` |
+| **Status** | proposed |
+| **Rationale** | Feature slices provide vertical cohesion, reducing coupling between unrelated API domains and enabling independent scaling and deployment |
+
+**Rule:** Each API feature must be organized as a self-contained slice under `Features/<FeatureName>Api/` with subdirectories for Endpoints, Services, Configuration, and Auth.
+
+**Allowed:**
+- `Features/AdminApi/Endpoints/AdminStatsEndpoints.cs`
+- `Features/WebApi/Services/WorkflowService.cs`
+- `Features/AppsApi/Configuration/AppsApiConfiguration.cs`
+
+**Forbidden:**
+- `Services/AdminStatsService.cs` (cross-feature service outside the slice)
+- `Features/AdminApi/WebApiController.cs` (mixing feature concerns)
+- `Features/Shared/Endpoints/` (shared code belongs in `Shared/`, not `Features/`)
+
+---
+
+### ARCH-002 — Shared layer for cross-cutting concerns
+
+| Field | Value |
+|---|---|
+| **ID** | ARCH-002 |
+| **Severity** | high |
+| **Scope** | `XiansAi.Server.Src/Shared/*` |
+| **Status** | proposed |
+| **Rationale** | Centralizing infrastructure (data access, auth primitives, providers) prevents duplication and ensures consistent security and persistence patterns across features |
+
+**Rule:** Cross-cutting concerns (Data access, Auth primitives, Providers, Utils, Repositories, shared Services) must reside under `Shared/` and must not contain feature-specific business logic.
+
+**Allowed:**
+- `Shared/Data/MongoDbContext.cs`
+- `Shared/Auth/ApiKeyAuthenticationHandler.cs`
+- `Shared/Providers/Cache/RedisCacheProvider.cs`
+- `Shared/Repositories/ConversationRepository.cs` (generic conversation storage)
+
+**Forbidden:**
+- `Shared/Services/AdminStatsService.cs` (feature-specific logic)
+- `Shared/Endpoints/AdminEndpoints.cs` (endpoints belong in Features)
+- `Features/AdminApi/Data/MongoConnection.cs` (data access duplication)
+
+---
+
+### ARCH-003 — Feature dependencies flow outward
+
+| Field | Value |
+|---|---|
+| **ID** | ARCH-003 |
+| **Severity** | critical |
+| **Scope** | `XiansAi.Server.Src/Features/*` |
+| **Status** | proposed |
+| **Rationale** | Feature slices may depend on Shared, but Shared must never depend on Features to prevent circular dependencies and maintain a clear layering boundary |
+
+**Rule:** Feature slices may reference `Shared/` namespaces. `Shared/` must never reference `Features/` namespaces.
+
+**Allowed:**
+```csharp
+// In Features/AdminApi/Endpoints/AdminStatsEndpoints.cs
+using Shared.Services;
+using Shared.Utils.Services;
+```
+
+**Forbidden:**
+```csharp
+// In Shared/Services/MessageService.cs
+using Features.AdminApi.Services;  // Violation: Shared depends on Feature
+```
+
+---
+
+### ARCH-004 — Feature slice isolation
+
+| Field | Value |
+|---|---|
+| **ID** | ARCH-004 |
+| **Severity** | medium |
+| **Scope** | `XiansAi.Server.Src/Features/*` |
+| **Status** | proposed |
+| **Rationale** | Cross-feature dependencies create coupling and break the feature slice pattern. Shared concerns should be extracted to Shared/ |
+
+**Rule:** Feature slices should not directly reference other feature slices. Shared abstractions must be extracted to `Shared/`.
+
+**Allowed:**
+```csharp
+// Features communicate via shared services/repositories
+// In Features/AdminApi/Endpoints/
+using Shared.Services.IMessageService;
+```
+
+**Forbidden:**
+```csharp
+// In Features/WebApi/Services/
+using Features.AdminApi.Services.AdminStatsService;  // Violation: direct feature coupling
+```
+
+---
+
+### ARCH-005 — Endpoint-scoped authentication policies
+
+| Field | Value |
+|---|---|
+| **ID** | ARCH-005 |
+| **Severity** | critical |
+| **Scope** | `XiansAi.Server.Src/Features/*/Endpoints/*.cs` |
+| **Status** | proposed |
+| **Rationale** | Each API surface has distinct authentication requirements (AdminApi uses API keys, WebApi uses OIDC). Explicit policy declaration prevents accidental exposure |
+
+**Rule:** All endpoint groups must explicitly declare an authorization policy via `.RequireAuthorization("<PolicyName>")`. No endpoints may be registered without authentication.
+
+**Allowed:**
+```csharp
+var group = adminApiGroup.MapGroup("/tenants/{tenantId}")
+    .RequireAuthorization("AdminEndpointAuthPolicy");
+```
+
+**Forbidden:**
+```csharp
+app.MapGet("/api/v1/admin/stats", handler);  // No policy specified
+```
+
+---
+
+### ARCH-006 — Tenant isolation enforcement
+
+| Field | Value |
+|---|---|
+| **ID** | ARCH-006 |
+| **Severity** | critical |
+| **Scope** | All tenant-scoped endpoints and repositories |
+| **Status** | proposed |
+| **Rationale** | Multi-tenant SaaS requires strict tenant data isolation to prevent unauthorized cross-tenant access (IDOR) |
+
+**Rule:** All tenant-scoped endpoints must apply `TenantRouteScopeFilter` or equivalent to validate that the authenticated user/key has access to the requested tenantId.
+
+**Allowed:**
+```csharp
+var statsGroup = adminApiGroup.MapGroup("/tenants/{tenantId}")
+    .AddEndpointFilter<TenantRouteScopeFilter>();
+```
+
+**Forbidden:**
+```csharp
+// Endpoint with tenantId in route but no filter
+app.MapGet("/api/v1/admin/tenants/{tenantId}/data", async (string tenantId, ...) => { ... });
+```
+
+---
+
+### ARCH-007 — Repository layer for data access
+
+| Field | Value |
+|---|---|
+| **ID** | ARCH-007 |
+| **Severity** | high |
+| **Scope** | Data access operations |
+| **Status** | proposed |
+| **Rationale** | Encapsulating MongoDB access in repositories centralizes query logic, indexes, and schema mapping, preventing direct database coupling in endpoints |
+
+**Rule:** Endpoints and services must access MongoDB through repository classes (`Shared/Repositories/*` or feature-specific repositories). Direct `IMongoCollection<T>` usage outside repositories is forbidden.
+
+**Allowed:**
+```csharp
+// In endpoint
+var stats = await statsRepository.GetByTenantAsync(tenantId);
+```
+
+**Forbidden:**
+```csharp
+// In endpoint
+var collection = mongoDatabase.GetCollection<StatsDocument>("stats");
+var stats = await collection.Find(x => x.TenantId == tenantId).ToListAsync();
+```
+
+---
+
+### ARCH-008 — Minimal API endpoint pattern
+
+| Field | Value |
+|---|---|
+| **ID** | ARCH-008 |
+| **Severity** | medium |
+| **Scope** | `XiansAi.Server.Src/Features/*/Endpoints/*.cs` |
+| **Status** | proposed |
+| **Rationale** | Consistent use of ASP.NET Core Minimal APIs reduces boilerplate, improves discoverability, and aligns with modern .NET patterns |
+
+**Rule:** HTTP endpoints must be defined using Minimal API `Map*` methods in static endpoint classes. MVC controllers are not permitted.
+
+**Allowed:**
+```csharp
+public static class AdminStatsEndpoints
+{
+    public static void MapAdminStatsEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapGet("/stats", handler);
+    }
+}
+```
+
+**Forbidden:**
+```csharp
+[ApiController]
+[Route("api/v1/admin")]
+public class AdminStatsController : ControllerBase { }
+```
+
+---
+
+### ARCH-009 — API versioning via URL path
+
+| Field | Value |
+|---|---|
+| **ID** | ARCH-009 |
+| **Severity** | medium |
+| **Scope** | All public API endpoints |
+| **Status** | proposed |
+| **Rationale** | URL-based versioning (`/api/v1/`, `/api/v2/`) provides explicit, cache-friendly version signaling and avoids header/query complexity |
+
+**Rule:** All public API routes must include a version segment (`/api/v{version}/...`). Internal/webhook endpoints may omit versioning if they are not part of the public contract.
+
+**Allowed:**
+- `/api/v1/admin/tenants`
+- `/api/v2/admin/agents`
+- `/api/apps/slack/webhook/{instanceId}` (webhook endpoint, not public API)
+
+**Forbidden:**
+- `/api/admin/tenants` (missing version)
+
+---
+
+### ARCH-010 — Configuration via DI registration
+
+| Field | Value |
+|---|---|
+| **ID** | ARCH-010 |
+| **Severity** | medium |
+| **Scope** | `XiansAi.Server.Src/Features/*/Configuration/*.cs` |
+| **Status** | proposed |
+| **Rationale** | Each feature slice registers its own services, making dependencies explicit and enabling independent feature testing |
+
+**Rule:** Each feature must provide a `Configure<Feature>Services()` extension method on `IServiceCollection` that registers all feature-specific services.
+
+**Allowed:**
+```csharp
+// Features/AdminApi/Configuration/AdminApiConfiguration.cs
+public static IServiceCollection ConfigureAdminApiServices(this IServiceCollection services)
+{
+    services.AddScoped<IAdminStatsService, AdminStatsService>();
+    return services;
+}
+```
+
+**Forbidden:**
+- Registering AdminApi services in `Program.cs` or another feature's configuration
+- Service registration scattered across multiple files
+
+---
+
+### ARCH-011 — Test isolation and in-memory dependencies
+
+| Field | Value |
+|---|---|
+| **ID** | ARCH-011 |
+| **Severity** | high |
+| **Scope** | `XiansAi.Server.Tests/*` |
+| **Status** | proposed |
+| **Rationale** | Integration tests must be self-contained and not depend on external services to ensure reliability and fast feedback |
+
+**Rule:** Integration tests must use in-memory/stubbed dependencies (MongoDB in-memory, mocked Temporal, stubbed auth). No test may require a live external service.
+
+**Allowed:**
+- `MongoDbFixture` (in-memory MongoDB)
+- `TestAuthHandler` (stubbed authentication)
+- Mocked `ITemporalClientService`
+
+**Forbidden:**
+- Tests connecting to a live MongoDB instance
+- Tests calling real Temporal workflows
+- Tests requiring Auth0/Azure AD
+
+---
+
+### ARCH-012 — Secrets encryption at rest
+
+| Field | Value |
+|---|---|
+| **ID** | ARCH-012 |
+| **Severity** | critical |
+| **Scope** | Secret storage (API keys, tokens, credentials) |
+| **Status** | proposed |
+| **Rationale** | Storing plaintext secrets in the database violates security best practices and compliance requirements |
+
+**Rule:** All sensitive credentials (API keys, OAuth tokens, signing secrets) stored in MongoDB must be encrypted using the encryption service before persistence.
+
+**Allowed:**
+```csharp
+var encryptedToken = await encryptionService.EncryptAsync(plainToken);
+await repository.SaveAsync(new Config { Token = encryptedToken });
+```
+
+**Forbidden:**
+```csharp
+await repository.SaveAsync(new Config { Token = plainTextToken });  // Violation: plaintext secret
+```
+
+---

--- a/docs/architecture/decisions/0001-feature-slice-architecture.md
+++ b/docs/architecture/decisions/0001-feature-slice-architecture.md
@@ -1,0 +1,46 @@
+# ADR-0001: Feature Slice Architecture
+
+**Status:** Proposed
+
+**Date:** 2026-07-16
+
+## Context
+
+The XiansAi Server provides multiple API surfaces (AdminApi, WebApi, AgentApi, UserApi, AppsApi) that serve different audiences and have distinct authentication, authorization, and domain concerns. Traditional N-tier layering (Controllers → Services → Repositories) would create horizontal coupling across unrelated features, making it difficult to understand, test, and deploy individual API surfaces independently.
+
+We needed an architectural approach that:
+- Provides vertical cohesion within each API surface
+- Enables independent evolution and deployment of features
+- Reduces coupling between unrelated concerns
+- Maintains clear boundaries for testing and ownership
+
+## Decision
+
+We adopt a **feature-slice architecture** where each API surface is organized as a self-contained vertical slice under `Features/<FeatureName>Api/`. Each slice contains:
+
+- `Endpoints/` - Minimal API endpoint definitions
+- `Services/` - Feature-specific business logic
+- `Configuration/` - Service registration and setup
+- `Auth/` - Feature-specific authentication/authorization handlers
+- `Models/` or `Requests/` - DTOs and request/response types (when needed)
+
+Cross-cutting concerns (data access, shared auth primitives, providers, utilities) are extracted to a `Shared/` layer that features depend on, but which never depends back on features.
+
+## Consequences
+
+**Positive:**
+- Each feature can be understood, tested, and changed independently
+- Clear ownership boundaries (team X owns AdminApi, team Y owns WebApi)
+- Easier onboarding: new developers can focus on one feature slice
+- Supports future microservice extraction (each slice could become a separate service)
+- Reduced merge conflicts across teams
+
+**Negative:**
+- Some duplication across features (e.g., similar validation logic)
+- Requires discipline to avoid cross-feature dependencies
+- Shared concerns must be identified and extracted intentionally
+
+**Mitigations:**
+- Use `ARCH-003` and `ARCH-004` constraints to enforce dependency rules
+- Extract truly shared logic to `Shared/` proactively
+- Code reviews focus on feature boundary violations

--- a/docs/architecture/decisions/0002-minimal-api-pattern.md
+++ b/docs/architecture/decisions/0002-minimal-api-pattern.md
@@ -1,0 +1,56 @@
+# ADR-0002: Minimal API Pattern
+
+**Status:** Proposed
+
+**Date:** 2026-07-16
+
+## Context
+
+ASP.NET Core offers two primary approaches for defining HTTP endpoints:
+
+1. **MVC Controllers**: Class-based controllers with action methods decorated with routing attributes
+2. **Minimal APIs**: Functional endpoint definitions using `Map*` methods
+
+The project needed a consistent approach that:
+- Reduces boilerplate and ceremony
+- Provides clear, discoverable endpoint definitions
+- Aligns with modern .NET best practices
+- Supports flexible composition (grouping, filters, policies)
+
+## Decision
+
+We adopt **ASP.NET Core Minimal APIs** for all HTTP endpoint definitions. Endpoints are defined as static extension methods on `RouteGroupBuilder` or `WebApplication` within dedicated `*Endpoints.cs` files in each feature's `Endpoints/` directory.
+
+Pattern:
+```csharp
+public static class AdminStatsEndpoints
+{
+    public static void MapAdminStatsEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapGet("/stats", async (string tenantId, ...) => { ... })
+            .Produces<StatsResponse>(200)
+            .WithName("GetAdminStats");
+    }
+}
+```
+
+MVC controllers (`[ApiController]`, `ControllerBase`) are not permitted.
+
+## Consequences
+
+**Positive:**
+- Less boilerplate: no need for controller classes, base classes, or attribute routing
+- Better composition: groups, filters, and policies are applied programmatically
+- Improved readability: routes, handlers, and metadata are co-located
+- Modern .NET alignment: Microsoft recommends Minimal APIs for new projects
+- Easier testing: handlers are simple delegates or local functions
+
+**Negative:**
+- Less familiar to developers coming from ASP.NET MVC or Web API backgrounds
+- Complex handlers can become inline and harder to extract
+- No built-in model binding validation attributes (must use validators or filters)
+
+**Mitigations:**
+- Complex handlers delegate to service classes
+- Use endpoint filters for cross-cutting validation
+- Maintain clear naming conventions for endpoint files

--- a/docs/architecture/decisions/0003-multi-tenant-isolation.md
+++ b/docs/architecture/decisions/0003-multi-tenant-isolation.md
@@ -1,0 +1,47 @@
+# ADR-0003: Multi-Tenant Isolation Enforcement
+
+**Status:** Proposed
+
+**Date:** 2026-07-16
+
+## Context
+
+The XiansAi Server is a multi-tenant SaaS platform. Each tenant's data (agents, workflows, conversations, secrets) must be strictly isolated to prevent unauthorized cross-tenant access (IDOR vulnerabilities). Without enforced isolation, a compromised API key or token could leak data across tenant boundaries.
+
+We needed a mechanism to:
+- Ensure route-level tenant parameters match the authenticated tenant
+- Fail fast on unauthorized tenant access attempts
+- Apply isolation consistently across all tenant-scoped endpoints
+
+## Decision
+
+We enforce multi-tenant isolation using **endpoint filters** applied to route groups:
+
+1. All tenant-scoped routes include `{tenantId}` as a route parameter
+2. A `TenantRouteScopeFilter` (or equivalent) validates that the authenticated user/API key has access to the requested `tenantId`
+3. The filter is applied at the route group level:
+   ```csharp
+   var group = adminApiGroup.MapGroup("/tenants/{tenantId}")
+       .AddEndpointFilter<TenantRouteScopeFilter>();
+   ```
+4. Unauthorized access attempts result in HTTP 403 Forbidden
+
+Repository and service layers receive the validated `tenantId` and use it in all queries.
+
+## Consequences
+
+**Positive:**
+- Centralized enforcement prevents developers from forgetting tenant checks
+- Fail-fast behavior reduces risk of accidental data leaks
+- Clear audit trail: 403 responses indicate authorization failures
+- Simplified endpoint logic: tenantId is pre-validated
+
+**Negative:**
+- Adds overhead to every tenant-scoped request (filter execution)
+- Requires consistent tenantId naming in routes
+- Cross-tenant operations (rare) require special handling
+
+**Mitigations:**
+- Filter logic is lightweight and cached where possible
+- Document cross-tenant use cases (e.g., system-level operations) and their authorization model
+- Use integration tests to verify isolation enforcement

--- a/docs/architecture/decisions/0004-repository-pattern-for-data-access.md
+++ b/docs/architecture/decisions/0004-repository-pattern-for-data-access.md
@@ -1,0 +1,57 @@
+# ADR-0004: Repository Pattern for Data Access
+
+**Status:** Proposed
+
+**Date:** 2026-07-16
+
+## Context
+
+The XiansAi Server uses MongoDB for persistence. Allowing endpoints and services to directly interact with `IMongoCollection<T>` creates several issues:
+
+- Scattered query logic across the codebase
+- Difficulty changing data models or indexes
+- Hard to mock or test data access
+- No single location for tenant scoping or security checks
+
+We needed a consistent data access pattern that:
+- Encapsulates MongoDB operations
+- Provides a clear abstraction boundary
+- Enables testability and future data store changes
+
+## Decision
+
+We adopt the **Repository Pattern** for all MongoDB data access:
+
+1. Repositories reside in `Shared/Repositories/` for cross-feature entities (Conversation, Tenant, Agent) or in feature-specific directories for feature-local entities
+2. Each repository exposes domain-focused methods (e.g., `GetByTenantAsync`, `CreateAsync`, `UpdateAsync`)
+3. Repositories encapsulate MongoDB collection access, query logic, and index definitions
+4. Endpoints and services depend on repository interfaces, not `IMongoDatabase` or `IMongoCollection<T>`
+
+Example:
+```csharp
+public interface IConversationRepository
+{
+    Task<Conversation?> GetByIdAsync(string tenantId, string conversationId);
+    Task<List<Conversation>> GetByTenantAsync(string tenantId, int limit);
+    Task CreateAsync(Conversation conversation);
+}
+```
+
+## Consequences
+
+**Positive:**
+- Centralized query logic and index management
+- Easier to test: mock repository interfaces instead of MongoDB
+- Clear data access boundary for security reviews
+- Supports future data store changes (e.g., Cosmos DB, PostgreSQL)
+- Tenant scoping can be enforced at repository level
+
+**Negative:**
+- Additional abstraction layer adds indirection
+- Repository explosion if not carefully designed (one per entity)
+- May duplicate some query logic across repositories
+
+**Mitigations:**
+- Use generic base repositories for common CRUD patterns
+- Extract shared query logic to helper methods
+- Prefer coarse-grained repositories over fine-grained (e.g., one ConversationRepository, not separate MessageRepository and ParticipantRepository)

--- a/docs/architecture/decisions/0005-api-key-and-oidc-authentication.md
+++ b/docs/architecture/decisions/0005-api-key-and-oidc-authentication.md
@@ -1,0 +1,58 @@
+# ADR-0005: API Key and OIDC Authentication Strategy
+
+**Status:** Proposed
+
+**Date:** 2026-07-16
+
+## Context
+
+The XiansAi Server exposes multiple API surfaces with different authentication requirements:
+
+- **AdminApi**: Server-to-server or CLI access requiring high privileges (manage tenants, agents)
+- **WebApi**: Client applications (web, mobile) accessing tenant-scoped resources on behalf of users
+- **AgentApi**: Agent workflows accessing internal services (secrets, cache, logs)
+- **UserApi**: End-user webhooks and websocket connections
+- **AppsApi**: External platform webhooks (Slack, Teams) with signature-based verification
+
+We needed an authentication strategy that:
+- Supports both machine (API key) and human (OIDC/OAuth) authentication
+- Applies the appropriate mechanism per API surface
+- Allows flexible provider configuration (Auth0, Azure AD, Keycloak)
+
+## Decision
+
+We implement a **dual authentication strategy**:
+
+1. **API Key Authentication** for AdminApi and AgentApi:
+   - Custom `AuthenticationHandler` validates Bearer tokens against stored API keys
+   - API keys are tenant-scoped or system-scoped
+   - Authorization policies (`AdminEndpointAuthPolicy`, `AgentEndpointAuthPolicy`) enforce role requirements
+
+2. **OIDC/OAuth Authentication** for WebApi and UserApi:
+   - JWT Bearer tokens issued by external identity providers (Auth0, Azure AD, Azure B2C, Keycloak)
+   - Provider configured via `appsettings.json` (`AuthProvider:Provider`)
+   - Standard OIDC claims mapped to application roles and tenant context
+
+3. **Signature-based Verification** for AppsApi webhooks:
+   - Platform-specific signature validation (HMAC-SHA256 for Slack, JWT for Teams)
+   - No traditional Bearer token authentication
+
+Each feature registers its own authentication scheme and authorization policies in its Configuration class.
+
+## Consequences
+
+**Positive:**
+- Flexibility: each API surface uses the authentication model that fits its use case
+- Security: strong machine authentication (API keys) and standard human authentication (OIDC)
+- Provider independence: swap Auth0 for Keycloak without changing application logic
+- Clear separation: AdminApi keys cannot access WebApi endpoints and vice versa
+
+**Negative:**
+- Complexity: multiple authentication schemes in a single application
+- Configuration overhead: each provider (Auth0, Azure AD) requires specific settings
+- Testing challenges: must stub multiple authentication mechanisms
+
+**Mitigations:**
+- Clear documentation per API surface (see `docs/AUTH_CONFIGURATION.md`)
+- Use `TestAuthHandler` in integration tests to unify test authentication
+- Endpoint filters and policies make authentication enforcement explicit and auditable

--- a/docs/architecture/decisions/0006-url-based-api-versioning.md
+++ b/docs/architecture/decisions/0006-url-based-api-versioning.md
@@ -1,0 +1,58 @@
+# ADR-0006: URL-Based API Versioning
+
+**Status:** Proposed
+
+**Date:** 2026-07-16
+
+## Context
+
+The XiansAi Server provides public APIs consumed by external clients (web apps, mobile apps, integrations). Over time, breaking changes to the API contract are inevitable. We needed a versioning strategy that:
+
+- Allows multiple API versions to coexist
+- Provides clear, discoverable version information
+- Supports client caching and routing
+- Avoids complex header or query parameter schemes
+
+## Decision
+
+We adopt **URL-based API versioning** with the version segment embedded in the path:
+
+```
+/api/v1/admin/tenants
+/api/v2/admin/tenants
+```
+
+All public API routes include a version segment (`/api/v{version}/`). Internal or webhook endpoints that are not part of the public contract may omit versioning.
+
+Version increments:
+- **Major version** (`v1` → `v2`): Breaking changes (removed fields, changed semantics)
+- **Minor/patch versions**: Not exposed in the URL; clients always get the latest minor/patch for their major version
+
+Route groups are versioned at registration:
+```csharp
+var v1Group = app.MapGroup("/api/v1/admin");
+v1Group.MapAdminEndpoints(); // v1 endpoints
+
+var v2Group = app.MapGroup("/api/v2/admin");
+v2Group.MapAdminEndpointsV2(); // v2 endpoints with breaking changes
+```
+
+## Consequences
+
+**Positive:**
+- Explicit and discoverable: version is visible in the URL
+- Cache-friendly: different URLs = different cache keys
+- Simple routing: no need to inspect headers or query parameters
+- Client clarity: developers know exactly which version they're using
+- Supports gradual migration: old clients use v1, new clients use v2
+
+**Negative:**
+- URL length increases slightly
+- Endpoint proliferation if not managed (v1, v2, v3 variants)
+- Requires discipline to maintain multiple versions concurrently
+
+**Mitigations:**
+- Deprecate and remove old versions after a transition period
+- Document migration paths for breaking changes
+- Use shared logic for non-breaking differences (version-specific DTOs, shared services)
+- See `Features/AdminApi/API_VERSIONING_GUIDE.md` for implementation guidance

--- a/docs/architecture/decisions/0007-secrets-encryption-at-rest.md
+++ b/docs/architecture/decisions/0007-secrets-encryption-at-rest.md
@@ -1,0 +1,63 @@
+# ADR-0007: Secrets Encryption at Rest
+
+**Status:** Proposed
+
+**Date:** 2026-07-16
+
+## Context
+
+The XiansAi Server stores sensitive credentials in MongoDB:
+- Admin and agent API keys
+- OAuth tokens for external platform integrations (Slack, Teams)
+- Signing secrets for webhook verification
+- Customer-provided secrets in the Secret Vault
+
+Storing these secrets in plaintext violates security best practices and compliance requirements (SOC 2, GDPR, etc.). A database breach would expose all tenant secrets.
+
+We needed a solution that:
+- Encrypts secrets before persistence
+- Decrypts secrets transparently on retrieval
+- Supports key rotation
+- Uses industry-standard algorithms (AES-256-GCM)
+
+## Decision
+
+We implement **secrets encryption at rest** using an encryption service:
+
+1. All sensitive fields are encrypted using AES-256-GCM before being saved to MongoDB
+2. The encryption service uses a base secret (from environment or key vault) and optional per-tenant unique secrets
+3. Repositories and services call `encryptionService.EncryptAsync()` before persistence and `encryptionService.DecryptAsync()` after retrieval
+4. Configuration values stored in `appsettings.json` or environment variables are not encrypted (they are not persisted to the database)
+
+Example:
+```csharp
+// Before saving
+var encryptedToken = await _encryptionService.EncryptAsync(plainToken, tenantId);
+appInstance.Configuration["botToken"] = encryptedToken;
+await _repository.SaveAsync(appInstance);
+
+// After retrieval
+var encryptedToken = appInstance.Configuration["botToken"];
+var plainToken = await _encryptionService.DecryptAsync(encryptedToken, tenantId);
+```
+
+See `docs/SECRETS_ENCRYPTION.md` for implementation details.
+
+## Consequences
+
+**Positive:**
+- Defense in depth: even if MongoDB is compromised, secrets are encrypted
+- Compliance: meets requirements for secrets protection
+- Key rotation support: can re-encrypt with new keys
+- Transparent to application logic: encryption is encapsulated in the service
+
+**Negative:**
+- Performance overhead: encryption/decryption on every secret access
+- Complexity: key management and rotation must be handled carefully
+- Debugging difficulty: cannot inspect secrets directly in the database
+
+**Mitigations:**
+- Cache decrypted secrets in memory for short periods (with caution)
+- Use Azure Key Vault or AWS Secrets Manager for base secret storage
+- Provide tooling for key rotation and re-encryption
+- Log encryption failures clearly for troubleshooting

--- a/docs/architecture/fitness-functions.md
+++ b/docs/architecture/fitness-functions.md
@@ -1,0 +1,269 @@
+# Architecture Fitness Functions
+
+This document maps each architecture constraint to a verification heuristic or check. These functions are used by automated tooling and human reviewers to assess constraint compliance.
+
+---
+
+## ARCH-001 — Feature-slice organization
+
+**Heuristic:** Feature code must live under `Features/<FeatureName>Api/` with conventional subdirectories.
+
+**Check:**
+```bash
+# Verify all feature APIs follow directory conventions
+find XiansAi.Server.Src/Features -mindepth 1 -maxdepth 1 -type d | while read feature; do
+  if [[ ! -d "$feature/Endpoints" ]]; then
+    echo "VIOLATION: $feature missing Endpoints/"
+  fi
+done
+
+# Detect misplaced feature code
+find XiansAi.Server.Src -name '*Endpoints.cs' -o -name '*Service.cs' | grep -v 'Features/' | grep -v 'Shared/'
+```
+
+**False positives:**
+- `Shared/Services/` is allowed (cross-cutting services)
+- Test projects may have different structure
+
+---
+
+## ARCH-002 — Shared layer for cross-cutting concerns
+
+**Heuristic:** `Shared/` must only contain infrastructure and cross-feature abstractions, not feature business logic.
+
+**Check:**
+```bash
+# Look for feature-specific names in Shared
+find XiansAi.Server.Src/Shared -name '*Admin*.cs' -o -name '*WebApi*.cs' -o -name '*AgentApi*.cs' -o -name '*UserApi*.cs' -o -name '*AppsApi*.cs'
+
+# Manually review Shared/Services for feature-specific logic
+```
+
+**False positives:**
+- `AdminStatsService` might be legitimately shared if used across multiple features
+- Names like `AdminAuthHandler` in `Shared/Auth` may be acceptable if the auth pattern is shared
+
+**Review trigger:** New files added to `Shared/` should be reviewed to ensure they are truly cross-cutting.
+
+---
+
+## ARCH-003 — Feature dependencies flow outward
+
+**Heuristic:** Check for `using Features.*` statements in `Shared/` namespace files.
+
+**Check:**
+```bash
+# Scan Shared/ for any imports of Features namespaces
+grep -r "using Features\." XiansAi.Server.Src/Shared/
+```
+
+**Expected output:** None (empty result = compliant)
+
+**False positives:** None. This is a hard constraint.
+
+---
+
+## ARCH-004 — Feature slice isolation
+
+**Heuristic:** Check for cross-feature `using` statements (e.g., `Features.AdminApi` referencing `Features.WebApi`).
+
+**Check:**
+```bash
+# Example: scan AdminApi for references to other features
+grep -r "using Features\.WebApi\|using Features\.AgentApi\|using Features\.AppsApi\|using Features\.UserApi" XiansAi.Server.Src/Features/AdminApi/
+
+# Generalize for all features
+for feature in AdminApi WebApi AgentApi UserApi AppsApi; do
+  echo "Checking $feature for cross-feature dependencies..."
+  grep -r "using Features\." "XiansAi.Server.Src/Features/$feature/" | grep -v "using Features\.$feature"
+done
+```
+
+**Expected output:** None
+
+**False positives:**
+- Test projects may reference multiple features
+- Configuration or Program.cs orchestrates features and will reference multiple Features namespaces (acceptable)
+
+---
+
+## ARCH-005 — Endpoint-scoped authentication policies
+
+**Heuristic:** All `Map*` endpoint registrations must chain `.RequireAuthorization(...)`.
+
+**Check:**
+```bash
+# Find MapGet/MapPost/MapPut/MapDelete/MapPatch without RequireAuthorization
+grep -E "Map(Get|Post|Put|Delete|Patch)" XiansAi.Server.Src/Features/*/Endpoints/*.cs | \
+  grep -v "RequireAuthorization"
+```
+
+**False positives:**
+- Webhook endpoints (`/api/apps/{platform}/webhook`) may not use `.RequireAuthorization` if they implement custom signature validation
+- `.RequireAuthorization()` may be set on the parent `MapGroup` instead of each individual endpoint
+
+**Better check:** Verify that the endpoint group declares authorization before mapping endpoints.
+
+---
+
+## ARCH-006 — Tenant isolation enforcement
+
+**Heuristic:** Routes containing `{tenantId}` must apply `TenantRouteScopeFilter` or equivalent.
+
+**Check:**
+```bash
+# Find routes with tenantId in path
+grep -E "MapGroup\(.*tenantId" XiansAi.Server.Src/Features/*/Endpoints/*.cs | while read line; do
+  file=$(echo "$line" | cut -d: -f1)
+  # Check if TenantRouteScopeFilter appears in the same endpoint file
+  if ! grep -q "TenantRouteScopeFilter" "$file"; then
+    echo "VIOLATION: $file has tenantId route but no TenantRouteScopeFilter"
+  fi
+done
+```
+
+**False positives:**
+- Some endpoints may validate tenant scope inline (less common but valid if equivalent logic exists)
+
+---
+
+## ARCH-007 — Repository layer for data access
+
+**Heuristic:** Endpoint and service files should not directly call `GetCollection<T>()` or `IMongoDatabase`.
+
+**Check:**
+```bash
+# Scan endpoints and services for direct MongoDB usage
+grep -r "GetCollection<" XiansAi.Server.Src/Features/*/Endpoints/
+grep -r "IMongoDatabase" XiansAi.Server.Src/Features/*/Endpoints/
+grep -r "GetCollection<" XiansAi.Server.Src/Features/*/Services/ | grep -v Repository
+```
+
+**Expected output:** None outside of Repository classes
+
+**False positives:**
+- Repository classes themselves will use `GetCollection<T>()` (allowed)
+- Migration or seeding scripts may use direct access (acceptable)
+
+---
+
+## ARCH-008 — Minimal API endpoint pattern
+
+**Heuristic:** No `[ApiController]` or `ControllerBase` usage in Features.
+
+**Check:**
+```bash
+# Detect MVC controller usage
+grep -r "\[ApiController\]" XiansAi.Server.Src/Features/
+grep -r ": ControllerBase" XiansAi.Server.Src/Features/
+```
+
+**Expected output:** None
+
+**False positives:** None. This is a hard constraint.
+
+---
+
+## ARCH-009 — API versioning via URL path
+
+**Heuristic:** All public API routes should match `/api/v\d+/` pattern.
+
+**Check:**
+```bash
+# Find MapGroup calls without /api/v
+grep -E "MapGroup\(" XiansAi.Server.Src/Features/*/Configuration/*.cs | grep -v "/api/v"
+```
+
+**False positives:**
+- Internal webhook endpoints (`/api/apps/`) are exempt
+- Health check endpoints (`/health`) are exempt
+
+**Manual review:** Examine each result to confirm it's a public API that requires versioning.
+
+---
+
+## ARCH-010 — Configuration via DI registration
+
+**Heuristic:** Each feature should have a `Configuration/*Configuration.cs` file with a `Configure<Feature>Services()` method.
+
+**Check:**
+```bash
+# Verify each feature has a Configuration directory
+for feature in AdminApi WebApi AgentApi UserApi AppsApi; do
+  if [[ ! -d "XiansAi.Server.Src/Features/$feature/Configuration" ]]; then
+    echo "VIOLATION: $feature missing Configuration/"
+  fi
+done
+
+# Check for Configure*Services method in each feature
+for feature in AdminApi WebApi AgentApi UserApi AppsApi; do
+  if ! grep -q "Configure${feature}Services" "XiansAi.Server.Src/Features/$feature/Configuration/"*.cs 2>/dev/null; then
+    echo "WARNING: $feature may be missing Configure${feature}Services method"
+  fi
+done
+```
+
+**False positives:**
+- Small features may register services inline in Program.cs (acceptable if documented)
+
+---
+
+## ARCH-011 — Test isolation and in-memory dependencies
+
+**Heuristic:** Integration tests should use `MongoDbFixture`, `TestAuthHandler`, and mocked external services.
+
+**Check:**
+```bash
+# Verify no hardcoded MongoDB connection strings in tests
+grep -r "mongodb://" XiansAi.Server.Tests/ | grep -v "localhost"
+grep -r "mongodb+srv://" XiansAi.Server.Tests/
+
+# Ensure TestAuthHandler is used
+grep -r "AddAuthentication" XiansAi.Server.Tests/TestUtils/ | grep -q "TestAuthHandler"
+```
+
+**Manual review:**
+- Check `XiansAiWebApplicationFactory.cs` for proper service mocking
+- Verify `appsettings.Tests.json` points to in-memory or test fixtures
+
+---
+
+## ARCH-012 — Secrets encryption at rest
+
+**Heuristic:** Look for sensitive field assignments without encryption service usage.
+
+**Check:**
+```bash
+# Search for patterns like Token =, ApiKey =, Secret = without Encrypt
+grep -r "Token = " XiansAi.Server.Src/Features/ | grep -v "Encrypt"
+grep -r "ApiKey = " XiansAi.Server.Src/Features/ | grep -v "Encrypt"
+grep -r "Secret = " XiansAi.Server.Src/Features/ | grep -v "Encrypt"
+```
+
+**False positives:**
+- Local variables or DTOs that hold pre-encrypted values
+- Decryption operations (`Token = await Decrypt(...)`)
+- Configuration loading (environment variables are not stored in DB)
+
+**Manual review:** Examine repository `SaveAsync` / `CreateAsync` methods to verify encryption is applied before persistence.
+
+---
+
+## Summary
+
+| Constraint ID | Automated? | Tool |
+|---|---|---|
+| ARCH-001 | Partial | Shell script / directory structure check |
+| ARCH-002 | Manual | Code review for Shared/ additions |
+| ARCH-003 | Yes | `grep` for `using Features.*` in Shared |
+| ARCH-004 | Yes | `grep` for cross-feature using statements |
+| ARCH-005 | Partial | Grep + manual review of authorization chains |
+| ARCH-006 | Partial | Grep for tenantId routes + filter check |
+| ARCH-007 | Yes | Grep for `GetCollection<T>` in Endpoints/Services |
+| ARCH-008 | Yes | Grep for `[ApiController]` or `ControllerBase` |
+| ARCH-009 | Partial | Grep for MapGroup without `/api/v` |
+| ARCH-010 | Partial | Check for Configuration/ directory and method |
+| ARCH-011 | Manual | Review test setup and appsettings.Tests.json |
+| ARCH-012 | Manual | Review repository methods for encryption usage |
+
+Future enhancements may include Roslyn analyzers for constraints ARCH-003, ARCH-004, ARCH-005, ARCH-007, and ARCH-008.


### PR DESCRIPTION
Adds testable architecture constraints and fitness functions under docs/architecture/. This establishes foundational constraints for the XiansAi Server codebase including:

- ARCH-001: Feature-slice organization
- ARCH-002: Shared layer for cross-cutting concerns
- ARCH-003: Feature dependencies flow outward
- ARCH-004: Feature slice isolation
- ARCH-005: Endpoint-scoped authentication policies
- ARCH-006: Tenant isolation enforcement
- ARCH-007: Repository layer for data access
- ARCH-008: Minimal API endpoint pattern
- ARCH-009: API versioning via URL path
- ARCH-010: Configuration via DI registration
- ARCH-011: Test isolation and in-memory dependencies
- ARCH-012: Secrets encryption at rest

All constraints are marked status: proposed pending human ratification.

Includes seed ADRs documenting major architectural decisions:
- 0001: Feature slice architecture
- 0002: Minimal API pattern
- 0003: Multi-tenant isolation
- 0004: Repository pattern for data access
- 0005: API key and OIDC authentication
- 0006: URL-based API versioning
- 0007: Secrets encryption at rest