### PR TITLE
feat(admin): resolve a participant whose address several accounts hold

### DIFF
--- a/XiansAi.Server.Src/Features/AdminApi/Endpoints/AdminParticipantsEndpoints.cs
+++ b/XiansAi.Server.Src/Features/AdminApi/Endpoints/AdminParticipantsEndpoints.cs
@@ -98,112 +98,28 @@ public static class AdminParticipantsEndpoints
                 }
                 email = validatedEmail;
 
-                // Get user by email. The reply describes one participant's memberships, so an
-                // address that answers to several accounts is refused rather than answered from
-                // whichever record came back first.
-                var owners = await userRepository.GetAllByUserEmailAsync(email);
+                // An address can answer to more than one record — the same person arriving through
+                // two directories is legitimate — and this reply names no account, only the tenants
+                // the person reaches and their role in each. So the records are combined rather
+                // than one being picked or the request refused, which would leave the person with
+                // no tenants at all and no way for an operator to resolve it.
+                var records = await userRepository.GetAllByUserEmailAsync(email);
+                var subject = new ParticipantSubject("email", email, LogSanitizer.RedactEmail(email));
+
+                if (RefuseWhenEveryRecordIsDisabled(records, subject, logger, out var disabled))
+                {
+                    return disabled;
+                }
+
+                var owners = EmailIdentityResolution.UsableRecords(records);
                 if (owners.Count > 1)
                 {
-                    logger.LogWarning("Participant lookup refused: {EmailRedacted} matches {Count} accounts",
-                        LogSanitizer.RedactEmail(email), owners.Count);
-                    return Results.Problem(
-                        detail: "This email matches more than one account, so participant details " +
-                                "cannot be resolved from it.",
-                        statusCode: StatusCodes.Status409Conflict);
+                    logger.LogInformation("Participant {Subject} resolves to {Count} accounts; combining them",
+                        subject.Redacted, owners.Count);
                 }
 
