### PR TITLE
fix(auth): record a display name when the token splits it in two

### DIFF
--- a/XiansAi.Server.Src/Shared/Auth/OidcTokenInspector.cs
+++ b/XiansAi.Server.Src/Shared/Auth/OidcTokenInspector.cs
@@ -155,8 +155,34 @@ public static class OidcTokenInspector
     public static string? GetEmail(JsonWebToken jwt) =>
         FirstPresent(jwt, ["email", ClaimTypes.Email, "emails", "emailAddress", "preferred_username", "upn"]).Value;
 
+    /// <summary>
+    /// The display name to record.
+    ///
+    /// A directory that issues the given and family names separately carries no single name claim,
+    /// so without composing one the record is created with no name at all. Both the OIDC spellings
+    /// and the camelCase spellings some directories use are accepted.
+    ///
+    /// The composed name is preferred over <c>preferred_username</c>, which is usually an address
+    /// and makes a poor display name when the person's actual name is in the same token.
+    /// </summary>
     public static string? GetName(JsonWebToken jwt) =>
-        FirstPresent(jwt, ["name", ClaimTypes.Name, "preferred_username"]).Value;
+        FirstPresent(jwt, ["name", ClaimTypes.Name]).Value
+        ?? ComposeName(jwt)
+        ?? FirstPresent(jwt, ["preferred_username"]).Value;
+
+    private static string? ComposeName(JsonWebToken jwt)
+    {
+        var givenName = FirstPresent(jwt, ["given_name", ClaimTypes.GivenName, "firstName"]).Value;
+        var familyName = FirstPresent(jwt, ["family_name", ClaimTypes.Surname, "lastName"]).Value;
+
+        // Either one alone is still a better name than none.
+        var parts = new[] { givenName, familyName }
+            .Where(part => !string.IsNullOrWhiteSpace(part))
+            .Select(part => part!.Trim());
+
+        var composed = string.Join(' ', parts);
+        return string.IsNullOrWhiteSpace(composed) ? null : composed;
+    }
 
     /// <summary>
     /// Checks that the token carries every scope the provider requires, or returns null when the

--- a/XiansAi.Server.Tests/UnitTests/Shared/Auth/OidcTokenInspectorTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Shared/Auth/OidcTokenInspectorTests.cs
@@ -170,6 +170,44 @@ public class OidcTokenInspectorTests
     }
 
     [Fact]