-                var user = owners.FirstOrDefault();
-
-                // Reject locked-out users
-                if (user?.IsLockedOut == true)
-                {
-                    logger.LogWarning("Participant lookup denied: user {EmailRedacted} is locked out", LogSanitizer.RedactEmail(email));
-                    return Results.Problem(
-                        detail: "Access denied: the user account is locked out",
-                        statusCode: StatusCodes.Status403Forbidden);
-                }
-
-                // Get tenant IDs and highest-privilege role per tenant for all memberships (approved or not)
-                var participantTenantIds = new List<string>();
-                var tenantRoleMap = new Dictionary<string, string>(); // tenantId -> highest role
-                if (user != null)
-                {
-                    foreach (var tr in user.TenantRoles)
-                    {
-                        participantTenantIds.Add(tr.Tenant);
-                        tenantRoleMap[tr.Tenant] = PrimaryRole(tr.Roles);
-                    }
-
-                    logger.LogInformation("User {EmailRedacted} has roles in {Count} tenants: {TenantIds}", 
-                        LogSanitizer.RedactEmail(email), participantTenantIds.Count, string.Join(", ", participantTenantIds));
-                }
-                else
-                {
-                    logger.LogInformation("User {EmailRedacted} not found", LogSanitizer.RedactEmail(email));
-                }
-
-                // Check if user is system admin
-                var isSystemAdmin = user?.IsSysAdmin ?? false;
-
-                // System admins have access to all tenants, regardless of explicit memberships.
-                // Other users' tenants are derived strictly from their explicit memberships (TenantRoles).
-                // Email-domain matching is intentionally not used to grant tenant access or roles.
-                var matchingTenants = new List<Tenant>();
-                if (isSystemAdmin)
-                {
-                    matchingTenants = await tenantRepository.GetAllAsync();
-                    logger.LogInformation("User {EmailRedacted} is a system admin. Returning all {Count} tenants.",
-                        LogSanitizer.RedactEmail(email), matchingTenants.Count);
-                }
-                else if (participantTenantIds.Any())
-                {
-                    matchingTenants = await tenantRepository.GetByTenantIdsAsync(participantTenantIds);
-                    logger.LogInformation("Found {Count} tenants from roles: {TenantIds}", 
-                        matchingTenants.Count, string.Join(", ", matchingTenants.Select(t => t.TenantId)));
-                }
-
-                if (!matchingTenants.Any())
-                {
-                    return Results.NotFound(new { message = $"User with email '{email}' has no matching tenants" });
-                }
-                
-                logger.LogInformation("Matched {Count} tenants by TenantId. Tenants: {Tenants}", 
-                    matchingTenants.Count, 
-                    string.Join(", ", matchingTenants.Select(t => $"{t.TenantId}(enabled:{t.Enabled})")));
-
-                // Default role for tenants where the user has no explicit membership.
-                // System admins implicitly have access to every tenant via their SysAdmin role.
-                var defaultRole = isSystemAdmin ? SystemRoles.SysAdmin : SystemRoles.TenantParticipant;
-
-                var tenantList = matchingTenants
-                    .Where(t => t.Enabled)
-                    .Select(t => new ParticipantTenantResponse
-                    {
-                        TenantId = t.TenantId,
-                        TenantName = t.Name,
-                        Logo = TenantLogoHelper.BuildLogoResponse(t, httpContext, linkGenerator),
-                        Role = tenantRoleMap.TryGetValue(t.TenantId, out var role) ? role : defaultRole,
-                        Theme = t.Theme
-                    })
-                    .OrderBy(t => t.TenantName)
-                    .ToList();
-
-                // Return 404 if no enabled tenants found
-                if (!tenantList.Any())
-                {
-                    logger.LogWarning("User {EmailRedacted} has matching tenants but no enabled tenants found. " +
-                        "Matching tenant IDs: {TenantIds}, Matched tenants: {MatchedCount}", 
-                        LogSanitizer.RedactEmail(email), string.Join(", ", matchingTenants.Select(t => t.TenantId)), matchingTenants.Count);
-                    return Results.NotFound(new { message = $"User with email '{email}' has no enabled tenants" });
-                }
-
-                var response = new ParticipantTenantsResponse
-                {
-                    IsSystemAdmin = isSystemAdmin,
-                    Tenants = tenantList
-                };
-
-                return Results.Ok(response);
+                return await BuildParticipantTenantsAsync(
+                    owners, subject, httpContext, tenantRepository, linkGenerator, logger);
             }
             catch (Exception ex)
             {
@@ -221,6 +137,215 @@ public static class AdminParticipantsEndpoints
         .Produces(StatusCodes.Status404NotFound)
         .Produces(StatusCodes.Status500InternalServerError)
         ;
+
+        // Same reply, keyed on the account rather than on an address. Preferred by callers that
+        // hold the signed-in person's provider subject, because it names one account outright:
+        // nothing is combined, so what comes back is what that account alone can reach. The
+        // address route stays for callers that have no more than an address.
+        participantGroup.MapGet("/by-user-id/{userId}", async (
+            string userId,
+            HttpContext httpContext,
+            [FromServices] ITenantContext tenantContext,
+            [FromServices] IUserRepository userRepository,
+            [FromServices] ITenantRepository tenantRepository,
+            [FromServices] LinkGenerator linkGenerator,
+            [FromServices] ILogger<IUserRepository> logger) =>
+        {
+            try
+            {
+                // Restrict to SysAdmin only - prevents cross-tenant information disclosure
+                if (tenantContext.UserRoles?.Contains(SystemRoles.SysAdmin) != true)
+                {
+                    logger.LogWarning("Access denied: Participants endpoint requires SysAdmin role. User: {UserId}", tenantContext.LoggedInUser);
+                    return Results.Problem(
+                        detail: "Access denied: Only system administrators can retrieve participant information across tenants",
+                        statusCode: StatusCodes.Status403Forbidden);
+                }
+
+                if (string.IsNullOrWhiteSpace(userId) || userId.Length > MaxUserIdLength)
+                {
+                    logger.LogWarning("Invalid user id for participant lookup: {Length} characters", userId?.Length ?? 0);
+                    return Results.Problem(
+                        detail: $"Invalid user id. It must not be empty or exceed {MaxUserIdLength} characters.",
+                        statusCode: StatusCodes.Status400BadRequest);
+                }
+
+                var user = await userRepository.GetByUserIdAsync(userId);
+                var records = user == null ? new List<User>() : new List<User> { user };
+                var subject = new ParticipantSubject("id", userId, LogSanitizer.RedactUserId(userId));
+
+                if (RefuseWhenEveryRecordIsDisabled(records, subject, logger, out var disabled))
+                {
+                    return disabled;
+                }
+
+                return await BuildParticipantTenantsAsync(
+                    EmailIdentityResolution.UsableRecords(records), subject,
+                    httpContext, tenantRepository, linkGenerator, logger);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error retrieving participant tenants for {UserId}", LogSanitizer.RedactUserId(userId));
+                return Results.Problem(
+                    detail: "An error occurred while retrieving participant tenants",
+                    statusCode: StatusCodes.Status500InternalServerError);
+            }
+        })
+        .WithName("GetParticipantTenantsByUserId")
+        .Produces<ParticipantTenantsResponse>()
+        .Produces(StatusCodes.Status400BadRequest)
+        .Produces(StatusCodes.Status403Forbidden)
+        .Produces(StatusCodes.Status404NotFound)
+        .Produces(StatusCodes.Status500InternalServerError)
+        ;
+    }
+
+    private const int MaxUserIdLength = 200;
+
+    /// <summary>
+    /// How a participant was named, so that the reply and the log can each say so appropriately.
+    /// The caller supplied <paramref name="Value"/>, so echoing it back discloses nothing, while
+    /// the log is read by people who did not supply it and gets <paramref name="Redacted"/>.
+    /// </summary>
+    /// <param name="Kind">"email" or "id", as it appears in the not-found messages.</param>
+    /// <param name="Value">The identifier as the caller gave it.</param>
+    /// <param name="Redacted">The same identifier, safe to log.</param>
+    private readonly record struct ParticipantSubject(string Kind, string Value, string Redacted);
+
+    /// <summary>
+    /// Refuses when records exist for the participant but every one of them is disabled.
+    ///
+    /// A disabled duplicate awaiting review is dropped rather than counted, so it cannot shut out
+    /// the live account beside it. Only when nothing is left is the person themselves refused.
+    /// </summary>
+    private static bool RefuseWhenEveryRecordIsDisabled(
+        IReadOnlyList<User> records, ParticipantSubject subject, ILogger logger, out IResult refusal)
+    {
+        if (records.Count == 0 || EmailIdentityResolution.UsableRecords(records).Count > 0)
+        {
+            refusal = Results.Empty;
+            return false;
+        }
+
+        logger.LogWarning("Participant lookup denied: every account for {Subject} is locked out", subject.Redacted);
+        refusal = Results.Problem(
+            detail: "Access denied: the user account is locked out",
+            statusCode: StatusCodes.Status403Forbidden);
+        return true;
+    }
+
+    /// <summary>
+    /// Builds the reply from the records that answer for one participant: the tenants they reach
+    /// and their highest role in each.
+    ///
+    /// Takes a list rather than one record because an address can answer to several — the same
+    /// person arriving through two directories — and this reply names no account, so combining them
+    /// is the right answer where picking one would not be. A caller naming an account outright
+    /// passes the one record and the combining steps are no-ops.
+    /// </summary>
+    private static async Task<IResult> BuildParticipantTenantsAsync(
+        IReadOnlyList<User> owners,
+        ParticipantSubject subject,
+        HttpContext httpContext,
+        ITenantRepository tenantRepository,
+        LinkGenerator linkGenerator,
+        ILogger logger)
+    {
+        // Tenant IDs and highest-privilege role per tenant, for all memberships (approved or not).
+        // Roles for a tenant are combined across the records first, so someone who is an
+        // administrator through one is not reported as a participant because the other says less.
+        var participantTenantIds = new List<string>();
+        var rolesByTenant = new Dictionary<string, List<string>>();
+        foreach (var owner in owners)
+        {
+            foreach (var membership in owner.TenantRoles)
+            {
+                if (!rolesByTenant.TryGetValue(membership.Tenant, out var combinedRoles))
+                {
+                    combinedRoles = new List<string>();
+                    rolesByTenant[membership.Tenant] = combinedRoles;
+                    participantTenantIds.Add(membership.Tenant);
+                }
+
+                combinedRoles.AddRange(membership.Roles);
+            }
+        }
+
+        var tenantRoleMap = rolesByTenant.ToDictionary(entry => entry.Key, entry => PrimaryRole(entry.Value));
+
+        if (owners.Count > 0)
+        {
+            logger.LogInformation("User {Subject} has roles in {Count} tenants: {TenantIds}",
+                subject.Redacted, participantTenantIds.Count, string.Join(", ", participantTenantIds));
+        }
+        else
+        {
+            logger.LogInformation("User {Subject} not found", subject.Redacted);
+        }
+
+        // Granted only when every record answering for the participant holds it: the role is
+        // global, so one record short means nobody has yet accepted that the records are one
+        // person. Where a single record answers, that is simply its own flag.
+        var isSystemAdmin = owners.Count > 0
+            && EmailIdentityResolution.ResolveSysAdmin(subject.Redacted, owners, logger);
+
+        // System admins have access to all tenants, regardless of explicit memberships.
+        // Other users' tenants are derived strictly from their explicit memberships (TenantRoles).
+        // Email-domain matching is intentionally not used to grant tenant access or roles.
+        var matchingTenants = new List<Tenant>();
+        if (isSystemAdmin)
+        {
+            matchingTenants = await tenantRepository.GetAllAsync();
+            logger.LogInformation("User {Subject} is a system admin. Returning all {Count} tenants.",
+                subject.Redacted, matchingTenants.Count);
+        }
+        else if (participantTenantIds.Any())
+        {
+            matchingTenants = await tenantRepository.GetByTenantIdsAsync(participantTenantIds);
+            logger.LogInformation("Found {Count} tenants from roles: {TenantIds}",
+                matchingTenants.Count, string.Join(", ", matchingTenants.Select(t => t.TenantId)));
+        }
+
+        if (!matchingTenants.Any())
+        {
+            return Results.NotFound(new { message = $"User with {subject.Kind} '{subject.Value}' has no matching tenants" });
+        }
+
+        logger.LogInformation("Matched {Count} tenants by TenantId. Tenants: {Tenants}",
+            matchingTenants.Count,
+            string.Join(", ", matchingTenants.Select(t => $"{t.TenantId}(enabled:{t.Enabled})")));
+
+        // Default role for tenants where the user has no explicit membership.
+        // System admins implicitly have access to every tenant via their SysAdmin role.
+        var defaultRole = isSystemAdmin ? SystemRoles.SysAdmin : SystemRoles.TenantParticipant;
+
+        var tenantList = matchingTenants
+            .Where(t => t.Enabled)
+            .Select(t => new ParticipantTenantResponse
+            {
+                TenantId = t.TenantId,
+                TenantName = t.Name,
+                Logo = TenantLogoHelper.BuildLogoResponse(t, httpContext, linkGenerator),
+                Role = tenantRoleMap.TryGetValue(t.TenantId, out var role) ? role : defaultRole,
+                Theme = t.Theme
+            })
+            .OrderBy(t => t.TenantName)
+            .ToList();
+
+        // Return 404 if no enabled tenants found
+        if (!tenantList.Any())
+        {
+            logger.LogWarning("User {Subject} has matching tenants but no enabled tenants found. " +
+                "Matching tenant IDs: {TenantIds}, Matched tenants: {MatchedCount}",
+                subject.Redacted, string.Join(", ", matchingTenants.Select(t => t.TenantId)), matchingTenants.Count);
+            return Results.NotFound(new { message = $"User with {subject.Kind} '{subject.Value}' has no enabled tenants" });
+        }
+
+        return Results.Ok(new ParticipantTenantsResponse
+        {
+            IsSystemAdmin = isSystemAdmin,
+            Tenants = tenantList
+        });
     }
 
     /// <summary>