+    public void NameIsComposedFromTheStandardGivenAndFamilyClaims()
+    {
+        var jwt = TokenWith(("sub", "user-1"), ("given_name", "Prasadini"), ("family_name", "Abeyasinghe"));
+
+        Assert.Equal("Prasadini Abeyasinghe", OidcTokenInspector.GetName(jwt));
+    }
+
+    [Fact]
+    public void NameIsComposedFromTheCamelCaseClaimsSomeDirectoriesIssue()
+    {
+        // A directory issuing firstName/lastName and no name claim left the record with no name.
+        var jwt = TokenWith(("sub", "user-1"), ("firstName", "Prasadini"), ("lastName", "Abeyasinghe"));
+
+        Assert.Equal("Prasadini Abeyasinghe", OidcTokenInspector.GetName(jwt));
+    }
+
+    [Fact]
+    public void HalfAComposedNameIsBetterThanNone()
+    {
+        Assert.Equal("Prasadini", OidcTokenInspector.GetName(TokenWith(("given_name", "Prasadini"))));
+    }
+
+    [Fact]
+    public void APersonsNameIsPreferredOverThePreferredUsernameAddress()
+    {
+        var jwt = TokenWith(
+            ("preferred_username", "a@b.com"), ("given_name", "Prasadini"), ("family_name", "Abeyasinghe"));
+
+        Assert.Equal("Prasadini Abeyasinghe", OidcTokenInspector.GetName(jwt));
+    }
+
+    [Fact]
+    public void PreferredUsernameIsStillTheNameWhenNothingElseCarriesOne()
+    {
+        Assert.Equal("a@b.com", OidcTokenInspector.GetName(TokenWith(("preferred_username", "a@b.com"))));
+    }
+
+    [Fact]
     public void PreferredUsernameStandsInForAMissingEmail()
     {
         Assert.Equal("a@b.com", OidcTokenInspector.GetEmail(TokenWith(("preferred_username", "a@b.com"))));

--- a/XiansAi.Server.Tests/UnitTests/Shared/Services/GlobalUserAdminServiceDeleteTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Shared/Services/GlobalUserAdminServiceDeleteTests.cs
@@ -2,7 +2,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Shared.Auth;
 using Shared.Data.Models;
-using Shared.Providers.Auth;
 using Shared.Repositories;
 using Shared.Services;
 using Shared.Utils.Services;
@@ -15,8 +14,7 @@ public class GlobalUserAdminServiceDeleteTests
     private const string TargetUserId = "target-user";
 
     private readonly Mock<IUserRepository> _userRepo = new();
-    private readonly Mock<IRoleCacheService> _roleCache = new();
-    private readonly Mock<ITokenValidationCache> _tokenCache = new();
+    private readonly Mock<IUserAuthorizationInvalidator> _invalidator = new();
     private readonly Mock<IWebhookEventPublisher> _webhooks = new();
     private readonly GlobalUserAdminService _service;
 
@@ -24,14 +22,13 @@ public class GlobalUserAdminServiceDeleteTests
     {
         _webhooks.Setup(x => x.PublishAsync(It.IsAny<string>(), It.IsAny<object?>(), It.IsAny<string?>()))
             .Returns(Task.CompletedTask);
-        _tokenCache.Setup(x => x.InvalidateUserTokens(It.IsAny<string>()))
+        _invalidator.Setup(x => x.InvalidateAsync(It.IsAny<User>()))
             .Returns(Task.CompletedTask);
 
         _service = new GlobalUserAdminService(
             _userRepo.Object,
             Mock.Of<ITenantCacheService>(),
-            _roleCache.Object,
-            _tokenCache.Object,
+            _invalidator.Object,
             _webhooks.Object,
             NullLogger<GlobalUserAdminService>.Instance);
     }
@@ -47,8 +44,9 @@ public class GlobalUserAdminServiceDeleteTests
 
         Assert.True(result.IsSuccess);
         _userRepo.Verify(x => x.DeleteUser(TargetUserId, null), Times.Once);
-        _roleCache.Verify(x => x.InvalidateUserRoles(TargetUserId, "parkly.no"), Times.Once);
-        _tokenCache.Verify(x => x.InvalidateUserTokens(TargetUserId), Times.Once);
+        // One call now stands for every cache the account is held in, including those of any
+        // account sharing its address.
+        _invalidator.Verify(x => x.InvalidateAsync(user), Times.Once);
         _webhooks.Verify(
             x => x.PublishAsync(WebhookEventTypes.UserDeleted, It.IsAny<object?>(), It.IsAny<string?>()),
             Times.Once);


### PR DESCRIPTION
## Summary

OIDC provisioning via the User API created user records with an email but no name. The tenant's tokens carry no `name` claim — the person's name is split across `firstName` and `lastName` — and `OidcTokenInspector.GetName` only looked at `name`, `ClaimTypes.Name`, and `preferred_username`.

- `GetName` now composes a name from the given and family name claims when no single name claim exists, accepting both the standard OIDC spellings (`given_name`/`family_name`) and the camelCase spellings some directories issue. The standard spellings were not handled either, so this was not limited to one tenant's custom claims.
- The composed name is preferred over `preferred_username`, which is usually an address and makes a poor display name when the person's actual name is in the same token. This only changes what gets written for records that have no name yet.
- Repairs `GlobalUserAdminServiceDeleteTests`, which stopped compiling when #476 (user deletion) and #475 (cache invalidator refactor) merged: the service moved to `IUserAuthorizationInvalidator` while the test still constructed it with the role and token caches. `main` did not build.

Existing records repair themselves — `BackfillMissingProfileAsync` fills a blank name from the token on the next sign-in, so no migration is needed.

## Test plan

- [x] Five new cases in `OidcTokenInspectorTests` covering the standard claims, the camelCase claims, a given name with no family name, precedence over `preferred_username`, and `preferred_username` still standing in when nothing else carries a name.
- [x] Full suite green at 735 tests (`main` itself did not compile before this).
- [ ] Sign in as an affected user and confirm the record picks up the name.

Made with [Cursor](https://cursor.com)