--- a/XiansAi.Server.Src/Shared/Repositories/EmailIdentityResolution.cs
+++ b/XiansAi.Server.Src/Shared/Repositories/EmailIdentityResolution.cs
@@ -47,14 +47,7 @@ public sealed record EmailIdentityResolution(
     public static EmailIdentityResolution? From(
         string email, IReadOnlyList<User> records, string tenantId, ILogger logger)
     {
-        // Ordered so the identity a credential acts as does not change between requests. Unordered
-        // this is whatever the collection scan returned first, which is how the same credential
-        // could resolve to a different account on a later call.
-        var candidates = records
-            .Where(user => !user.IsLockedOut)
-            .OrderBy(user => user.CreatedAt)
-            .ThenBy(user => user.UserId, StringComparer.Ordinal)
-            .ToList();
+        var candidates = UsableRecords(records);
 
         if (candidates.Count == 0)
         {
@@ -95,6 +88,25 @@ public sealed record EmailIdentityResolution(
     }
 
     /// <summary>
+    /// The records an address can actually answer as: the disabled ones dropped, and the rest in a
+    /// fixed order.
+    ///
+    /// Ordered so the identity a credential acts as does not change between requests. Unordered
+    /// this is whatever the collection scan returned first, which is how the same credential could
+    /// resolve to a different account on a later call.
+    ///
+    /// Exposed for callers that combine the records themselves because they answer a question this
+    /// record does not model — one that spans every tenant rather than the one being resolved —
+    /// and which must still drop disabled records and order the rest identically.
+    /// </summary>
+    public static IReadOnlyList<User> UsableRecords(IReadOnlyList<User> records) =>
+        records
+            .Where(user => !user.IsLockedOut)
+            .OrderBy(user => user.CreatedAt)
+            .ThenBy(user => user.UserId, StringComparer.Ordinal)
+            .ToList();
+
+    /// <summary>
     /// SysAdmin is global and grants access to every tenant, so an address only carries it when
     /// every record answering to that address holds it. One record short and the answer is no: a
     /// second account at another provider is created for review and without the role, so a mixed
@@ -104,7 +116,13 @@ public sealed record EmailIdentityResolution(
     /// away from the account that had it, on the paths that name only an address. Completing the
     /// grant restores it.
     /// </summary>
-    private static bool ResolveSysAdmin(string email, IReadOnlyList<User> candidates, ILogger logger)
+    /// <param name="email">The address being resolved, used only for logging.</param>
+    /// <param name="candidates">
+    /// The records from <see cref="UsableRecords"/>. Passing disabled records would let one that
+    /// nobody has reviewed withhold the role from the account that holds it.
+    /// </param>
+    /// <param name="logger">Records a set that does not agree on the role.</param>
+    public static bool ResolveSysAdmin(string email, IReadOnlyList<User> candidates, ILogger logger)
     {
         // Safe on the single-record case, which is the ordinary one: the record's own flag decides.
         if (candidates.All(user => user.IsSysAdmin))

--- a/XiansAi.Server.Src/docs/EMAIL_IDENTITY_RESOLUTION.md
+++ b/XiansAi.Server.Src/docs/EMAIL_IDENTITY_RESOLUTION.md
@@ -66,7 +66,9 @@ Address-based resolution only happens where the credential carries nothing else.
 | Agent API certificate, OU is an email | An email | Folded. |
 | User API sign-in | The provider subject | Direct lookup. Never folded — a token names its subject exactly. |
 | WebAPI console sign-in | Whatever `ClaimMappings.UserIdClaim` names, `sub` by default | Direct lookup. Folded only where that claim is configured to an address, since then the token names one no more exactly than a legacy API key does. |
-| Admin ownership transfer, participant lookup | Either | **Refused** on an ambiguous address rather than folded. See [Endpoints that refuse](#endpoints-that-refuse-instead-of-folding). |
+| Admin participant lookup, `/participants/{email}` | An email | Folded across every tenant, since the reply names no account. |
+| Admin participant lookup, `/participants/by-user-id/{userId}` | The `UserId` | Direct lookup. Nothing is combined: the caller named one account, so the reply describes that one. |
+| Admin ownership transfer, tenant participant create | Either | **Refused** on an ambiguous address rather than folded. See [Endpoints that refuse](#endpoints-that-refuse-instead-of-folding). |
 
 ## The fold
 
@@ -187,8 +189,6 @@ address exactly one account holds names it as surely as a user id would, so that
 refusing it would not make anything safer, since an operator sent to find the user id would search
 by the same address and arrive at the same record.
 
-- **Participant lookup** (`AdminParticipantsEndpoints`) — `409` with "This email matches more than
-  one account, so participant details cannot be resolved from it." Read-only.
 - **Create tenant participant** (`TenantParticipantUserService.CreateAsync`) — grants any tenant
   role, up to `TenantAdmin`. `userId` names an account outright and is the way past an ambiguous
   address; otherwise `email` names the single account holding it, or creates one when none does.
@@ -196,6 +196,25 @@ by the same address and arrive at the same record.
 - **Add user to current tenant** (`UserTenantService.AddTenantToUserIfExist`) — grants an approved
   `TenantUser`, which is console access. Resolves through `EmailAccountLookup.From` and refuses a
   disabled account. WebAPI only.
+
+**Participant lookup** (`AdminParticipantsEndpoints`) used to sit in this list and no longer does.
+It is the one address-named surface whose reply names no account: it returns the tenants a person
+reaches and their role in each, so there is nothing for the caller to act on with the wrong record.
+Refusing it also had no way out — the remedy for two accounts belonging to one administrator is to
+enable both and grant the role to both, and this endpoint kept refusing afterwards, leaving deleting
+a record as the only escape. It now combines them: tenants are the union, `PrimaryRole` picks the
+highest role across the records for each tenant, and `isSystemAdmin` follows
+`EmailIdentityResolution.ResolveSysAdmin`. Disabled records are dropped first, so the `403` for a
+locked-out account is now reached only when every record holding the address is disabled.
+
+`GET /participants/by-user-id/{userId}` answers the same shape without any of that. A caller holding
+the signed-in person's provider subject names one account outright, so nothing is combined and the
+reply describes what that account alone reaches — the rule every sign-in path already follows. The
+two can differ deliberately: where one record holds SysAdmin and another does not, the address says
+no and the user id says whatever that record says. That is the point of naming an account rather
+than an address, and it is safe because a squatter arriving at another directory is provisioned
+disabled and refused here on that basis, not on the strength of the address. The address route
+remains for callers that have no more than an address, so no stored data or existing caller changes.
 
 One surface takes no address at all. It never creates an account, so its target always exists and
 the caller has necessarily obtained it from something that returned a user id; accepting an address
@@ -279,8 +298,9 @@ Two limits are worth knowing:
   are tracked and evicted as described above.
 - **The endpoints that refuse count disabled records too.** They count every record holding the
   address, unlike the fold, which drops disabled ones first. So an administrator's address that has
-  a disabled duplicate awaiting review will get a `409` from all four of them even though every
-  other path resolves it without difficulty. Use the user id there.
+  a disabled duplicate awaiting review will get a `409` from them even though every other path
+  resolves it without difficulty. Use the user id there. Participant lookup no longer behaves this
+  way.
 - **No record is kept of whether a provider vouched for an address.** An address a provider merely
   asserted admits a second record on exactly the same terms as one it verified, so someone able to
   set an arbitrary address at their own IdP can put a victim's address on a record they control.

--- a/XiansAi.Server.Tests/UnitTests/Shared/Repositories/EmailIdentityResolutionTests.cs
+++ b/XiansAi.Server.Tests/UnitTests/Shared/Repositories/EmailIdentityResolutionTests.cs
@@ -43,6 +43,34 @@ public class EmailIdentityResolutionTests
         Assert.Null(Fold());
     }
 
+    // UsableRecords and ResolveSysAdmin are used directly by the participant lookup, which spans
+    // every tenant rather than resolving one and so combines the records itself.
+
+    [Fact]
+    public void UsableRecords_DropsTheDisabledOnesAndOrdersTheRestByAge()
+    {
+        var older = Record("b-older", createdAt: new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        var newer = Record("a-newer", createdAt: new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        var disabled = Record("c-disabled", isLockedOut: true);
+
+        var usable = EmailIdentityResolution.UsableRecords(new[] { newer, disabled, older });
+
+        Assert.Equal(new[] { "b-older", "a-newer" }, usable.Select(record => record.UserId));
+    }
+
+    [Fact]
+    public void ResolveSysAdmin_GrantsTheRoleOnlyWhenEveryRecordHoldsIt()
+    {
+        var admin = Record("admin", isSysAdmin: true);
+        var other = Record("other", isSysAdmin: true);
+        var notAnAdmin = Record("plain");
+
+        Assert.True(EmailIdentityResolution.ResolveSysAdmin(
+            Email, new[] { admin, other }, NullLogger.Instance));
+        Assert.False(EmailIdentityResolution.ResolveSysAdmin(
+            Email, new[] { admin, notAnAdmin }, NullLogger.Instance));
+    }
+
     [Fact]
     public void From_ReturnsNull_WhenEveryRecordHoldingItIsLockedOut()
     {


### PR DESCRIPTION
## Summary

`GET /api/v1/admin/participants/{email}` refused with `409` whenever more than one record held the address, and there was no way out of it. The documented remedy for two accounts belonging to one administrator is to enable both and grant SysAdmin to both — already done for the account that hit this in the Parkly dev environment — and the endpoint kept refusing, leaving deleting a record as the only escape.

**The lookup now combines the records.** This is the one address-named surface whose reply names no account: it returns the tenants a person reaches and their role in each, so there is nothing for the caller to act on with the wrong record. Tenants are the union, roles are combined per tenant before `PrimaryRole` picks the highest, and `isSystemAdmin` follows the existing intersection rule — granted only when *every* record holding the address has it. Disabled records are dropped first, so the `403` is reached only when every record holding the address is disabled.

**Adds `GET /participants/by-user-id/{userId}`** returning the identical `ParticipantTenantsResponse`, for callers that hold the signed-in person's provider subject. Naming an account outright combines nothing, which is the rule every sign-in path already follows. Agent Studio has `session.user.id` available at all four of its call sites and its tenant-provider interface already accepts a user id it currently ignores, so migrating is a one-URL change there.

The two routes will deliberately disagree in one case: where one record holds SysAdmin and another does not, the address says no and the user id says whatever that record says. That is the point of naming an account rather than an address, and it stays safe because a squatter arriving at another directory is provisioned disabled and refused on that basis. Documented rather than left as folklore.

`UsableRecords` and `ResolveSysAdmin` become public on `EmailIdentityResolution` so neither rule is reimplemented in the endpoint. The fold record itself does not fit here, since it resolves one named tenant while this reply spans them all.

**No stored data changes and no existing caller is affected.** The address route keeps its response shape and its `404` wording; `participantId` semantics are untouched.

## Test plan

- [x] Two new cases covering the newly public `UsableRecords` (drops disabled, orders by age) and `ResolveSysAdmin` (grants only on unanimity).
- [x] Full suite green at 737 tests.
- [ ] `GET /participants/skenos.peniel@parkly.no` returns `isSystemAdmin: true` with `parkly.no`, `default`, and `parklytest.no`, the last as `TenantAdmin`.
- [ ] Confirm `session.user.id` from the studio matches a `users.user_id` before migrating callers — if the studio and server sit behind different app registrations, Entra's per-application `sub` would make the new route return `404`.

## Note

Neither route is unit-tested directly: the endpoint is an inline minimal-API lambda and the test project has no harness for admin endpoints. The rules the routes lean on are covered; the branch selection is not.

Made with [Cursor](https://cursor.com)